### PR TITLE
add some numpy vulnerabilities from 2014 and 2017

### DIFF
--- a/vulns/numpy/PYSEC-0000-CVE-2014-1858.yaml
+++ b/vulns/numpy/PYSEC-0000-CVE-2014-1858.yaml
@@ -1,0 +1,38 @@
+id: PYSEC-0000-CVE-2014-1858
+package:
+  name: numpy
+  ecosystem: PyPI
+details: __init__.py in f2py in NumPy before 1.8.1 allows local users to write to
+  arbitrary files via a symlink attack on a temporary file.
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/numpy/numpy
+    fixed: 0bb46c1448b0d3f5453d5182a17ea7ac5854ee15
+  - type: ECOSYSTEM
+    fixed: 1.8.1
+references:
+- type: WEB
+  url: https://github.com/numpy/numpy/pull/4262
+- type: WEB
+  url: https://github.com/numpy/numpy/commit/0bb46c1448b0d3f5453d5182a17ea7ac5854ee15
+- type: WEB
+  url: https://github.com/numpy/numpy/blob/maintenance/1.8.x/doc/release/1.8.1-notes.rst
+- type: WEB
+  url: https://exchange.xforce.ibmcloud.com/vulnerabilities/91318
+- type: WEB
+  url: https://bugzilla.redhat.com/show_bug.cgi?id=1062009
+- type: WEB
+  url: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=737778
+- type: WEB
+  url: http://www.securityfocus.com/bid/65441
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2014/02/08/3
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2014-February/128781.html
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2014-February/128358.html
+aliases:
+- CVE-2014-1858
+modified: "2018-01-30T14:44:00Z"
+published: "2018-01-08T19:29:00Z"

--- a/vulns/numpy/PYSEC-0000-CVE-2014-1859.yaml
+++ b/vulns/numpy/PYSEC-0000-CVE-2014-1859.yaml
@@ -1,0 +1,39 @@
+id: PYSEC-0000-CVE-2014-1859
+package:
+  name: numpy
+  ecosystem: PyPI
+details: (1) core/tests/test_memmap.py, (2) core/tests/test_multiarray.py, (3) f2py/f2py2e.py,
+  and (4) lib/tests/test_io.py in NumPy before 1.8.1 allow local users to write to
+  arbitrary files via a symlink attack on a temporary file.
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/numpy/numpy
+    fixed: 0bb46c1448b0d3f5453d5182a17ea7ac5854ee15
+  - type: ECOSYSTEM
+    fixed: 1.8.1
+references:
+- type: WEB
+  url: https://github.com/numpy/numpy/pull/4262
+- type: WEB
+  url: https://github.com/numpy/numpy/commit/0bb46c1448b0d3f5453d5182a17ea7ac5854ee15
+- type: WEB
+  url: https://github.com/numpy/numpy/blob/maintenance/1.8.x/doc/release/1.8.1-notes.rst
+- type: WEB
+  url: https://exchange.xforce.ibmcloud.com/vulnerabilities/91317
+- type: WEB
+  url: https://bugzilla.redhat.com/show_bug.cgi?id=1062009
+- type: WEB
+  url: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=737778
+- type: WEB
+  url: http://www.securityfocus.com/bid/65440
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2014/02/08/3
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2014-February/128781.html
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2014-February/128358.html
+aliases:
+- CVE-2014-1859
+modified: "2019-04-22T17:48:00Z"
+published: "2018-01-08T19:29:00Z"

--- a/vulns/numpy/PYSEC-0000-CVE-2017-12852.yaml
+++ b/vulns/numpy/PYSEC-0000-CVE-2017-12852.yaml
@@ -1,0 +1,20 @@
+id: PYSEC-0000-CVE-2017-12852
+package:
+  name: numpy
+  ecosystem: PyPI
+details: The numpy.pad function in Numpy 1.13.1 and older versions is missing input
+  validation. An empty list or ndarray will stick into an infinite loop, which can
+  allow attackers to cause a DoS attack.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.13.3
+references:
+- type: WEB
+  url: https://github.com/numpy/numpy/issues/9560#issuecomment-322395292
+- type: WEB
+  url: https://github.com/BT123/testcasesForMyRequest/tree/master/CVE-2017-12852
+aliases:
+- CVE-2017-12852
+modified: "2019-10-03T00:03:00Z"
+published: "2017-08-15T16:29:00Z"


### PR DESCRIPTION
I am just adding these older numpy CVE's as an initial test to ensure I understand how this process works before putting in some more effort to find and add some stuff that isn't currently discovered by the triage tool.  Thanks for  getting this started!