### PR TITLE
triaged more historical advisories

### DIFF
--- a/vulns/ansible-vault/PYSEC-0000-CVE-2017-2809.yaml
+++ b/vulns/ansible-vault/PYSEC-0000-CVE-2017-2809.yaml
@@ -1,0 +1,30 @@
+id: PYSEC-0000-CVE-2017-2809
+package:
+  name: ansible-vault
+  ecosystem: PyPI
+details: An exploitable vulnerability exists in the yaml loading functionality of
+  ansible-vault before 1.0.5. A specially crafted vault can execute arbitrary python
+  commands resulting in command execution. An attacker can insert python into the
+  vault to trigger this vulnerability.
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/tomoh1r/ansible-vault
+    fixed: 3f8f659ef443ab870bb19f95d43543470168ae04
+  - type: ECOSYSTEM
+    fixed: 1.0.5
+references:
+- type: WEB
+  url: https://www.talosintelligence.com/vulnerability_reports/TALOS-2017-0305
+- type: WEB
+  url: https://github.com/tomoh1r/ansible-vault/issues/4
+- type: WEB
+  url: https://github.com/tomoh1r/ansible-vault/commit/3f8f659ef443ab870bb19f95d43543470168ae04
+- type: WEB
+  url: https://github.com/tomoh1r/ansible-vault/blob/v1.0.5/CHANGES.txt
+- type: WEB
+  url: http://www.securityfocus.com/bid/100824
+aliases:
+- CVE-2017-2809
+modified: "2017-10-02T12:09:00Z"
+published: "2017-09-14T19:29:00Z"

--- a/vulns/apache-airflow/PYSEC-0000-CVE-2017-12614.yaml
+++ b/vulns/apache-airflow/PYSEC-0000-CVE-2017-12614.yaml
@@ -1,0 +1,19 @@
+id: PYSEC-0000-CVE-2017-12614
+package:
+  name: apache-airflow
+  ecosystem: PyPI
+details: 'It was noticed an XSS in certain 404 pages that could be exploited to perform
+  an XSS attack. Chrome will detect this as a reflected XSS attempt and prevent the
+  page from loading. Firefox and other browsers don''t, and are vulnerable to this
+  attack. Mitigation: The fix for this is to upgrade to Apache Airflow 1.9.0 or above.'
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.9.0
+references:
+- type: WEB
+  url: https://lists.apache.org/thread.html/2c72480c76619c5e7793f0d213c34082f0598eaa4d212172f068940f@%3Cdev.airflow.apache.org%3E
+aliases:
+- CVE-2017-12614
+modified: "2018-10-04T13:27:00Z"
+published: "2018-08-06T13:29:00Z"

--- a/vulns/apache-airflow/PYSEC-0000-CVE-2017-15720.yaml
+++ b/vulns/apache-airflow/PYSEC-0000-CVE-2017-15720.yaml
@@ -1,0 +1,17 @@
+id: PYSEC-0000-CVE-2017-15720
+package:
+  name: apache-airflow
+  ecosystem: PyPI
+details: In Apache Airflow 1.8.2 and earlier, an authenticated user can execute code
+  remotely on the Airflow webserver by creating a special object.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.9.0
+references:
+- type: WEB
+  url: https://lists.apache.org/thread.html/ade4d54ebf614f68dc81a08891755e60ea58ba88e0209233eeea5f57@%3Cdev.airflow.apache.org%3E
+aliases:
+- CVE-2017-15720
+modified: "2019-01-25T17:11:00Z"
+published: "2019-01-23T17:29:00Z"

--- a/vulns/apache-airflow/PYSEC-0000-CVE-2017-17835.yaml
+++ b/vulns/apache-airflow/PYSEC-0000-CVE-2017-17835.yaml
@@ -1,0 +1,17 @@
+id: PYSEC-0000-CVE-2017-17835
+package:
+  name: apache-airflow
+  ecosystem: PyPI
+details: In Apache Airflow 1.8.2 and earlier, a CSRF vulnerability allowed for a remote
+  command injection on a default install of Airflow.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.9.0
+references:
+- type: WEB
+  url: https://lists.apache.org/thread.html/ade4d54ebf614f68dc81a08891755e60ea58ba88e0209233eeea5f57@%3Cdev.airflow.apache.org%3E
+aliases:
+- CVE-2017-17835
+modified: "2019-01-25T15:51:00Z"
+published: "2019-01-23T17:29:00Z"

--- a/vulns/apache-airflow/PYSEC-0000-CVE-2017-17836.yaml
+++ b/vulns/apache-airflow/PYSEC-0000-CVE-2017-17836.yaml
@@ -1,0 +1,19 @@
+id: PYSEC-0000-CVE-2017-17836
+package:
+  name: apache-airflow
+  ecosystem: PyPI
+details: In Apache Airflow 1.8.2 and earlier, an experimental Airflow feature displayed
+  authenticated cookies, as well as passwords to databases used by Airflow. An attacker
+  who has limited access to airflow, whether it be via XSS or by leaving a machine
+  unlocked can exfiltrate all credentials from the system.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.9.0
+references:
+- type: WEB
+  url: https://lists.apache.org/thread.html/ade4d54ebf614f68dc81a08891755e60ea58ba88e0209233eeea5f57@%3Cdev.airflow.apache.org%3E
+aliases:
+- CVE-2017-17836
+modified: "2019-04-19T15:06:00Z"
+published: "2019-01-23T17:29:00Z"

--- a/vulns/attic/PYSEC-0000-CVE-2015-4082.yaml
+++ b/vulns/attic/PYSEC-0000-CVE-2015-4082.yaml
@@ -1,0 +1,28 @@
+id: PYSEC-0000-CVE-2015-4082
+package:
+  name: attic
+  ecosystem: PyPI
+details: attic before 0.15 does not confirm unencrypted backups with the user, which
+  allows remote attackers with read and write privileges for the encrypted repository
+  to obtain potentially sensitive information by changing the manifest type byte of
+  the repository to "unencrypted / without key file".
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/jborg/attic
+    fixed: 78f9ad1faba7193ca7f0acccbc13b1ff6ebf9072
+  - type: ECOSYSTEM
+    fixed: "0.15"
+references:
+- type: WEB
+  url: https://github.com/jborg/attic/issues/271
+- type: WEB
+  url: https://github.com/jborg/attic/commit/78f9ad1faba7193ca7f0acccbc13b1ff6ebf9072
+- type: WEB
+  url: http://www.securityfocus.com/bid/74821
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2015/05/31/3
+aliases:
+- CVE-2015-4082
+modified: "2017-08-25T12:05:00Z"
+published: "2017-08-18T16:29:00Z"

--- a/vulns/beaker/PYSEC-0000-CVE-2012-3458.yaml
+++ b/vulns/beaker/PYSEC-0000-CVE-2012-3458.yaml
@@ -1,0 +1,31 @@
+id: PYSEC-0000-CVE-2012-3458
+package:
+  name: beaker
+  ecosystem: PyPI
+details: Beaker before 1.6.4, when using PyCrypto to encrypt sessions, uses AES in
+  ECB cipher mode, which might allow remote attackers to obtain portions of sensitive
+  session data via unspecified vectors.
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/bbangert/beaker
+    fixed: 91becae76101cf87ce8cbfabe3af2622fc328fe5
+  - type: ECOSYSTEM
+    fixed: 1.6.5.post1
+references:
+- type: WEB
+  url: http://www.debian.org/security/2012/dsa-2541
+- type: WEB
+  url: http://secunia.com/advisories/50520
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2012/08/13/10
+- type: WEB
+  url: https://github.com/bbangert/beaker/commit/91becae76101cf87ce8cbfabe3af2622fc328fe5
+- type: WEB
+  url: http://secunia.com/advisories/50226
+- type: WEB
+  url: https://bugzilla.redhat.com/show_bug.cgi?id=809267
+aliases:
+- CVE-2012-3458
+modified: "2012-09-17T17:43:00Z"
+published: "2012-09-15T17:55:00Z"

--- a/vulns/bodhi/PYSEC-0000-CVE-2017-1002152.yaml
+++ b/vulns/bodhi/PYSEC-0000-CVE-2017-1002152.yaml
@@ -1,0 +1,17 @@
+id: PYSEC-0000-CVE-2017-1002152
+package:
+  name: bodhi
+  ecosystem: PyPI
+details: Bodhi 2.9.0 and lower is vulnerable to cross-site scripting resulting in
+  code injection caused by incorrect validation of bug titles.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 3.3.0
+references:
+- type: WEB
+  url: https://github.com/fedora-infra/bodhi/issues/1740
+aliases:
+- CVE-2017-1002152
+modified: "2019-10-09T23:21:00Z"
+published: "2019-01-10T21:29:00Z"

--- a/vulns/ceph-deploy/PYSEC-0000-CVE-2015-3010.yaml
+++ b/vulns/ceph-deploy/PYSEC-0000-CVE-2015-3010.yaml
@@ -1,0 +1,36 @@
+id: PYSEC-0000-CVE-2015-3010
+package:
+  name: ceph-deploy
+  ecosystem: PyPI
+details: ceph-deploy before 1.5.23 uses weak permissions (644) for ceph/ceph.client.admin.keyring,
+  which allows local users to obtain sensitive information by reading the file.
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/ceph/ceph-deploy
+    fixed: eee56770393bf19ed2dd5389226c6190c08dee3f
+  - type: ECOSYSTEM
+    fixed: 1.5.23
+references:
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2015/04/09/9
+- type: WEB
+  url: http://rhn.redhat.com/errata/RHSA-2015-1092.html
+- type: WEB
+  url: https://bugzilla.suse.com/show_bug.cgi?id=920926
+- type: WEB
+  url: https://github.com/ceph/ceph-deploy/pull/272
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2015/04/09/11
+- type: WEB
+  url: https://github.com/ceph/ceph-deploy/commit/eee56770393bf19ed2dd5389226c6190c08dee3f
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2015-April/155576.html
+- type: WEB
+  url: http://www.securityfocus.com/bid/74043
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2015-April/155631.html
+aliases:
+- CVE-2015-3010
+modified: "2016-12-03T03:07:00Z"
+published: "2015-06-16T16:59:00Z"

--- a/vulns/ceph-deploy/PYSEC-0000-CVE-2015-4053.yaml
+++ b/vulns/ceph-deploy/PYSEC-0000-CVE-2015-4053.yaml
@@ -1,0 +1,26 @@
+id: PYSEC-0000-CVE-2015-4053
+package:
+  name: ceph-deploy
+  ecosystem: PyPI
+details: The admin command in ceph-deploy before 1.5.25 uses world-readable permissions
+  for /etc/ceph/ceph.client.admin.keyring, which allows local users to obtain sensitive
+  information by reading the file.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.5.23
+references:
+- type: WEB
+  url: http://tracker.ceph.com/issues/11694
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2015/04/09/9
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2015/05/22/1
+- type: WEB
+  url: http://www.securityfocus.com/bid/74775
+- type: WEB
+  url: http://rhn.redhat.com/errata/RHSA-2015-1092.html
+aliases:
+- CVE-2015-4053
+modified: "2015-06-25T16:23:00Z"
+published: "2015-06-08T14:59:00Z"

--- a/vulns/cfscrape/PYSEC-0000-CVE-2017-7235.yaml
+++ b/vulns/cfscrape/PYSEC-0000-CVE-2017-7235.yaml
@@ -1,0 +1,23 @@
+id: PYSEC-0000-CVE-2017-7235
+package:
+  name: cfscrape
+  ecosystem: PyPI
+details: An issue was discovered in cloudflare-scrape 1.6.6 through 1.7.1. A malicious
+  website owner could craft a page that executes arbitrary Python code against any
+  cfscrape user who scrapes that website. This is fixed in 1.8.0.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    introduced: 1.6.6
+    fixed: 1.8.0
+references:
+- type: WEB
+  url: https://github.com/Anorov/cloudflare-scrape/releases/tag/1.8.0
+- type: WEB
+  url: https://github.com/Anorov/cloudflare-scrape/issues/97
+- type: WEB
+  url: http://www.securityfocus.com/bid/97191
+aliases:
+- CVE-2017-7235
+modified: "2019-10-03T00:03:00Z"
+published: "2017-03-23T04:59:00Z"

--- a/vulns/cherrypy/PYSEC-0000-CVE-2006-0847.yaml
+++ b/vulns/cherrypy/PYSEC-0000-CVE-2006-0847.yaml
@@ -1,0 +1,34 @@
+id: PYSEC-0000-CVE-2006-0847
+package:
+  name: cherrypy
+  ecosystem: PyPI
+details: Directory traversal vulnerability in the staticfilter component in CherryPy
+  before 2.1.1 allows remote attackers to read arbitrary files via ".." sequences
+  in unspecified vectors.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 2.1.1
+references:
+- type: WEB
+  url: http://sourceforge.net/project/shownotes.php?release_id=384316&group_id=56099
+- type: WEB
+  url: http://groups.google.com/group/cherrypy-announce/browse_thread/thread/92b2972f774fe6df/2f63afc9433dc306#2f63afc9433dc306
+- type: WEB
+  url: http://www.securityfocus.com/bid/16760
+- type: WEB
+  url: http://www.cherrypy.org/
+- type: WEB
+  url: http://secunia.com/advisories/18944
+- type: WEB
+  url: http://www.gentoo.org/security/en/glsa/glsa-200605-16.xml
+- type: WEB
+  url: http://secunia.com/advisories/20344
+- type: WEB
+  url: http://www.vupen.com/english/advisories/2006/0677
+- type: WEB
+  url: https://exchange.xforce.ibmcloud.com/vulnerabilities/24809
+aliases:
+- CVE-2006-0847
+modified: "2017-07-20T01:30:00Z"
+published: "2006-02-22T02:02:00Z"

--- a/vulns/cryptography/PYSEC-0000-CVE-2016-9243.yaml
+++ b/vulns/cryptography/PYSEC-0000-CVE-2016-9243.yaml
@@ -1,0 +1,36 @@
+id: PYSEC-0000-CVE-2016-9243
+package:
+  name: cryptography
+  ecosystem: PyPI
+details: HKDF in cryptography before 1.5.2 returns an empty byte-string if used with
+  a length less than algorithm.digest_size.
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/pyca/cryptography
+    fixed: b924696b2e8731f39696584d12cceeb3aeb2d874
+  - type: ECOSYSTEM
+    fixed: 1.5.3
+references:
+- type: WEB
+  url: https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/WQ5G7KHKZC4SI23JE7277KZXM57GEQKT/
+- type: WEB
+  url: https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/U23KDR2M2N7W2ZSREG63BVW7D4VC6CIZ/
+- type: WEB
+  url: https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/5R2ZOBMPWDFFHUZ6QOZZY36A6H5CGJXL/
+- type: WEB
+  url: https://github.com/pyca/cryptography/issues/3211
+- type: WEB
+  url: https://github.com/pyca/cryptography/commit/b924696b2e8731f39696584d12cceeb3aeb2d874
+- type: WEB
+  url: https://cryptography.io/en/latest/changelog
+- type: WEB
+  url: http://www.ubuntu.com/usn/USN-3138-1
+- type: WEB
+  url: http://www.securityfocus.com/bid/94216
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2016/11/09/2
+aliases:
+- CVE-2016-9243
+modified: "2017-04-04T16:00:00Z"
+published: "2017-03-27T17:59:00Z"

--- a/vulns/django-anymail/PYSEC-0000-CVE-2018-1000089.yaml
+++ b/vulns/django-anymail/PYSEC-0000-CVE-2018-1000089.yaml
@@ -1,0 +1,28 @@
+id: PYSEC-0000-CVE-2018-1000089
+package:
+  name: django-anymail
+  ecosystem: PyPI
+details: Anymail django-anymail version version 0.2 through 1.3 contains a CWE-532,
+  CWE-209 vulnerability in WEBHOOK_AUTHORIZATION setting value that can result in
+  An attacker with access to error logs could fabricate email tracking events. This
+  attack appear to be exploitable via If you have exposed your Django error reports,
+  an attacker could discover your ANYMAIL_WEBHOOK setting and use this to post fabricated
+  or malicious Anymail tracking/inbound events to your app. This vulnerability appears
+  to have been fixed in v1.4.
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/anymail/django-anymail
+    fixed: 1a6086f2b58478d71f89bf27eb034ed81aefe5ef
+  - type: ECOSYSTEM
+    introduced: "0.2"
+    fixed: "1.4"
+references:
+- type: WEB
+  url: https://github.com/anymail/django-anymail/releases/tag/v1.4
+- type: WEB
+  url: https://github.com/anymail/django-anymail/commit/1a6086f2b58478d71f89bf27eb034ed81aefe5ef
+aliases:
+- CVE-2018-1000089
+modified: "2018-04-11T14:12:00Z"
+published: "2018-03-13T15:29:00Z"

--- a/vulns/django-cms/PYSEC-0000-CVE-2015-5081.yaml
+++ b/vulns/django-cms/PYSEC-0000-CVE-2015-5081.yaml
@@ -1,0 +1,28 @@
+id: PYSEC-0000-CVE-2015-5081
+package:
+  name: django-cms
+  ecosystem: PyPI
+details: Cross-site request forgery (CSRF) vulnerability in django CMS before 3.0.14,
+  3.1.x before 3.1.1 allows remote attackers to manipulate privileged users into performing
+  unknown actions via unspecified vectors.
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/divio/django-cms
+    fixed: f77cbc607d6e2a62e63287d37ad320109a2cc78a
+  - type: ECOSYSTEM
+    fixed: 3.0.14
+  - type: ECOSYSTEM
+    introduced: '3.1'
+    fixed: 3.1.1
+references:
+- type: WEB
+  url: https://www.django-cms.org/en/blog/2015/06/27/311-3014-release/
+- type: WEB
+  url: https://github.com/divio/django-cms/commit/f77cbc607d6e2a62e63287d37ad320109a2cc78a
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2015/06/28/1
+aliases:
+- CVE-2015-5081
+modified: "2017-08-24T14:19:00Z"
+published: "2017-08-18T18:29:00Z"

--- a/vulns/django-markupfield/PYSEC-0000-CVE-2015-0846.yaml
+++ b/vulns/django-markupfield/PYSEC-0000-CVE-2015-0846.yaml
@@ -1,0 +1,20 @@
+id: PYSEC-0000-CVE-2015-0846
+package:
+  name: django-markupfield
+  ecosystem: PyPI
+details: django-markupfield before 1.3.2 uses the default docutils RESTRUCTUREDTEXT_FILTER_SETTINGS
+  settings, which allows remote attackers to include and read arbitrary files via
+  unspecified vectors.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.3.2
+references:
+- type: WEB
+  url: http://www.debian.org/security/2015/dsa-3230
+- type: WEB
+  url: https://github.com/jamesturk/django-markupfield/blob/master/CHANGELOG
+aliases:
+- CVE-2015-0846
+modified: "2015-04-27T15:11:00Z"
+published: "2015-04-24T14:59:00Z"

--- a/vulns/django/PYSEC-0000-CVE-2011-4136.yaml
+++ b/vulns/django/PYSEC-0000-CVE-2011-4136.yaml
@@ -1,0 +1,36 @@
+id: PYSEC-0000-CVE-2011-4136
+package:
+  name: django
+  ecosystem: PyPI
+details: django.contrib.sessions in Django before 1.2.7 and 1.3.x before 1.3.1, when
+  session data is stored in the cache, uses the root namespace for both session identifiers
+  and application-data keys, which allows remote attackers to modify a session by
+  triggering use of a key that is equal to that session's identifier.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.2.7
+  - type: ECOSYSTEM
+    introduced: '1.3'
+    fixed: 1.3.1
+references:
+- type: WEB
+  url: https://bugzilla.redhat.com/show_bug.cgi?id=737366
+- type: WEB
+  url: http://openwall.com/lists/oss-security/2011/09/13/2
+- type: WEB
+  url: https://www.djangoproject.com/weblog/2011/sep/09/
+- type: WEB
+  url: https://www.djangoproject.com/weblog/2011/sep/10/127/
+- type: WEB
+  url: http://openwall.com/lists/oss-security/2011/09/11/1
+- type: WEB
+  url: http://secunia.com/advisories/46614
+- type: WEB
+  url: http://www.debian.org/security/2011/dsa-2332
+- type: WEB
+  url: https://hermes.opensuse.org/messages/14700881
+aliases:
+- CVE-2011-4136
+modified: "2018-01-18T02:29:00Z"
+published: "2011-10-19T10:55:00Z"

--- a/vulns/django/PYSEC-0000-CVE-2011-4137.yaml
+++ b/vulns/django/PYSEC-0000-CVE-2011-4137.yaml
@@ -1,0 +1,40 @@
+id: PYSEC-0000-CVE-2011-4137
+package:
+  name: django
+  ecosystem: PyPI
+details: The verify_exists functionality in the URLField implementation in Django
+  before 1.2.7 and 1.3.x before 1.3.1 relies on Python libraries that attempt access
+  to an arbitrary URL with no timeout, which allows remote attackers to cause a denial
+  of service (resource consumption) via a URL associated with (1) a slow response,
+  (2) a completed TCP connection with no application data sent, or (3) a large amount
+  of application data, a related issue to CVE-2011-1521.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.2.7
+  - type: ECOSYSTEM
+    introduced: '1.3'
+    fixed: 1.3.1
+references:
+- type: WEB
+  url: https://bugzilla.redhat.com/show_bug.cgi?id=737366
+- type: WEB
+  url: https://www.djangoproject.com/weblog/2011/sep/10/127/
+- type: WEB
+  url: http://openwall.com/lists/oss-security/2011/09/13/2
+- type: WEB
+  url: http://openwall.com/lists/oss-security/2011/09/15/5
+- type: WEB
+  url: https://www.djangoproject.com/weblog/2011/sep/09/
+- type: WEB
+  url: http://openwall.com/lists/oss-security/2011/09/11/1
+- type: WEB
+  url: http://secunia.com/advisories/46614
+- type: WEB
+  url: http://www.debian.org/security/2011/dsa-2332
+- type: WEB
+  url: https://hermes.opensuse.org/messages/14700881
+aliases:
+- CVE-2011-4137
+modified: "2018-01-18T02:29:00Z"
+published: "2011-10-19T10:55:00Z"

--- a/vulns/django/PYSEC-0000-CVE-2011-4138.yaml
+++ b/vulns/django/PYSEC-0000-CVE-2011-4138.yaml
@@ -1,0 +1,37 @@
+id: PYSEC-0000-CVE-2011-4138
+package:
+  name: django
+  ecosystem: PyPI
+details: The verify_exists functionality in the URLField implementation in Django
+  before 1.2.7 and 1.3.x before 1.3.1 originally tests a URL's validity through a
+  HEAD request, but then uses a GET request for the new target URL in the case of
+  a redirect, which might allow remote attackers to trigger arbitrary GET requests
+  with an unintended source IP address via a crafted Location header.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.2.7
+  - type: ECOSYSTEM
+    introduced: '1.3'
+    fixed: 1.3.1
+references:
+- type: WEB
+  url: https://www.djangoproject.com/weblog/2011/sep/10/127/
+- type: WEB
+  url: http://openwall.com/lists/oss-security/2011/09/13/2
+- type: WEB
+  url: https://bugzilla.redhat.com/show_bug.cgi?id=737366
+- type: WEB
+  url: http://openwall.com/lists/oss-security/2011/09/11/1
+- type: WEB
+  url: https://www.djangoproject.com/weblog/2011/sep/09/
+- type: WEB
+  url: http://secunia.com/advisories/46614
+- type: WEB
+  url: http://www.debian.org/security/2011/dsa-2332
+- type: WEB
+  url: https://hermes.opensuse.org/messages/14700881
+aliases:
+- CVE-2011-4138
+modified: "2018-01-18T02:29:00Z"
+published: "2011-10-19T10:55:00Z"

--- a/vulns/django/PYSEC-0000-CVE-2011-4139.yaml
+++ b/vulns/django/PYSEC-0000-CVE-2011-4139.yaml
@@ -1,0 +1,35 @@
+id: PYSEC-0000-CVE-2011-4139
+package:
+  name: django
+  ecosystem: PyPI
+details: Django before 1.2.7 and 1.3.x before 1.3.1 uses a request's HTTP Host header
+  to construct a full URL in certain circumstances, which allows remote attackers
+  to conduct cache poisoning attacks via a crafted request.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.2.7
+  - type: ECOSYSTEM
+    introduced: '1.3'
+    fixed: 1.3.1
+references:
+- type: WEB
+  url: https://bugzilla.redhat.com/show_bug.cgi?id=737366
+- type: WEB
+  url: https://www.djangoproject.com/weblog/2011/sep/09/
+- type: WEB
+  url: http://openwall.com/lists/oss-security/2011/09/11/1
+- type: WEB
+  url: https://www.djangoproject.com/weblog/2011/sep/10/127/
+- type: WEB
+  url: http://openwall.com/lists/oss-security/2011/09/13/2
+- type: WEB
+  url: http://secunia.com/advisories/46614
+- type: WEB
+  url: http://www.debian.org/security/2011/dsa-2332
+- type: WEB
+  url: https://hermes.opensuse.org/messages/14700881
+aliases:
+- CVE-2011-4139
+modified: "2018-01-18T02:29:00Z"
+published: "2011-10-19T10:55:00Z"

--- a/vulns/django/PYSEC-0000-CVE-2011-4140.yaml
+++ b/vulns/django/PYSEC-0000-CVE-2011-4140.yaml
@@ -1,0 +1,36 @@
+id: PYSEC-0000-CVE-2011-4140
+package:
+  name: django
+  ecosystem: PyPI
+details: The CSRF protection mechanism in Django through 1.2.7 and 1.3.x through 1.3.1
+  does not properly handle web-server configurations supporting arbitrary HTTP Host
+  headers, which allows remote attackers to trigger unauthenticated forged requests
+  via vectors involving a DNS CNAME record and a web page containing JavaScript code.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.2.7
+  - type: ECOSYSTEM
+    introduced: '1.3'
+    fixed: 1.3.1
+references:
+- type: WEB
+  url: https://bugzilla.redhat.com/show_bug.cgi?id=737366
+- type: WEB
+  url: http://openwall.com/lists/oss-security/2011/09/11/1
+- type: WEB
+  url: https://www.djangoproject.com/weblog/2011/sep/09/
+- type: WEB
+  url: http://openwall.com/lists/oss-security/2011/09/13/2
+- type: WEB
+  url: https://www.djangoproject.com/weblog/2011/sep/10/127/
+- type: WEB
+  url: http://secunia.com/advisories/46614
+- type: WEB
+  url: http://www.debian.org/security/2011/dsa-2332
+- type: WEB
+  url: https://hermes.opensuse.org/messages/14700881
+aliases:
+- CVE-2011-4140
+modified: "2018-01-18T02:29:00Z"
+published: "2011-10-19T10:55:00Z"

--- a/vulns/django/PYSEC-0000-CVE-2012-3442.yaml
+++ b/vulns/django/PYSEC-0000-CVE-2012-3442.yaml
@@ -1,0 +1,32 @@
+id: PYSEC-0000-CVE-2012-3442
+package:
+  name: django
+  ecosystem: PyPI
+details: 'The (1) django.http.HttpResponseRedirect and (2) django.http.HttpResponsePermanentRedirect
+  classes in Django before 1.3.2 and 1.4.x before 1.4.1 do not validate the scheme
+  of a redirect target, which might allow remote attackers to conduct cross-site scripting
+  (XSS) attacks via a data: URL.'
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.3.2
+  - type: ECOSYSTEM
+    introduced: '1.4'
+    fixed: 1.4.1
+references:
+- type: WEB
+  url: https://www.djangoproject.com/weblog/2012/jul/30/security-releases-issued/
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2012/07/31/1
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2012/07/31/2
+- type: WEB
+  url: http://www.ubuntu.com/usn/USN-1560-1
+- type: WEB
+  url: http://www.debian.org/security/2012/dsa-2529
+- type: WEB
+  url: http://www.mandriva.com/security/advisories?name=MDVSA-2012:143
+aliases:
+- CVE-2012-3442
+modified: "2013-04-11T03:29:00Z"
+published: "2012-07-31T17:55:00Z"

--- a/vulns/django/PYSEC-0000-CVE-2012-3443.yaml
+++ b/vulns/django/PYSEC-0000-CVE-2012-3443.yaml
@@ -1,0 +1,32 @@
+id: PYSEC-0000-CVE-2012-3443
+package:
+  name: django
+  ecosystem: PyPI
+details: The django.forms.ImageField class in the form system in Django before 1.3.2
+  and 1.4.x before 1.4.1 completely decompresses image data during image validation,
+  which allows remote attackers to cause a denial of service (memory consumption)
+  by uploading an image file.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.3.2
+  - type: ECOSYSTEM
+    introduced: '1.4'
+    fixed: 1.4.1
+references:
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2012/07/31/2
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2012/07/31/1
+- type: WEB
+  url: https://www.djangoproject.com/weblog/2012/jul/30/security-releases-issued/
+- type: WEB
+  url: http://www.ubuntu.com/usn/USN-1560-1
+- type: WEB
+  url: http://www.debian.org/security/2012/dsa-2529
+- type: WEB
+  url: http://www.mandriva.com/security/advisories?name=MDVSA-2012:143
+aliases:
+- CVE-2012-3443
+modified: "2013-04-11T03:29:00Z"
+published: "2012-07-31T17:55:00Z"

--- a/vulns/django/PYSEC-0000-CVE-2012-3444.yaml
+++ b/vulns/django/PYSEC-0000-CVE-2012-3444.yaml
@@ -1,0 +1,32 @@
+id: PYSEC-0000-CVE-2012-3444
+package:
+  name: django
+  ecosystem: PyPI
+details: The get_image_dimensions function in the image-handling functionality in
+  Django before 1.3.2 and 1.4.x before 1.4.1 uses a constant chunk size in all attempts
+  to determine dimensions, which allows remote attackers to cause a denial of service
+  (process or thread consumption) via a large TIFF image.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.3.2
+  - type: ECOSYSTEM
+    introduced: '1.4'
+    fixed: 1.4.1
+references:
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2012/07/31/1
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2012/07/31/2
+- type: WEB
+  url: https://www.djangoproject.com/weblog/2012/jul/30/security-releases-issued/
+- type: WEB
+  url: http://www.ubuntu.com/usn/USN-1560-1
+- type: WEB
+  url: http://www.debian.org/security/2012/dsa-2529
+- type: WEB
+  url: http://www.mandriva.com/security/advisories?name=MDVSA-2012:143
+aliases:
+- CVE-2012-3444
+modified: "2013-04-11T03:29:00Z"
+published: "2012-07-31T17:55:00Z"

--- a/vulns/django/PYSEC-0000-CVE-2014-0472.yaml
+++ b/vulns/django/PYSEC-0000-CVE-2014-0472.yaml
@@ -1,0 +1,37 @@
+id: PYSEC-0000-CVE-2014-0472
+package:
+  name: django
+  ecosystem: PyPI
+details: The django.core.urlresolvers.reverse function in Django before 1.4.11, 1.5.x
+  before 1.5.6, 1.6.x before 1.6.3, and 1.7.x before 1.7 beta 2 allows remote attackers
+  to import and execute arbitrary Python modules by leveraging a view that constructs
+  URLs using user input and a "dotted Python path."
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.4.11
+  - type: ECOSYSTEM
+    introduced: '1.5'
+    fixed: 1.5.6
+  - type: ECOSYSTEM
+    introduced: '1.6'
+    fixed: 1.6.3
+references:
+- type: WEB
+  url: https://www.djangoproject.com/weblog/2014/apr/21/security/
+- type: WEB
+  url: http://www.ubuntu.com/usn/USN-2169-1
+- type: WEB
+  url: http://rhn.redhat.com/errata/RHSA-2014-0457.html
+- type: WEB
+  url: http://www.debian.org/security/2014/dsa-2934
+- type: WEB
+  url: http://rhn.redhat.com/errata/RHSA-2014-0456.html
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-updates/2014-09/msg00023.html
+- type: WEB
+  url: http://secunia.com/advisories/61281
+aliases:
+- CVE-2014-0472
+modified: "2017-01-07T02:59:00Z"
+published: "2014-04-23T15:55:00Z"

--- a/vulns/django/PYSEC-0000-CVE-2014-0473.yaml
+++ b/vulns/django/PYSEC-0000-CVE-2014-0473.yaml
@@ -1,0 +1,37 @@
+id: PYSEC-0000-CVE-2014-0473
+package:
+  name: django
+  ecosystem: PyPI
+details: The caching framework in Django before 1.4.11, 1.5.x before 1.5.6, 1.6.x
+  before 1.6.3, and 1.7.x before 1.7 beta 2 reuses a cached CSRF token for all anonymous
+  users, which allows remote attackers to bypass CSRF protections by reading the CSRF
+  cookie for anonymous users.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.4.11
+  - type: ECOSYSTEM
+    introduced: '1.5'
+    fixed: 1.5.6
+  - type: ECOSYSTEM
+    introduced: '1.6'
+    fixed: 1.6.3
+references:
+- type: WEB
+  url: https://www.djangoproject.com/weblog/2014/apr/21/security/
+- type: WEB
+  url: http://www.ubuntu.com/usn/USN-2169-1
+- type: WEB
+  url: http://rhn.redhat.com/errata/RHSA-2014-0457.html
+- type: WEB
+  url: http://www.debian.org/security/2014/dsa-2934
+- type: WEB
+  url: http://rhn.redhat.com/errata/RHSA-2014-0456.html
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-updates/2014-09/msg00023.html
+- type: WEB
+  url: http://secunia.com/advisories/61281
+aliases:
+- CVE-2014-0473
+modified: "2017-01-07T02:59:00Z"
+published: "2014-04-23T15:55:00Z"

--- a/vulns/django/PYSEC-0000-CVE-2014-0474.yaml
+++ b/vulns/django/PYSEC-0000-CVE-2014-0474.yaml
@@ -1,0 +1,37 @@
+id: PYSEC-0000-CVE-2014-0474
+package:
+  name: django
+  ecosystem: PyPI
+details: The (1) FilePathField, (2) GenericIPAddressField, and (3) IPAddressField
+  model field classes in Django before 1.4.11, 1.5.x before 1.5.6, 1.6.x before 1.6.3,
+  and 1.7.x before 1.7 beta 2 do not properly perform type conversion, which allows
+  remote attackers to have unspecified impact and vectors, related to "MySQL typecasting."
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.4.11
+  - type: ECOSYSTEM
+    introduced: '1.5'
+    fixed: 1.5.6
+  - type: ECOSYSTEM
+    introduced: '1.6'
+    fixed: 1.6.3
+references:
+- type: WEB
+  url: https://www.djangoproject.com/weblog/2014/apr/21/security/
+- type: WEB
+  url: http://www.ubuntu.com/usn/USN-2169-1
+- type: WEB
+  url: http://rhn.redhat.com/errata/RHSA-2014-0457.html
+- type: WEB
+  url: http://www.debian.org/security/2014/dsa-2934
+- type: WEB
+  url: http://rhn.redhat.com/errata/RHSA-2014-0456.html
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-updates/2014-09/msg00023.html
+- type: WEB
+  url: http://secunia.com/advisories/61281
+aliases:
+- CVE-2014-0474
+modified: "2017-01-07T02:59:00Z"
+published: "2014-04-23T15:55:00Z"

--- a/vulns/django/PYSEC-0000-CVE-2014-0480.yaml
+++ b/vulns/django/PYSEC-0000-CVE-2014-0480.yaml
@@ -1,0 +1,37 @@
+id: PYSEC-0000-CVE-2014-0480
+package:
+  name: django
+  ecosystem: PyPI
+details: The core.urlresolvers.reverse function in Django before 1.4.14, 1.5.x before
+  1.5.9, 1.6.x before 1.6.6, and 1.7 before release candidate 3 does not properly
+  validate URLs, which allows remote attackers to conduct phishing attacks via a //
+  (slash slash) in a URL, which triggers a scheme-relative URL to be generated.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.4.14
+  - type: ECOSYSTEM
+    introduced: '1.5'
+    fixed: 1.5.9
+  - type: ECOSYSTEM
+    introduced: '1.6'
+    fixed: 1.6.6
+references:
+- type: WEB
+  url: https://www.djangoproject.com/weblog/2014/aug/20/security/
+- type: WEB
+  url: http://www.debian.org/security/2014/dsa-3010
+- type: WEB
+  url: http://secunia.com/advisories/59782
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-updates/2014-09/msg00023.html
+- type: WEB
+  url: http://www.securityfocus.com/bid/69425
+- type: WEB
+  url: http://secunia.com/advisories/61281
+- type: WEB
+  url: http://secunia.com/advisories/61276
+aliases:
+- CVE-2014-0480
+modified: "2018-10-30T16:27:00Z"
+published: "2014-08-26T14:55:00Z"

--- a/vulns/django/PYSEC-0000-CVE-2014-0481.yaml
+++ b/vulns/django/PYSEC-0000-CVE-2014-0481.yaml
@@ -1,0 +1,36 @@
+id: PYSEC-0000-CVE-2014-0481
+package:
+  name: django
+  ecosystem: PyPI
+details: The default configuration for the file upload handling system in Django before
+  1.4.14, 1.5.x before 1.5.9, 1.6.x before 1.6.6, and 1.7 before release candidate
+  3 uses a sequential file name generation process when a file with a conflicting
+  name is uploaded, which allows remote attackers to cause a denial of service (CPU
+  consumption) by unloading a multiple files with the same name.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.4.14
+  - type: ECOSYSTEM
+    introduced: '1.5'
+    fixed: 1.5.9
+  - type: ECOSYSTEM
+    introduced: '1.6'
+    fixed: 1.6.6
+references:
+- type: WEB
+  url: http://www.debian.org/security/2014/dsa-3010
+- type: WEB
+  url: https://www.djangoproject.com/weblog/2014/aug/20/security/
+- type: WEB
+  url: http://secunia.com/advisories/59782
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-updates/2014-09/msg00023.html
+- type: WEB
+  url: http://secunia.com/advisories/61281
+- type: WEB
+  url: http://secunia.com/advisories/61276
+aliases:
+- CVE-2014-0481
+modified: "2018-10-30T16:27:00Z"
+published: "2014-08-26T14:55:00Z"

--- a/vulns/django/PYSEC-0000-CVE-2014-0482.yaml
+++ b/vulns/django/PYSEC-0000-CVE-2014-0482.yaml
@@ -1,0 +1,36 @@
+id: PYSEC-0000-CVE-2014-0482
+package:
+  name: django
+  ecosystem: PyPI
+details: The contrib.auth.middleware.RemoteUserMiddleware middleware in Django before
+  1.4.14, 1.5.x before 1.5.9, 1.6.x before 1.6.6, and 1.7 before release candidate
+  3, when using the contrib.auth.backends.RemoteUserBackend backend, allows remote
+  authenticated users to hijack web sessions via vectors related to the REMOTE_USER
+  header.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.4.14
+  - type: ECOSYSTEM
+    introduced: '1.5'
+    fixed: 1.5.9
+  - type: ECOSYSTEM
+    introduced: '1.6'
+    fixed: 1.6.6
+references:
+- type: WEB
+  url: http://www.debian.org/security/2014/dsa-3010
+- type: WEB
+  url: https://www.djangoproject.com/weblog/2014/aug/20/security/
+- type: WEB
+  url: http://secunia.com/advisories/59782
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-updates/2014-09/msg00023.html
+- type: WEB
+  url: http://secunia.com/advisories/61281
+- type: WEB
+  url: http://secunia.com/advisories/61276
+aliases:
+- CVE-2014-0482
+modified: "2018-10-30T16:27:00Z"
+published: "2014-08-26T14:55:00Z"

--- a/vulns/django/PYSEC-0000-CVE-2014-0483.yaml
+++ b/vulns/django/PYSEC-0000-CVE-2014-0483.yaml
@@ -1,0 +1,42 @@
+id: PYSEC-0000-CVE-2014-0483
+package:
+  name: django
+  ecosystem: PyPI
+details: The administrative interface (contrib.admin) in Django before 1.4.14, 1.5.x
+  before 1.5.9, 1.6.x before 1.6.6, and 1.7 before release candidate 3 does not check
+  if a field represents a relationship between models, which allows remote authenticated
+  users to obtain sensitive information via a to_field parameter in a popup action
+  to an admin change form page, as demonstrated by a /admin/auth/user/?pop=1&t=password
+  URI.
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/django/django
+    fixed: 2b31342cdf14fc20e07c43d258f1e7334ad664a6
+  - type: ECOSYSTEM
+    fixed: 1.4.14
+  - type: ECOSYSTEM
+    introduced: '1.5'
+    fixed: 1.5.9
+  - type: ECOSYSTEM
+    introduced: '1.6'
+    fixed: 1.6.6
+references:
+- type: WEB
+  url: https://github.com/django/django/commit/2b31342cdf14fc20e07c43d258f1e7334ad664a6
+- type: WEB
+  url: https://www.djangoproject.com/weblog/2014/aug/20/security/
+- type: WEB
+  url: http://www.debian.org/security/2014/dsa-3010
+- type: WEB
+  url: http://secunia.com/advisories/59782
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-updates/2014-09/msg00023.html
+- type: WEB
+  url: http://secunia.com/advisories/61281
+- type: WEB
+  url: http://secunia.com/advisories/61276
+aliases:
+- CVE-2014-0483
+modified: "2018-10-30T16:27:00Z"
+published: "2014-08-26T14:55:00Z"

--- a/vulns/django/PYSEC-0000-CVE-2015-0219.yaml
+++ b/vulns/django/PYSEC-0000-CVE-2015-0219.yaml
@@ -1,0 +1,48 @@
+id: PYSEC-0000-CVE-2015-0219
+package:
+  name: django
+  ecosystem: PyPI
+details: Django before 1.4.18, 1.6.x before 1.6.10, and 1.7.x before 1.7.3 allows
+  remote attackers to spoof WSGI headers by using an _ (underscore) character instead
+  of a - (dash) character in an HTTP header, as demonstrated by an X-Auth_User header.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.4.18
+  - type: ECOSYSTEM
+    introduced: '1.5'
+    fixed: 1.6.10
+  - type: ECOSYSTEM
+    introduced: '1.7'
+    fixed: 1.7.3
+references:
+- type: WEB
+  url: http://secunia.com/advisories/62285
+- type: WEB
+  url: https://www.djangoproject.com/weblog/2015/jan/13/security/
+- type: WEB
+  url: http://secunia.com/advisories/62309
+- type: WEB
+  url: http://www.ubuntu.com/usn/USN-2469-1
+- type: WEB
+  url: http://secunia.com/advisories/62718
+- type: WEB
+  url: http://advisories.mageia.org/MGASA-2015-0026.html
+- type: WEB
+  url: http://www.mandriva.com/security/advisories?name=MDVSA-2015:036
+- type: WEB
+  url: http://www.mandriva.com/security/advisories?name=MDVSA-2015:109
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-updates/2015-04/msg00001.html
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2015-January/148485.html
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2015-January/148696.html
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2015-January/148608.html
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-updates/2015-09/msg00035.html
+aliases:
+- CVE-2015-0219
+modified: "2016-12-22T02:59:00Z"
+published: "2015-01-16T16:59:00Z"

--- a/vulns/django/PYSEC-0000-CVE-2015-0220.yaml
+++ b/vulns/django/PYSEC-0000-CVE-2015-0220.yaml
@@ -1,0 +1,47 @@
+id: PYSEC-0000-CVE-2015-0220
+package:
+  name: django
+  ecosystem: PyPI
+details: The django.util.http.is_safe_url function in Django before 1.4.18, 1.6.x
+  before 1.6.10, and 1.7.x before 1.7.3 does not properly handle leading whitespaces,
+  which allows remote attackers to conduct cross-site scripting (XSS) attacks via
+  a crafted URL, related to redirect URLs, as demonstrated by a "\njavascript:" URL.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.4.18
+  - type: ECOSYSTEM
+    introduced: '1.5'
+    fixed: 1.6.10
+  - type: ECOSYSTEM
+    introduced: '1.7'
+    fixed: 1.7.3
+references:
+- type: WEB
+  url: http://secunia.com/advisories/62285
+- type: WEB
+  url: https://www.djangoproject.com/weblog/2015/jan/13/security/
+- type: WEB
+  url: http://secunia.com/advisories/62309
+- type: WEB
+  url: http://ubuntu.com/usn/usn-2469-1
+- type: WEB
+  url: http://secunia.com/advisories/62718
+- type: WEB
+  url: http://advisories.mageia.org/MGASA-2015-0026.html
+- type: WEB
+  url: http://www.mandriva.com/security/advisories?name=MDVSA-2015:036
+- type: WEB
+  url: http://www.mandriva.com/security/advisories?name=MDVSA-2015:109
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-updates/2015-04/msg00001.html
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2015-January/148485.html
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2015-January/148608.html
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-updates/2015-09/msg00035.html
+aliases:
+- CVE-2015-0220
+modified: "2016-12-22T02:59:00Z"
+published: "2015-01-16T16:59:00Z"

--- a/vulns/django/PYSEC-0000-CVE-2015-0221.yaml
+++ b/vulns/django/PYSEC-0000-CVE-2015-0221.yaml
@@ -1,0 +1,49 @@
+id: PYSEC-0000-CVE-2015-0221
+package:
+  name: django
+  ecosystem: PyPI
+details: The django.views.static.serve view in Django before 1.4.18, 1.6.x before
+  1.6.10, and 1.7.x before 1.7.3 reads files an entire line at a time, which allows
+  remote attackers to cause a denial of service (memory consumption) via a long line
+  in a file.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.4.18
+  - type: ECOSYSTEM
+    introduced: '1.5'
+    fixed: 1.6.10
+  - type: ECOSYSTEM
+    introduced: '1.7'
+    fixed: 1.7.3
+references:
+- type: WEB
+  url: http://secunia.com/advisories/62285
+- type: WEB
+  url: https://www.djangoproject.com/weblog/2015/jan/13/security/
+- type: WEB
+  url: http://secunia.com/advisories/62309
+- type: WEB
+  url: http://ubuntu.com/usn/usn-2469-1
+- type: WEB
+  url: http://secunia.com/advisories/62718
+- type: WEB
+  url: http://advisories.mageia.org/MGASA-2015-0026.html
+- type: WEB
+  url: http://www.mandriva.com/security/advisories?name=MDVSA-2015:036
+- type: WEB
+  url: http://www.mandriva.com/security/advisories?name=MDVSA-2015:109
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-updates/2015-04/msg00001.html
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2015-January/148485.html
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2015-January/148696.html
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2015-January/148608.html
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-updates/2015-09/msg00035.html
+aliases:
+- CVE-2015-0221
+modified: "2016-12-22T02:59:00Z"
+published: "2015-01-16T16:59:00Z"

--- a/vulns/django/PYSEC-0000-CVE-2015-0222.yaml
+++ b/vulns/django/PYSEC-0000-CVE-2015-0222.yaml
@@ -1,0 +1,45 @@
+id: PYSEC-0000-CVE-2015-0222
+package:
+  name: django
+  ecosystem: PyPI
+details: ModelMultipleChoiceField in Django 1.6.x before 1.6.10 and 1.7.x before 1.7.3,
+  when show_hidden_initial is set to True, allows remote attackers to cause a denial
+  of service by submitting duplicate values, which triggers a large number of SQL
+  queries.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.4.18
+  - type: ECOSYSTEM
+    introduced: '1.5'
+    fixed: 1.6.10
+  - type: ECOSYSTEM
+    introduced: '1.7'
+    fixed: 1.7.3
+references:
+- type: WEB
+  url: http://secunia.com/advisories/62285
+- type: WEB
+  url: https://www.djangoproject.com/weblog/2015/jan/13/security/
+- type: WEB
+  url: http://secunia.com/advisories/62309
+- type: WEB
+  url: http://ubuntu.com/usn/usn-2469-1
+- type: WEB
+  url: http://advisories.mageia.org/MGASA-2015-0026.html
+- type: WEB
+  url: http://www.mandriva.com/security/advisories?name=MDVSA-2015:109
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-updates/2015-04/msg00001.html
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2015-January/148485.html
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2015-January/148696.html
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2015-January/148608.html
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-updates/2015-09/msg00035.html
+aliases:
+- CVE-2015-0222
+modified: "2016-12-22T02:59:00Z"
+published: "2015-01-16T16:59:00Z"

--- a/vulns/django/PYSEC-0000-CVE-2015-2241.yaml
+++ b/vulns/django/PYSEC-0000-CVE-2015-2241.yaml
@@ -1,0 +1,28 @@
+id: PYSEC-0000-CVE-2015-2241
+package:
+  name: django
+  ecosystem: PyPI
+details: Cross-site scripting (XSS) vulnerability in the contents function in admin/helpers.py
+  in Django before 1.7.6 and 1.8 before 1.8b2 allows remote attackers to inject arbitrary
+  web script or HTML via a model attribute in ModelAdmin.readonly_fields, as demonstrated
+  by a @property.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.7.6
+  - type: ECOSYSTEM
+    introduced: '1.8a1'
+    fixed: '1.8b2'
+references:
+- type: WEB
+  url: https://code.djangoproject.com/ticket/24461
+- type: WEB
+  url: https://www.djangoproject.com/weblog/2015/mar/09/security-releases/
+- type: WEB
+  url: http://www.mandriva.com/security/advisories?name=MDVSA-2015:109
+- type: WEB
+  url: http://www.securityfocus.com/bid/73095
+aliases:
+- CVE-2015-2241
+modified: "2016-12-03T03:04:00Z"
+published: "2015-03-12T14:59:00Z"

--- a/vulns/django/PYSEC-0000-CVE-2015-2317.yaml
+++ b/vulns/django/PYSEC-0000-CVE-2015-2317.yaml
@@ -1,0 +1,46 @@
+id: PYSEC-0000-CVE-2015-2317
+package:
+  name: django
+  ecosystem: PyPI
+details: 'The utils.http.is_safe_url function in Django before 1.4.20, 1.5.x, 1.6.x
+  before 1.6.11, 1.7.x before 1.7.7, and 1.8.x before 1.8c1 does not properly validate
+  URLs, which allows remote attackers to conduct cross-site scripting (XSS) attacks
+  via a control character in a URL, as demonstrated by a \x08javascript: URL.'
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.4.20
+  - type: ECOSYSTEM
+    introduced: '1.5'
+    fixed: 1.6.11
+  - type: ECOSYSTEM
+    introduced: '1.7'
+    fixed: 1.7.7 
+  - type: ECOSYSTEM
+    introduced: '1.8'
+    fixed: '1.8c1'
+references:
+- type: WEB
+  url: http://ubuntu.com/usn/usn-2539-1
+- type: WEB
+  url: https://www.djangoproject.com/weblog/2015/mar/18/security-releases/
+- type: WEB
+  url: http://www.debian.org/security/2015/dsa-3204
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-updates/2015-04/msg00001.html
+- type: WEB
+  url: http://www.mandriva.com/security/advisories?name=MDVSA-2015:195
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2015-April/155421.html
+- type: WEB
+  url: http://www.oracle.com/technetwork/topics/security/bulletinapr2015-2511959.html
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2015-June/160263.html
+- type: WEB
+  url: http://www.securityfocus.com/bid/73319
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-updates/2015-09/msg00035.html
+aliases:
+- CVE-2015-2317
+modified: "2018-10-30T16:27:00Z"
+published: "2015-03-25T14:59:00Z"

--- a/vulns/django/PYSEC-0000-CVE-2015-5144.yaml
+++ b/vulns/django/PYSEC-0000-CVE-2015-5144.yaml
@@ -1,0 +1,44 @@
+id: PYSEC-0000-CVE-2015-5144
+package:
+  name: django
+  ecosystem: PyPI
+details: Django before 1.4.21, 1.5.x through 1.6.x, 1.7.x before 1.7.9, and 1.8.x
+  before 1.8.3 uses an incorrect regular expression, which allows remote attackers
+  to inject arbitrary headers and conduct HTTP response splitting attacks via a newline
+  character in an (1) email message to the EmailValidator, a (2) URL to the URLValidator,
+  or unspecified vectors to the (3) validate_ipv4_address or (4) validate_slug validator.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.4.21
+  - type: ECOSYSTEM
+    introduced: '1.5'
+    fixed: 1.7.9 
+  - type: ECOSYSTEM
+    introduced: '1.8'
+    fixed: 1.8.3
+references:
+- type: WEB
+  url: http://www.ubuntu.com/usn/USN-2671-1
+- type: WEB
+  url: http://www.debian.org/security/2015/dsa-3305
+- type: WEB
+  url: https://www.djangoproject.com/weblog/2015/jul/08/security-releases/
+- type: WEB
+  url: http://www.oracle.com/technetwork/topics/security/bulletinoct2015-2511968.html
+- type: WEB
+  url: http://www.securityfocus.com/bid/75665
+- type: WEB
+  url: https://security.gentoo.org/glsa/201510-06
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2015-November/172084.html
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-updates/2015-10/msg00046.html
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-updates/2015-10/msg00043.html
+- type: WEB
+  url: http://www.securitytracker.com/id/1032820
+aliases:
+- CVE-2015-5144
+modified: "2017-09-22T01:29:00Z"
+published: "2015-07-14T17:59:00Z"

--- a/vulns/django/PYSEC-0000-CVE-2015-8213.yaml
+++ b/vulns/django/PYSEC-0000-CVE-2015-8213.yaml
@@ -1,0 +1,54 @@
+id: PYSEC-0000-CVE-2015-8213
+package:
+  name: django
+  ecosystem: PyPI
+details: The get_format function in utils/formats.py in Django before 1.7.x before
+  1.7.11, 1.8.x before 1.8.7, and 1.9.x before 1.9rc2 might allow remote attackers
+  to obtain sensitive application secrets via a settings key in place of a date/time
+  format setting, as demonstrated by SECRET_KEY.
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/django/django
+    fixed: 316bc3fc9437c5960c24baceb93c73f1939711e4
+  - type: ECOSYSTEM
+    fixed: 1.7.11
+  - type: ECOSYSTEM
+    introduced: '1.8'
+    fixed: 1.8.7 
+  - type: ECOSYSTEM
+    introduced: '1.9'
+    fixed: '1.9rc2'
+references:
+- type: WEB
+  url: https://www.djangoproject.com/weblog/2015/nov/24/security-releases-issued/
+- type: WEB
+  url: https://github.com/django/django/commit/316bc3fc9437c5960c24baceb93c73f1939711e4
+- type: WEB
+  url: http://www.ubuntu.com/usn/USN-2816-1
+- type: WEB
+  url: http://www.securityfocus.com/bid/77750
+- type: WEB
+  url: http://rhn.redhat.com/errata/RHSA-2016-0156.html
+- type: WEB
+  url: http://rhn.redhat.com/errata/RHSA-2016-0158.html
+- type: WEB
+  url: http://rhn.redhat.com/errata/RHSA-2016-0129.html
+- type: WEB
+  url: http://rhn.redhat.com/errata/RHSA-2016-0157.html
+- type: WEB
+  url: http://www.securitytracker.com/id/1034237
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2015-December/174770.html
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-updates/2015-12/msg00017.html
+- type: WEB
+  url: http://www.debian.org/security/2015/dsa-3404
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2015-December/173375.html
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-updates/2015-12/msg00014.html
+aliases:
+- CVE-2015-8213
+modified: "2016-12-07T18:26:00Z"
+published: "2015-12-07T20:59:00Z"

--- a/vulns/django/PYSEC-0000-CVE-2016-6186.yaml
+++ b/vulns/django/PYSEC-0000-CVE-2016-6186.yaml
@@ -1,0 +1,63 @@
+id: PYSEC-0000-CVE-2016-6186
+package:
+  name: django
+  ecosystem: PyPI
+details: Cross-site scripting (XSS) vulnerability in the dismissChangeRelatedObjectPopup
+  function in contrib/admin/static/admin/js/admin/RelatedObjectLookups.js in Django
+  before 1.8.14, 1.9.x before 1.9.8, and 1.10.x before 1.10rc1 allows remote attackers
+  to inject arbitrary web script or HTML via vectors involving unsafe usage of Element.innerHTML.
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/django/django
+    fixed: d03bf6fe4e9bf5b07de62c1a271c4b41a7d3d158
+  - type: GIT
+    repo: https://github.com/django/django
+    fixed: f68e5a99164867ab0e071a936470958ed867479d
+  - type: ECOSYSTEM
+    fixed: 1.8.14
+  - type: ECOSYSTEM
+    introduced: '1.9'
+    fixed: 1.9.8
+  - type: ECOSYSTEM
+    introduced: '1.10'
+    fixed: '1.10rc1'
+references:
+- type: WEB
+  url: http://packetstormsecurity.com/files/137965/Django-3.3.0-Script-Insertion.html
+- type: WEB
+  url: http://www.vulnerability-lab.com/get_content.php?id=1869
+- type: WEB
+  url: http://www.securitytracker.com/id/1036338
+- type: WEB
+  url: http://www.ubuntu.com/usn/USN-3039-1
+- type: WEB
+  url: http://www.debian.org/security/2016/dsa-3622
+- type: WEB
+  url: https://github.com/django/django/commit/d03bf6fe4e9bf5b07de62c1a271c4b41a7d3d158
+- type: WEB
+  url: https://github.com/django/django/commit/f68e5a99164867ab0e071a936470958ed867479d
+- type: WEB
+  url: https://www.djangoproject.com/weblog/2016/jul/18/security-releases/
+- type: WEB
+  url: http://seclists.org/fulldisclosure/2016/Jul/53
+- type: WEB
+  url: http://www.securityfocus.com/bid/92058
+- type: WEB
+  url: http://rhn.redhat.com/errata/RHSA-2016-1596.html
+- type: WEB
+  url: http://rhn.redhat.com/errata/RHSA-2016-1595.html
+- type: WEB
+  url: https://www.exploit-db.com/exploits/40129/
+- type: WEB
+  url: https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/DMLLFAUT4J4IP4P2KI4NOVWRMHA22WUJ/
+- type: WEB
+  url: http://rhn.redhat.com/errata/RHSA-2016-1594.html
+- type: WEB
+  url: https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/KHHPN6MISX5I6UTXQHYLPTLEEUE6WDXW/
+- type: WEB
+  url: http://www.securityfocus.com/archive/1/538947/100/0/threaded
+aliases:
+- CVE-2016-6186
+modified: "2018-10-09T20:00:00Z"
+published: "2016-08-05T15:59:00Z"

--- a/vulns/django/PYSEC-0000-CVE-2016-7401.yaml
+++ b/vulns/django/PYSEC-0000-CVE-2016-7401.yaml
@@ -1,0 +1,41 @@
+id: PYSEC-0000-CVE-2016-7401
+package:
+  name: django
+  ecosystem: PyPI
+details: The cookie parsing code in Django before 1.8.15 and 1.9.x before 1.9.10,
+  when used on a site with Google Analytics, allows remote attackers to bypass an
+  intended CSRF protection mechanism by setting arbitrary cookies.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.8.15
+  - type: ECOSYSTEM
+    introduced: '1.9'
+    fixed: 1.9.10
+references:
+- type: WEB
+  url: http://www.securitytracker.com/id/1036899
+- type: WEB
+  url: https://www.djangoproject.com/weblog/2016/sep/26/security-releases/
+- type: WEB
+  url: http://www.debian.org/security/2016/dsa-3678
+- type: WEB
+  url: http://www.securityfocus.com/bid/93182
+- type: WEB
+  url: http://www.ubuntu.com/usn/USN-3089-1
+- type: WEB
+  url: http://rhn.redhat.com/errata/RHSA-2016-2043.html
+- type: WEB
+  url: http://rhn.redhat.com/errata/RHSA-2016-2042.html
+- type: WEB
+  url: http://rhn.redhat.com/errata/RHSA-2016-2041.html
+- type: WEB
+  url: http://rhn.redhat.com/errata/RHSA-2016-2040.html
+- type: WEB
+  url: http://rhn.redhat.com/errata/RHSA-2016-2039.html
+- type: WEB
+  url: http://rhn.redhat.com/errata/RHSA-2016-2038.html
+aliases:
+- CVE-2016-7401
+modified: "2018-01-05T02:31:00Z"
+published: "2016-10-03T18:59:00Z"

--- a/vulns/django/PYSEC-0000-CVE-2017-7233.yaml
+++ b/vulns/django/PYSEC-0000-CVE-2017-7233.yaml
@@ -1,0 +1,48 @@
+id: PYSEC-0000-CVE-2017-7233
+package:
+  name: django
+  ecosystem: PyPI
+details: Django 1.10 before 1.10.7, 1.9 before 1.9.13, and 1.8 before 1.8.18 relies
+  on user input in some cases to redirect the user to an "on success" URL. The security
+  check for these redirects (namely ``django.utils.http.is_safe_url()``) considered
+  some numeric URLs "safe" when they shouldn't be, aka an open redirect vulnerability.
+  Also, if a developer relies on ``is_safe_url()`` to provide safe redirect targets
+  and puts such a URL into a link, they could suffer from an XSS attack.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    introduced: "1.10"
+    fixed: 1.10.7
+  - type: ECOSYSTEM
+    introduced: "1.9"
+    fixed: 1.9.13
+  - type: ECOSYSTEM
+    introduced: "1.8"
+    fixed: 1.8.18
+references:
+- type: WEB
+  url: https://www.djangoproject.com/weblog/2017/apr/04/security-releases/
+- type: WEB
+  url: http://www.securityfocus.com/bid/97406
+- type: WEB
+  url: http://www.securitytracker.com/id/1038177
+- type: WEB
+  url: http://www.debian.org/security/2017/dsa-3835
+- type: WEB
+  url: https://access.redhat.com/errata/RHSA-2017:3093
+- type: WEB
+  url: https://access.redhat.com/errata/RHSA-2017:1596
+- type: WEB
+  url: https://access.redhat.com/errata/RHSA-2017:1470
+- type: WEB
+  url: https://access.redhat.com/errata/RHSA-2017:1462
+- type: WEB
+  url: https://access.redhat.com/errata/RHSA-2017:1451
+- type: WEB
+  url: https://access.redhat.com/errata/RHSA-2017:1445
+- type: WEB
+  url: https://access.redhat.com/errata/RHSA-2018:2927
+aliases:
+- CVE-2017-7233
+modified: "2018-10-17T10:29:00Z"
+published: "2017-04-04T17:59:00Z"

--- a/vulns/django/PYSEC-0000-CVE-2017-7234.yaml
+++ b/vulns/django/PYSEC-0000-CVE-2017-7234.yaml
@@ -1,0 +1,31 @@
+id: PYSEC-0000-CVE-2017-7234
+package:
+  name: django
+  ecosystem: PyPI
+details: A maliciously crafted URL to a Django (1.10 before 1.10.7, 1.9 before 1.9.13,
+  and 1.8 before 1.8.18) site using the ``django.views.static.serve()`` view could
+  redirect to any other domain, aka an open redirect vulnerability.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    introduced: "1.10"
+    fixed: 1.10.7
+  - type: ECOSYSTEM
+    introduced: "1.9"
+    fixed: 1.9.13
+  - type: ECOSYSTEM
+    introduced: "1.8"
+    fixed: 1.8.18
+references:
+- type: WEB
+  url: https://www.djangoproject.com/weblog/2017/apr/04/security-releases/
+- type: WEB
+  url: http://www.securityfocus.com/bid/97401
+- type: WEB
+  url: http://www.securitytracker.com/id/1038177
+- type: WEB
+  url: http://www.debian.org/security/2017/dsa-3835
+aliases:
+- CVE-2017-7234
+modified: "2017-11-04T01:29:00Z"
+published: "2017-04-04T17:59:00Z"

--- a/vulns/dulwich/PYSEC-0000-CVE-2017-16228.yaml
+++ b/vulns/dulwich/PYSEC-0000-CVE-2017-16228.yaml
@@ -1,0 +1,23 @@
+id: PYSEC-0000-CVE-2017-16228
+package:
+  name: dulwich
+  ecosystem: PyPI
+details: Dulwich before 0.18.5, when an SSH subprocess is used, allows remote attackers
+  to execute arbitrary commands via an ssh URL with an initial dash character in the
+  hostname, a related issue to CVE-2017-9800, CVE-2017-12836, CVE-2017-12976, CVE-2017-1000116,
+  and CVE-2017-1000117.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 0.18.5
+references:
+- type: WEB
+  url: https://www.dulwich.io/code/dulwich/commit/7116a0cbbda571f7dac863f4b1c00b6e16d6d8d6/
+- type: WEB
+  url: https://www.dulwich.io/code/dulwich/
+- type: WEB
+  url: https://tracker.debian.org/news/882440
+aliases:
+- CVE-2017-16228
+modified: "2019-10-03T00:03:00Z"
+published: "2017-10-29T20:29:00Z"

--- a/vulns/fedmsg/PYSEC-0000-CVE-2017-1000001.yaml
+++ b/vulns/fedmsg/PYSEC-0000-CVE-2017-1000001.yaml
@@ -1,0 +1,17 @@
+id: PYSEC-0000-CVE-2017-1000001
+package:
+  name: fedmsg
+  ecosystem: PyPI
+details: FedMsg 0.18.1 and older is vulnerable to a message validation flaw resulting
+  in message validation not being enabled if configured to be on.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 0.18.2
+references:
+- type: WEB
+  url: https://github.com/fedora-infra/fedmsg/blob/0.18.2/CHANGELOG.rst
+aliases:
+- CVE-2017-1000001
+modified: "2017-07-26T18:14:00Z"
+published: "2017-07-17T13:18:00Z"

--- a/vulns/graphite-web/PYSEC-0000-CVE-2013-5093.yaml
+++ b/vulns/graphite-web/PYSEC-0000-CVE-2013-5093.yaml
@@ -1,0 +1,31 @@
+id: PYSEC-0000-CVE-2013-5093
+package:
+  name: graphite-web
+  ecosystem: PyPI
+details: The renderLocalView function in render/views.py in graphite-web in Graphite
+  0.9.5 through 0.9.10 uses the pickle Python module unsafely, which allows remote
+  attackers to execute arbitrary code via a crafted serialized object.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    introduced: 0.9.5
+    fixed: 0.9.11
+references:
+- type: WEB
+  url: https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/unix/webapp/graphite_pickle_exec.rb
+- type: WEB
+  url: http://secunia.com/advisories/54556
+- type: WEB
+  url: https://github.com/graphite-project/graphite-web/blob/master/docs/releases/0_9_11.rst
+- type: WEB
+  url: http://ceriksen.com/2013/08/20/graphite-remote-code-execution-vulnerability-advisory/
+- type: WEB
+  url: http://www.securityfocus.com/bid/61894
+- type: WEB
+  url: http://www.osvdb.org/96436
+- type: WEB
+  url: http://www.exploit-db.com/exploits/27752
+aliases:
+- CVE-2013-5093
+modified: "2013-10-07T20:25:00Z"
+published: "2013-09-27T10:08:00Z"

--- a/vulns/graphite-web/PYSEC-0000-CVE-2013-5943.yaml
+++ b/vulns/graphite-web/PYSEC-0000-CVE-2013-5943.yaml
@@ -1,0 +1,19 @@
+id: PYSEC-0000-CVE-2013-5943
+package:
+  name: graphite-web
+  ecosystem: PyPI
+details: Multiple cross-site scripting (XSS) vulnerabilities in Graphite before 0.9.11
+  allow remote attackers to inject arbitrary web script or HTML via unspecified vectors.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 0.9.11
+references:
+- type: WEB
+  url: https://github.com/graphite-project/graphite-web/blob/master/docs/releases/0_9_11.rst
+- type: WEB
+  url: http://secunia.com/advisories/54556
+aliases:
+- CVE-2013-5943
+modified: "2013-10-07T20:17:00Z"
+published: "2013-09-27T10:08:00Z"

--- a/vulns/graphite-web/PYSEC-0000-CVE-2017-18638.yaml
+++ b/vulns/graphite-web/PYSEC-0000-CVE-2017-18638.yaml
@@ -1,0 +1,30 @@
+id: PYSEC-0000-CVE-2017-18638
+package:
+  name: graphite-web
+  ecosystem: PyPI
+details: send_email in graphite-web/webapp/graphite/composer/views.py in Graphite
+  through 1.1.5 is vulnerable to SSRF. The vulnerable SSRF endpoint can be used by
+  an attacker to have the Graphite web server request any resource. The response to
+  this SSRF request is encoded into an image file and then sent to an e-mail address
+  that can be supplied by the attacker. Thus, an attacker can exfiltrate any information.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.1.6
+references:
+- type: WEB
+  url: https://www.youtube.com/watch?v=ds4Gp4xoaeA
+- type: WEB
+  url: https://github.com/graphite-project/graphite-web/issues/2008
+- type: WEB
+  url: https://github.com/graphite-project/graphite-web/security/advisories/GHSA-vfj6-275q-4pvm
+- type: WEB
+  url: https://blog.orange.tw/2017/07/how-i-chained-4-vulnerabilities-on.html#second-bug-internal-graphite-ssrf
+- type: WEB
+  url: https://github.com/graphite-project/graphite-web/pull/2499
+- type: WEB
+  url: https://lists.debian.org/debian-lts-announce/2019/10/msg00030.html
+aliases:
+- CVE-2017-18638
+modified: "2019-10-21T16:15:00Z"
+published: "2019-10-11T23:15:00Z"

--- a/vulns/html5lib/PYSEC-0000-CVE-2016-9909.yaml
+++ b/vulns/html5lib/PYSEC-0000-CVE-2016-9909.yaml
@@ -1,0 +1,33 @@
+id: PYSEC-0000-CVE-2016-9909
+package:
+  name: html5lib
+  ecosystem: PyPI
+details: The serializer in html5lib before 0.99999999 might allow remote attackers
+  to conduct cross-site scripting (XSS) attacks by leveraging mishandling of the <
+  (less than) character in attribute values.
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/html5lib/html5lib-python
+    fixed: 9b8d8eb5afbc066b7fac9390f5ec75e5e8a7cab7
+  - type: ECOSYSTEM
+    fixed: "0.999999999"
+references:
+- type: WEB
+  url: https://html5lib.readthedocs.io/en/latest/changes.html#b9
+- type: WEB
+  url: https://github.com/html5lib/html5lib-python/issues/12
+- type: WEB
+  url: https://github.com/html5lib/html5lib-python/issues/11
+- type: WEB
+  url: https://github.com/html5lib/html5lib-python/commit/9b8d8eb5afbc066b7fac9390f5ec75e5e8a7cab7
+- type: WEB
+  url: http://www.securityfocus.com/bid/95132
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2016/12/08/8
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2016/12/06/5
+aliases:
+- CVE-2016-9909
+modified: "2017-02-23T18:56:00Z"
+published: "2017-02-22T16:59:00Z"

--- a/vulns/html5lib/PYSEC-0000-CVE-2016-9910.yaml
+++ b/vulns/html5lib/PYSEC-0000-CVE-2016-9910.yaml
@@ -1,0 +1,33 @@
+id: PYSEC-0000-CVE-2016-9910
+package:
+  name: html5lib
+  ecosystem: PyPI
+details: The serializer in html5lib before 0.99999999 might allow remote attackers
+  to conduct cross-site scripting (XSS) attacks by leveraging mishandling of special
+  characters in attribute values, a different vulnerability than CVE-2016-9909.
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/html5lib/html5lib-python
+    fixed: 9b8d8eb5afbc066b7fac9390f5ec75e5e8a7cab7
+  - type: ECOSYSTEM
+    fixed: "0.999999999"
+references:
+- type: WEB
+  url: https://html5lib.readthedocs.io/en/latest/changes.html#b9
+- type: WEB
+  url: https://github.com/html5lib/html5lib-python/issues/12
+- type: WEB
+  url: https://github.com/html5lib/html5lib-python/issues/11
+- type: WEB
+  url: https://github.com/html5lib/html5lib-python/commit/9b8d8eb5afbc066b7fac9390f5ec75e5e8a7cab7
+- type: WEB
+  url: http://www.securityfocus.com/bid/95132
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2016/12/08/8
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2016/12/06/5
+aliases:
+- CVE-2016-9910
+modified: "2017-02-23T18:56:00Z"
+published: "2017-02-22T16:59:00Z"

--- a/vulns/ironic-inspector/PYSEC-0000-CVE-2019-10141.yaml
+++ b/vulns/ironic-inspector/PYSEC-0000-CVE-2019-10141.yaml
@@ -1,0 +1,48 @@
+id: PYSEC-0000-CVE-2019-10141
+package:
+  name: ironic-inspector
+  ecosystem: PyPI
+details: A vulnerability was found in openstack-ironic-inspector all versions excluding
+  5.0.2, 6.0.3, 7.2.4, 8.0.3 and 8.2.1. A SQL-injection vulnerability was found in
+  openstack-ironic-inspector's node_cache.find_node(). This function makes a SQL query
+  using unfiltered data from a server reporting inspection results (by a POST to the
+  /v1/continue endpoint). Because the API is unauthenticated, the flaw could be exploited
+  by an attacker with access to the network on which ironic-inspector is listening.
+  Because of how ironic-inspector uses the query results, it is unlikely that data
+  could be obtained. However, the attacker could pass malicious data and create a
+  denial of service.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    introduced: 6.1.0
+    fixed: 7.2.4
+  - type: ECOSYSTEM
+    introduced: 8.1.0
+    fixed: 8.2.1
+  - type: ECOSYSTEM
+    fixed: 5.0.2
+  - type: ECOSYSTEM
+    introduced: 5.1.0
+    fixed: 6.0.3
+  - type: ECOSYSTEM
+    introduced: 8.0.0
+    fixed: 8.0.3
+references:
+- type: WEB
+  url: https://docs.openstack.org/releasenotes/ironic-inspector/ocata.html#relnotes-5-0-2-7-origin-stable-ocata
+- type: WEB
+  url: https://docs.openstack.org/releasenotes/ironic-inspector/stein.html#relnotes-8-2-1-stable-stein
+- type: WEB
+  url: https://docs.openstack.org/releasenotes/ironic-inspector/queens.html#relnotes-7-2-4-stable-queens
+- type: WEB
+  url: https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2019-10141
+- type: WEB
+  url: https://docs.openstack.org/releasenotes/ironic-inspector/rocky.html#relnotes-8-0-3-stable-rocky
+- type: WEB
+  url: https://docs.openstack.org/releasenotes/ironic-inspector/pike.html#relnotes-6-0-3-4-stable-pike
+- type: WEB
+  url: https://access.redhat.com/errata/RHSA-2019:2505
+aliases:
+- CVE-2019-10141
+modified: "2019-08-15T17:15:00Z"
+published: "2019-07-30T17:15:00Z"

--- a/vulns/jinja2/PYSEC-0000-CVE-2014-1402.yaml
+++ b/vulns/jinja2/PYSEC-0000-CVE-2014-1402.yaml
@@ -1,0 +1,50 @@
+id: PYSEC-0000-CVE-2014-1402
+package:
+  name: jinja2
+  ecosystem: PyPI
+details: The default configuration for bccache.FileSystemBytecodeCache in Jinja2 before
+  2.7.2 does not properly create temporary files, which allows local users to gain
+  privileges via a crafted .cache file with a name starting with __jinja2_ in /tmp.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 2.7.2
+references:
+- type: WEB
+  url: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=734747
+- type: WEB
+  url: http://advisories.mageia.org/MGASA-2014-0028.html
+- type: WEB
+  url: http://jinja.pocoo.org/docs/changelog/
+- type: WEB
+  url: http://openwall.com/lists/oss-security/2014/01/10/3
+- type: WEB
+  url: https://bugzilla.redhat.com/show_bug.cgi?id=1051421
+- type: WEB
+  url: http://www.mandriva.com/security/advisories?name=MDVSA-2014:096
+- type: WEB
+  url: http://openwall.com/lists/oss-security/2014/01/10/2
+- type: WEB
+  url: http://secunia.com/advisories/59017
+- type: WEB
+  url: http://secunia.com/advisories/58918
+- type: WEB
+  url: http://secunia.com/advisories/60770
+- type: WEB
+  url: http://secunia.com/advisories/60738
+- type: WEB
+  url: http://secunia.com/advisories/56287
+- type: WEB
+  url: http://www.gentoo.org/security/en/glsa/glsa-201408-13.xml
+- type: WEB
+  url: https://oss.oracle.com/pipermail/el-errata/2014-June/004192.html
+- type: WEB
+  url: http://secunia.com/advisories/58783
+- type: WEB
+  url: http://rhn.redhat.com/errata/RHSA-2014-0748.html
+- type: WEB
+  url: http://rhn.redhat.com/errata/RHSA-2014-0747.html
+aliases:
+- CVE-2014-1402
+modified: "2017-12-22T02:29:00Z"
+published: "2014-05-19T14:55:00Z"

--- a/vulns/jwcrypto/PYSEC-0000-CVE-2016-6298.yaml
+++ b/vulns/jwcrypto/PYSEC-0000-CVE-2016-6298.yaml
@@ -1,0 +1,29 @@
+id: PYSEC-0000-CVE-2016-6298
+package:
+  name: jwcrypto
+  ecosystem: PyPI
+details: The _Rsa15 class in the RSA 1.5 algorithm implementation in jwa.py in jwcrypto
+  before 0.3.2 lacks the Random Filling protection mechanism, which makes it easier
+  for remote attackers to obtain cleartext data via a Million Message Attack (MMA).
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/latchset/jwcrypto
+    fixed: eb5be5bd94c8cae1d7f3ba9801377084d8e5a7ba
+  - type: ECOSYSTEM
+    fixed: 0.4.0
+references:
+- type: WEB
+  url: https://github.com/latchset/jwcrypto/commit/eb5be5bd94c8cae1d7f3ba9801377084d8e5a7ba
+- type: WEB
+  url: https://github.com/latchset/jwcrypto/issues/65
+- type: WEB
+  url: https://github.com/latchset/jwcrypto/pull/66
+- type: WEB
+  url: https://github.com/latchset/jwcrypto/releases/tag/v0.3.2
+- type: WEB
+  url: http://www.securityfocus.com/bid/92729
+aliases:
+- CVE-2016-6298
+modified: "2016-11-28T20:31:00Z"
+published: "2016-09-01T23:59:00Z"

--- a/vulns/kallithea/PYSEC-0000-CVE-2015-0276.yaml
+++ b/vulns/kallithea/PYSEC-0000-CVE-2015-0276.yaml
@@ -1,0 +1,20 @@
+id: PYSEC-0000-CVE-2015-0276
+package:
+  name: kallithea
+  ecosystem: PyPI
+details: Cross-site request forgery (CSRF) vulnerability in Kallithea before 0.2.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: "0.2"
+references:
+- type: WEB
+  url: https://kallithea-scm.org/security/cve-2015-0276.html
+- type: WEB
+  url: http://www.securityfocus.com/bid/74052
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2015/04/10/8
+aliases:
+- CVE-2015-0276
+modified: "2020-05-28T16:58:00Z"
+published: "2017-09-21T14:29:00Z"

--- a/vulns/kallithea/PYSEC-0000-CVE-2015-1864.yaml
+++ b/vulns/kallithea/PYSEC-0000-CVE-2015-1864.yaml
@@ -1,0 +1,25 @@
+id: PYSEC-0000-CVE-2015-1864
+package:
+  name: kallithea
+  ecosystem: PyPI
+details: Multiple cross-site scripting (XSS) vulnerabilities in the administration
+  pages in Kallithea before 0.2.1 allow remote attackers to inject arbitrary web script
+  or HTML via the (1) first name or (2) last name user details, or the (3) repository,
+  (4) repository group, or (5) user group description.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 0.2.1
+references:
+- type: WEB
+  url: https://kallithea-scm.org/security/cve-2015-1864.html
+- type: WEB
+  url: https://kallithea-scm.org/repos/kallithea/changeset/a8f2986afc18c9221bf99f88b06e60ab83c86c55
+- type: WEB
+  url: http://www.securityfocus.com/bid/74184
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2015/04/14/12
+aliases:
+- CVE-2015-1864
+modified: "2020-05-28T16:59:00Z"
+published: "2017-09-19T15:29:00Z"

--- a/vulns/kallithea/PYSEC-0000-CVE-2015-5285.yaml
+++ b/vulns/kallithea/PYSEC-0000-CVE-2015-5285.yaml
@@ -1,0 +1,24 @@
+id: PYSEC-0000-CVE-2015-5285
+package:
+  name: kallithea
+  ecosystem: PyPI
+details: CRLF injection vulnerability in Kallithea before 0.3 allows remote attackers
+  to inject arbitrary HTTP headers and conduct HTTP response splitting attacks via
+  the came_from parameter to _admin/login.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: '0.3'
+references:
+- type: WEB
+  url: http://packetstormsecurity.com/files/133897/Kallithea-0.2.9-HTTP-Response-Splitting.html
+- type: WEB
+  url: http://www.zeroscience.mk/en/vulnerabilities/ZSL-2015-5267.php
+- type: WEB
+  url: https://www.exploit-db.com/exploits/38424/
+- type: WEB
+  url: https://kallithea-scm.org/security/cve-2015-5285.html
+aliases:
+- CVE-2015-5285
+modified: "2020-05-28T16:58:00Z"
+published: "2015-10-29T20:59:00Z"

--- a/vulns/lxml/PYSEC-0000-CVE-2014-3146.yaml
+++ b/vulns/lxml/PYSEC-0000-CVE-2014-3146.yaml
@@ -1,0 +1,44 @@
+id: PYSEC-0000-CVE-2014-3146
+package:
+  name: lxml
+  ecosystem: PyPI
+details: Incomplete blacklist vulnerability in the lxml.html.clean module in lxml
+  before 3.3.5 allows remote attackers to conduct cross-site scripting (XSS) attacks
+  via control characters in the link scheme to the clean_html function.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 3.3.5
+references:
+- type: WEB
+  url: http://lxml.de/3.3/changes-3.3.5.html
+- type: WEB
+  url: http://seclists.org/fulldisclosure/2014/Apr/210
+- type: WEB
+  url: http://www.securityfocus.com/bid/67159
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2014/05/09/7
+- type: WEB
+  url: http://secunia.com/advisories/58013
+- type: WEB
+  url: http://seclists.org/fulldisclosure/2014/Apr/319
+- type: WEB
+  url: https://mailman-mail5.webfaction.com/pipermail/lxml/2014-April/007128.html
+- type: WEB
+  url: http://www.ubuntu.com/usn/USN-2217-1
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-updates/2014-05/msg00083.html
+- type: WEB
+  url: http://secunia.com/advisories/58744
+- type: WEB
+  url: http://secunia.com/advisories/59008
+- type: WEB
+  url: http://www.mandriva.com/security/advisories?name=MDVSA-2015:112
+- type: WEB
+  url: http://advisories.mageia.org/MGASA-2014-0218.html
+- type: WEB
+  url: http://www.debian.org/security/2014/dsa-2941
+aliases:
+- CVE-2014-3146
+modified: "2017-12-29T02:29:00Z"
+published: "2014-05-14T19:55:00Z"

--- a/vulns/mako/PYSEC-0000-CVE-2010-2480.yaml
+++ b/vulns/mako/PYSEC-0000-CVE-2010-2480.yaml
@@ -1,0 +1,25 @@
+id: PYSEC-0000-CVE-2010-2480
+package:
+  name: mako
+  ecosystem: PyPI
+details: Mako before 0.3.4 relies on the cgi.escape function in the Python standard
+  library for cross-site scripting (XSS) protection, which makes it easier for remote
+  attackers to conduct XSS attacks via vectors involving single-quote characters and
+  a JavaScript onLoad event handler for a BODY element.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 0.3.4
+references:
+- type: WEB
+  url: http://bugs.python.org/issue9061
+- type: WEB
+  url: http://secunia.com/advisories/39935
+- type: WEB
+  url: http://www.makotemplates.org/CHANGES
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-security-announce/2010-08/msg00001.html
+aliases:
+- CVE-2010-2480
+modified: "2010-09-09T05:42:00Z"
+published: "2010-07-02T19:00:00Z"

--- a/vulns/mercurial/PYSEC-0000-CVE-2014-9462.yaml
+++ b/vulns/mercurial/PYSEC-0000-CVE-2014-9462.yaml
@@ -1,0 +1,30 @@
+id: PYSEC-0000-CVE-2014-9462
+package:
+  name: mercurial
+  ecosystem: PyPI
+details: The _validaterepo function in sshpeer in Mercurial before 3.2.4 allows remote
+  attackers to execute arbitrary commands via a crafted repository name in a clone
+  command.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 3.2.4
+references:
+- type: WEB
+  url: http://chargen.matasano.com/chargen/2015/3/17/this-new-vulnerability-mercurial-command-injection-cve-2014-9462.html
+- type: WEB
+  url: http://mercurial.selenic.com/wiki/WhatsNew
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-updates/2015-03/msg00085.html
+- type: WEB
+  url: http://www.osvdb.org/119816
+- type: WEB
+  url: http://www.oracle.com/technetwork/topics/security/bulletinjul2015-2511963.html
+- type: WEB
+  url: http://www.debian.org/security/2015/dsa-3257
+- type: WEB
+  url: https://security.gentoo.org/glsa/201612-19
+aliases:
+- CVE-2014-9462
+modified: "2018-10-30T16:27:00Z"
+published: "2015-03-31T14:59:00Z"

--- a/vulns/mistune/PYSEC-0000-CVE-2017-16876.yaml
+++ b/vulns/mistune/PYSEC-0000-CVE-2017-16876.yaml
@@ -1,0 +1,27 @@
+id: PYSEC-0000-CVE-2017-16876
+package:
+  name: mistune
+  ecosystem: PyPI
+details: Cross-site scripting (XSS) vulnerability in the _keyify function in mistune.py
+  in Mistune before 0.8.1 allows remote attackers to inject arbitrary web script or
+  HTML by leveraging failure to escape the "key" argument.
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/lepture/mistune
+    fixed: 5f06d724bc05580e7f203db2d4a4905fc1127f98
+  - type: ECOSYSTEM
+    fixed: 0.8.1
+references:
+- type: WEB
+  url: https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/NUR3GMHQBMA3UC4PFMCK6GCLOQC4LQQC/
+- type: WEB
+  url: https://github.com/lepture/mistune/commit/5f06d724bc05580e7f203db2d4a4905fc1127f98
+- type: WEB
+  url: https://github.com/lepture/mistune/blob/master/CHANGES.rst
+- type: WEB
+  url: https://bugzilla.redhat.com/show_bug.cgi?id=1524596
+aliases:
+- CVE-2017-16876
+modified: "2018-01-10T17:15:00Z"
+published: "2017-12-29T15:29:00Z"

--- a/vulns/mlalchemy/PYSEC-0000-CVE-2017-16615.yaml
+++ b/vulns/mlalchemy/PYSEC-0000-CVE-2017-16615.yaml
@@ -1,0 +1,27 @@
+id: PYSEC-0000-CVE-2017-16615
+package:
+  name: mlalchemy
+  ecosystem: PyPI
+details: An exploitable vulnerability exists in the YAML parsing functionality in
+  the parse_yaml_query method in parser.py in MLAlchemy before 0.2.2. When processing
+  YAML-Based queries for data, a YAML parser can execute arbitrary Python commands
+  resulting in command execution because load is used where safe_load should have
+  been used. An attacker can insert Python into loaded YAML to trigger this vulnerability.
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/thanethomson/MLAlchemy
+    fixed: bc795757febdcce430d89f9d08f75c32d6989d3c
+  - type: ECOSYSTEM
+    fixed: 0.2.2
+references:
+- type: WEB
+  url: https://github.com/thanethomson/MLAlchemy/issues/1
+- type: WEB
+  url: https://joel-malwarebenchmark.github.io/blog/2017/11/08/cve-2017-16615-critical-restful-web-applications-vulnerability/
+- type: WEB
+  url: https://github.com/thanethomson/MLAlchemy/commit/bc795757febdcce430d89f9d08f75c32d6989d3c
+aliases:
+- CVE-2017-16615
+modified: "2019-10-03T00:03:00Z"
+published: "2017-11-08T03:29:00Z"

--- a/vulns/modulemd/PYSEC-0000-CVE-2017-1002157.yaml
+++ b/vulns/modulemd/PYSEC-0000-CVE-2017-1002157.yaml
@@ -1,0 +1,17 @@
+id: PYSEC-0000-CVE-2017-1002157
+package:
+  name: modulemd
+  ecosystem: PyPI
+details: modulemd 1.3.1 and earlier uses an unsafe function for processing externally
+  provided data, leading to remote code execution.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.3.2
+references:
+- type: WEB
+  url: https://pagure.io/modulemd/issue/55
+aliases:
+- CVE-2017-1002157
+modified: "2019-10-09T23:21:00Z"
+published: "2019-01-10T21:29:00Z"

--- a/vulns/moin/PYSEC-0000-CVE-2010-0669.yaml
+++ b/vulns/moin/PYSEC-0000-CVE-2010-0669.yaml
@@ -1,0 +1,40 @@
+id: PYSEC-0000-CVE-2010-0669
+package:
+  name: moin
+  ecosystem: PyPI
+details: MoinMoin before 1.8.7 and 1.9.x before 1.9.2 does not properly sanitize user
+  profiles, which has unspecified impact and attack vectors.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.8.7
+  - type: ECOSYSTEM
+    introduced: '1.9'
+    fixed: 1.9.2
+references:
+- type: WEB
+  url: http://moinmo.in/MoinMoinRelease1.8
+- type: WEB
+  url: http://secunia.com/advisories/38444
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2010/02/15/4
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2010/02/15/2
+- type: WEB
+  url: http://hg.moinmo.in/moin/1.8/raw-file/1.8.7/docs/CHANGES
+- type: WEB
+  url: http://www.securityfocus.com/bid/38023
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2010/02/21/2
+- type: WEB
+  url: http://moinmo.in/SecurityFixes
+- type: WEB
+  url: http://www.vupen.com/english/advisories/2010/0600
+- type: WEB
+  url: http://www.debian.org/security/2010/dsa-2014
+- type: WEB
+  url: http://secunia.com/advisories/38903
+aliases:
+- CVE-2010-0669
+modified: "2010-03-31T05:41:00Z"
+published: "2010-02-26T19:30:00Z"

--- a/vulns/moin/PYSEC-0000-CVE-2010-0717.yaml
+++ b/vulns/moin/PYSEC-0000-CVE-2010-0717.yaml
@@ -1,0 +1,30 @@
+id: PYSEC-0000-CVE-2010-0717
+package:
+  name: moin
+  ecosystem: PyPI
+details: The default configuration of cfg.packagepages_actions_excluded in MoinMoin
+  before 1.8.7 does not prevent unsafe package actions, which has unspecified impact
+  and attack vectors.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.8.7
+references:
+- type: WEB
+  url: http://moinmo.in/MoinMoinRelease1.8
+- type: WEB
+  url: http://hg.moinmo.in/moin/1.8/raw-file/1.8.7/docs/CHANGES
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2010/02/15/2
+- type: WEB
+  url: http://www.vupen.com/english/advisories/2010/0600
+- type: WEB
+  url: http://www.debian.org/security/2010/dsa-2014
+- type: WEB
+  url: http://secunia.com/advisories/38903
+- type: WEB
+  url: https://exchange.xforce.ibmcloud.com/vulnerabilities/56595
+aliases:
+- CVE-2010-0717
+modified: "2017-08-17T01:32:00Z"
+published: "2010-02-26T19:30:00Z"

--- a/vulns/moin/PYSEC-0000-CVE-2011-1058.yaml
+++ b/vulns/moin/PYSEC-0000-CVE-2011-1058.yaml
@@ -1,0 +1,46 @@
+id: PYSEC-0000-CVE-2011-1058
+package:
+  name: moin
+  ecosystem: PyPI
+details: 'Cross-site scripting (XSS) vulnerability in the reStructuredText (rst) parser
+  in parser/text_rst.py in MoinMoin before 1.9.3, when docutils is installed or when
+  "format rst" is set, allows remote attackers to inject arbitrary web script or HTML
+  via a javascript: URL in the refuri attribute.  NOTE: some of these details are
+  obtained from third party information.'
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.9.3
+references:
+- type: WEB
+  url: http://moinmo.in/SecurityFixes
+- type: WEB
+  url: http://secunia.com/advisories/43413
+- type: WEB
+  url: http://www.vupen.com/english/advisories/2011/0455
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2011-March/055116.html
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2011-March/054544.html
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2011-March/055124.html
+- type: WEB
+  url: http://secunia.com/advisories/43665
+- type: WEB
+  url: http://www.vupen.com/english/advisories/2011/0571
+- type: WEB
+  url: http://www.securityfocus.com/bid/46476
+- type: WEB
+  url: http://www.vupen.com/english/advisories/2011/0588
+- type: WEB
+  url: http://www.debian.org/security/2011/dsa-2321
+- type: WEB
+  url: http://www.ubuntu.com/usn/USN-1604-1
+- type: WEB
+  url: http://secunia.com/advisories/50885
+- type: WEB
+  url: https://exchange.xforce.ibmcloud.com/vulnerabilities/65545
+aliases:
+- CVE-2011-1058
+modified: "2017-08-17T01:33:00Z"
+published: "2011-02-22T18:00:00Z"

--- a/vulns/moin/PYSEC-0000-CVE-2012-6080.yaml
+++ b/vulns/moin/PYSEC-0000-CVE-2012-6080.yaml
@@ -1,0 +1,37 @@
+id: PYSEC-0000-CVE-2012-6080
+package:
+  name: moin
+  ecosystem: PyPI
+details: Directory traversal vulnerability in the _do_attachment_move function in
+  the AttachFile action (action/AttachFile.py) in MoinMoin 1.9.3 through 1.9.5 allows
+  remote attackers to overwrite arbitrary files via a .. (dot dot) in a file name.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    introduced: 1.9.3
+    fixed: 1.9.6
+references:
+- type: WEB
+  url: http://secunia.com/advisories/51663
+- type: WEB
+  url: http://secunia.com/advisories/51696
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2012/12/30/6
+- type: WEB
+  url: http://www.securityfocus.com/bid/57076
+- type: WEB
+  url: http://moinmo.in/SecurityFixes
+- type: WEB
+  url: http://www.debian.org/security/2012/dsa-2593
+- type: WEB
+  url: http://hg.moinmo.in/moin/1.9/rev/3c27131a3c52
+- type: WEB
+  url: https://bugs.launchpad.net/ubuntu/+source/moin/+bug/1094599
+- type: WEB
+  url: http://secunia.com/advisories/51676
+- type: WEB
+  url: http://ubuntu.com/usn/usn-1680-1
+aliases:
+- CVE-2012-6080
+modified: "2013-01-03T05:00:00Z"
+published: "2013-01-03T01:55:00Z"

--- a/vulns/moin/PYSEC-0000-CVE-2012-6081.yaml
+++ b/vulns/moin/PYSEC-0000-CVE-2012-6081.yaml
@@ -1,0 +1,44 @@
+id: PYSEC-0000-CVE-2012-6081
+package:
+  name: moin
+  ecosystem: PyPI
+details: Multiple unrestricted file upload vulnerabilities in the (1) twikidraw (action/twikidraw.py)
+  and (2) anywikidraw (action/anywikidraw.py) actions in MoinMoin before 1.9.6 allow
+  remote authenticated users with write permissions to execute arbitrary code by uploading
+  a file with an executable extension, then accessing it via a direct request to the
+  file in an unspecified directory, as exploited in the wild in July 2012.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.9.6
+references:
+- type: WEB
+  url: http://secunia.com/advisories/51676
+- type: WEB
+  url: http://moinmo.in/SecurityFixes
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2012/12/29/6
+- type: WEB
+  url: http://ubuntu.com/usn/usn-1680-1
+- type: WEB
+  url: http://moinmo.in/MoinMoinRelease1.9
+- type: WEB
+  url: http://secunia.com/advisories/51696
+- type: WEB
+  url: http://hg.moinmo.in/moin/1.9/rev/7e7e1cbb9d3f
+- type: WEB
+  url: http://www.debian.org/security/2012/dsa-2593
+- type: WEB
+  url: http://secunia.com/advisories/51663
+- type: WEB
+  url: https://bugs.launchpad.net/ubuntu/+source/moin/+bug/1094599
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2012/12/30/4
+- type: WEB
+  url: http://www.securityfocus.com/bid/57082
+- type: WEB
+  url: http://www.exploit-db.com/exploits/25304
+aliases:
+- CVE-2012-6081
+modified: "2013-12-13T05:08:00Z"
+published: "2013-01-03T01:55:00Z"

--- a/vulns/moin/PYSEC-0000-CVE-2012-6495.yaml
+++ b/vulns/moin/PYSEC-0000-CVE-2012-6495.yaml
@@ -1,0 +1,36 @@
+id: PYSEC-0000-CVE-2012-6495
+package:
+  name: moin
+  ecosystem: PyPI
+details: 'Multiple directory traversal vulnerabilities in the (1) twikidraw (action/twikidraw.py)
+  and (2) anywikidraw (action/anywikidraw.py) actions in MoinMoin before 1.9.6 allow
+  remote authenticated users with write permissions to overwrite arbitrary files via
+  unspecified vectors.  NOTE: this can be leveraged with CVE-2012-6081 to execute
+  arbitrary code.'
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.9.6
+references:
+- type: WEB
+  url: http://secunia.com/advisories/51696
+- type: WEB
+  url: http://hg.moinmo.in/moin/1.9/rev/7e7e1cbb9d3f
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2012/12/29/6
+- type: WEB
+  url: http://moinmo.in/MoinMoinRelease1.9
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2012/12/30/4
+- type: WEB
+  url: https://bugs.launchpad.net/ubuntu/+source/moin/+bug/1094599
+- type: WEB
+  url: http://moinmo.in/SecurityFixes
+- type: WEB
+  url: http://www.debian.org/security/2012/dsa-2593
+- type: WEB
+  url: http://ubuntu.com/usn/usn-1680-1
+aliases:
+- CVE-2012-6495
+modified: "2013-01-07T05:00:00Z"
+published: "2013-01-03T01:55:00Z"

--- a/vulns/moin/PYSEC-0000-CVE-2016-9119.yaml
+++ b/vulns/moin/PYSEC-0000-CVE-2016-9119.yaml
@@ -1,0 +1,24 @@
+id: PYSEC-0000-CVE-2016-9119
+package:
+  name: moin
+  ecosystem: PyPI
+details: Cross-site scripting (XSS) vulnerability in the link dialogue in GUI editor
+  in MoinMoin before 1.9.8 allows remote attackers to inject arbitrary web script
+  or HTML via unspecified vectors.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.9.8
+references:
+- type: WEB
+  url: https://moinmo.in/SecurityFixes
+- type: WEB
+  url: http://www.ubuntu.com/usn/USN-3137-1
+- type: WEB
+  url: http://www.debian.org/security/2016/dsa-3715
+- type: WEB
+  url: http://www.securityfocus.com/bid/94501
+aliases:
+- CVE-2016-9119
+modified: "2017-02-03T15:59:00Z"
+published: "2017-01-30T22:59:00Z"

--- a/vulns/moin/PYSEC-0000-CVE-2017-5934.yaml
+++ b/vulns/moin/PYSEC-0000-CVE-2017-5934.yaml
@@ -1,0 +1,31 @@
+id: PYSEC-0000-CVE-2017-5934
+package:
+  name: moin
+  ecosystem: PyPI
+details: Cross-site scripting (XSS) vulnerability in the link dialogue in GUI editor
+  in MoinMoin before 1.9.10 allows remote attackers to inject arbitrary web script
+  or HTML via unspecified vectors.
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/moinwiki/moin-1.9
+    fixed: 70955a8eae091cc88fd9a6e510177e70289ec024
+  - type: ECOSYSTEM
+    fixed: 1.9.10
+references:
+- type: WEB
+  url: https://github.com/moinwiki/moin-1.9/commit/70955a8eae091cc88fd9a6e510177e70289ec024
+- type: WEB
+  url: http://moinmo.in/SecurityFixes
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-security-announce/2018-10/msg00024.html
+- type: WEB
+  url: https://www.debian.org/security/2018/dsa-4318
+- type: WEB
+  url: https://lists.debian.org/debian-lts-announce/2018/10/msg00007.html
+- type: WEB
+  url: https://usn.ubuntu.com/3794-1/
+aliases:
+- CVE-2017-5934
+modified: "2018-11-29T13:00:00Z"
+published: "2018-10-15T19:29:00Z"

--- a/vulns/nova-lxd/PYSEC-0000-CVE-2017-5936.yaml
+++ b/vulns/nova-lxd/PYSEC-0000-CVE-2017-5936.yaml
@@ -1,0 +1,29 @@
+id: PYSEC-0000-CVE-2017-5936
+package:
+  name: nova-lxd
+  ecosystem: PyPI
+details: OpenStack Nova-LXD before 13.1.1 uses the wrong name for the veth pairs when
+  applying Neutron security group rules for instances, which allows remote attackers
+  to bypass intended security restrictions.
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/openstack/nova-lxd
+    fixed: 1b76cefb92081efa1e88cd8f330253f857028bd2
+  - type: ECOSYSTEM
+    fixed: 13.1.1
+references:
+- type: WEB
+  url: https://github.com/openstack/nova-lxd/commit/1b76cefb92081efa1e88cd8f330253f857028bd2
+- type: WEB
+  url: https://bugs.launchpad.net/nova-lxd/+bug/1656847
+- type: WEB
+  url: http://www.ubuntu.com/usn/USN-3195-1
+- type: WEB
+  url: http://www.securityfocus.com/bid/96182
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2017/02/09/3
+aliases:
+- CVE-2017-5936
+modified: "2019-10-03T00:03:00Z"
+published: "2017-04-12T22:59:00Z"

--- a/vulns/owlmixin/PYSEC-0000-CVE-2017-16618.yaml
+++ b/vulns/owlmixin/PYSEC-0000-CVE-2017-16618.yaml
@@ -1,0 +1,27 @@
+id: PYSEC-0000-CVE-2017-16618
+package:
+  name: owlmixin
+  ecosystem: PyPI
+details: An exploitable vulnerability exists in the YAML loading functionality of
+  util.py in OwlMixin before 2.0.0a12. A "Load YAML" string or file (aka load_yaml
+  or load_yamlf) can execute arbitrary Python commands resulting in command execution
+  because load is used where safe_load should have been used. An attacker can insert
+  Python into loaded YAML to trigger this vulnerability.
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/tadashi-aikawa/owlmixin
+    fixed: 5d0575303f6df869a515ced4285f24ba721e0d4e
+  - type: ECOSYSTEM
+    fixed: 2.0.0
+references:
+- type: WEB
+  url: https://github.com/tadashi-aikawa/owlmixin/issues/12
+- type: WEB
+  url: https://github.com/tadashi-aikawa/owlmixin/commit/5d0575303f6df869a515ced4285f24ba721e0d4e
+- type: WEB
+  url: https://joel-malwarebenchmark.github.io/blog/2017/11/08/cve-2017-16618-convert-through-owlmixin/
+aliases:
+- CVE-2017-16618
+modified: "2019-10-03T00:03:00Z"
+published: "2017-11-08T03:29:00Z"

--- a/vulns/pillow/PYSEC-0000-CVE-2014-3589.yaml
+++ b/vulns/pillow/PYSEC-0000-CVE-2014-3589.yaml
@@ -1,0 +1,34 @@
+id: PYSEC-0000-CVE-2014-3589
+package:
+  name: pillow
+  ecosystem: PyPI
+details: PIL/IcnsImagePlugin.py in Python Imaging Library (PIL) and Pillow before
+  2.3.2 and 2.5.x before 2.5.2 allows remote attackers to cause a denial of service
+  via a crafted block size.
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/python-pillow/Pillow
+    fixed: 205e056f8f9b06ed7b925cf8aa0874bc4aaf8a7d
+  - type: ECOSYSTEM
+    fixed: 2.3.2
+  - type: ECOSYSTEM
+    introduced: '2.5'
+    fixed: 2.5.2
+references:
+- type: WEB
+  url: https://pypi.python.org/pypi/Pillow/2.5.2
+- type: WEB
+  url: https://pypi.python.org/pypi/Pillow/2.3.2
+- type: WEB
+  url: http://www.debian.org/security/2014/dsa-3009
+- type: WEB
+  url: https://github.com/python-pillow/Pillow/commit/205e056f8f9b06ed7b925cf8aa0874bc4aaf8a7d
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-updates/2015-04/msg00056.html
+- type: WEB
+  url: http://secunia.com/advisories/59825
+aliases:
+- CVE-2014-3589
+modified: "2018-10-30T16:27:00Z"
+published: "2014-08-25T14:55:00Z"

--- a/vulns/pillow/PYSEC-0000-CVE-2014-3598.yaml
+++ b/vulns/pillow/PYSEC-0000-CVE-2014-3598.yaml
@@ -1,0 +1,19 @@
+id: PYSEC-0000-CVE-2014-3598
+package:
+  name: pillow
+  ecosystem: PyPI
+details: The Jpeg2KImagePlugin plugin in Pillow before 2.5.3 allows remote attackers
+  to cause a denial of service via a crafted image.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 2.5.3
+references:
+- type: WEB
+  url: https://pypi.python.org/pypi/Pillow/2.5.3
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-updates/2015-04/msg00056.html
+aliases:
+- CVE-2014-3598
+modified: "2018-10-30T16:27:00Z"
+published: "2015-05-01T15:59:00Z"

--- a/vulns/pillow/PYSEC-0000-CVE-2014-9601.yaml
+++ b/vulns/pillow/PYSEC-0000-CVE-2014-9601.yaml
@@ -1,0 +1,29 @@
+id: PYSEC-0000-CVE-2014-9601
+package:
+  name: pillow
+  ecosystem: PyPI
+details: Pillow before 2.7.0 allows remote attackers to cause a denial of service
+  via a compressed text chunk in a PNG image that has a large size when it is decompressed.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 2.7.0
+references:
+- type: WEB
+  url: https://github.com/python-pillow/Pillow/pull/1060
+- type: WEB
+  url: https://www.djangoproject.com/weblog/2015/jan/02/pillow-security-release/
+- type: WEB
+  url: http://pillow.readthedocs.org/releasenotes/2.7.0.html
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2015-January/148442.html
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-updates/2015-04/msg00056.html
+- type: WEB
+  url: http://www.oracle.com/technetwork/topics/security/bulletinjul2015-2511963.html
+- type: WEB
+  url: http://www.securityfocus.com/bid/77758
+aliases:
+- CVE-2014-9601
+modified: "2018-10-30T16:27:00Z"
+published: "2015-01-16T16:59:00Z"

--- a/vulns/pillow/PYSEC-0000-CVE-2016-0740.yaml
+++ b/vulns/pillow/PYSEC-0000-CVE-2016-0740.yaml
@@ -1,0 +1,27 @@
+id: PYSEC-0000-CVE-2016-0740
+package:
+  name: pillow
+  ecosystem: PyPI
+details: Buffer overflow in the ImagingLibTiffDecode function in libImaging/TiffDecode.c
+  in Pillow before 3.1.1 allows remote attackers to overwrite memory via a crafted
+  TIFF file.
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/python-pillow/Pillow
+    fixed: 6dcbf5bd96b717c58d7b642949da8d323099928e
+  - type: ECOSYSTEM
+    fixed: 3.1.1
+references:
+- type: WEB
+  url: http://www.debian.org/security/2016/dsa-3499
+- type: WEB
+  url: https://github.com/python-pillow/Pillow/commit/6dcbf5bd96b717c58d7b642949da8d323099928e
+- type: WEB
+  url: https://github.com/python-pillow/Pillow/blob/c3cb690fed5d4bf0c45576759de55d054916c165/CHANGES.rst
+- type: WEB
+  url: https://security.gentoo.org/glsa/201612-52
+aliases:
+- CVE-2016-0740
+modified: "2017-07-01T01:29:00Z"
+published: "2016-04-13T16:59:00Z"

--- a/vulns/pillow/PYSEC-0000-CVE-2016-0775.yaml
+++ b/vulns/pillow/PYSEC-0000-CVE-2016-0775.yaml
@@ -1,0 +1,27 @@
+id: PYSEC-0000-CVE-2016-0775
+package:
+  name: pillow
+  ecosystem: PyPI
+details: Buffer overflow in the ImagingFliDecode function in libImaging/FliDecode.c
+  in Pillow before 3.1.1 allows remote attackers to cause a denial of service (crash)
+  via a crafted FLI file.
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/python-pillow/Pillow
+    fixed: 893a40850c2d5da41537958e40569c029a6e127b
+  - type: ECOSYSTEM
+    fixed: 3.1.1
+references:
+- type: WEB
+  url: http://www.debian.org/security/2016/dsa-3499
+- type: WEB
+  url: https://github.com/python-pillow/Pillow/commit/893a40850c2d5da41537958e40569c029a6e127b
+- type: WEB
+  url: https://github.com/python-pillow/Pillow/blob/c3cb690fed5d4bf0c45576759de55d054916c165/CHANGES.rst
+- type: WEB
+  url: https://security.gentoo.org/glsa/201612-52
+aliases:
+- CVE-2016-0775
+modified: "2017-07-01T01:29:00Z"
+published: "2016-04-13T16:59:00Z"

--- a/vulns/pillow/PYSEC-0000-CVE-2016-4009.yaml
+++ b/vulns/pillow/PYSEC-0000-CVE-2016-4009.yaml
@@ -1,0 +1,29 @@
+id: PYSEC-0000-CVE-2016-4009
+package:
+  name: pillow
+  ecosystem: PyPI
+details: Integer overflow in the ImagingResampleHorizontal function in libImaging/Resample.c
+  in Pillow before 3.1.1 allows remote attackers to have unspecified impact via negative
+  values of the new size, which triggers a heap-based buffer overflow.
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/python-pillow/Pillow
+    fixed: 4e0d9b0b9740d258ade40cce248c93777362ac1e
+  - type: ECOSYSTEM
+    fixed: 3.1.1
+references:
+- type: WEB
+  url: https://github.com/python-pillow/Pillow/commit/4e0d9b0b9740d258ade40cce248c93777362ac1e
+- type: WEB
+  url: https://github.com/python-pillow/Pillow/pull/1714
+- type: WEB
+  url: https://github.com/python-pillow/Pillow/blob/c3cb690fed5d4bf0c45576759de55d054916c165/CHANGES.rst
+- type: WEB
+  url: http://www.securityfocus.com/bid/86064
+- type: WEB
+  url: https://security.gentoo.org/glsa/201612-52
+aliases:
+- CVE-2016-4009
+modified: "2017-07-01T01:29:00Z"
+published: "2016-04-13T16:59:00Z"

--- a/vulns/pillow/PYSEC-0000-CVE-2016-9189.yaml
+++ b/vulns/pillow/PYSEC-0000-CVE-2016-9189.yaml
@@ -1,0 +1,28 @@
+id: PYSEC-0000-CVE-2016-9189
+package:
+  name: pillow
+  ecosystem: PyPI
+details: Pillow before 3.3.2 allows context-dependent attackers to obtain sensitive
+  information by using the "crafted image file" approach, related to an "Integer Overflow"
+  issue affecting the Image.core.map_buffer in map.c component.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 3.3.2
+references:
+- type: WEB
+  url: http://pillow.readthedocs.io/en/3.4.x/releasenotes/3.3.2.html
+- type: WEB
+  url: https://github.com/python-pillow/Pillow/issues/2105
+- type: WEB
+  url: https://github.com/python-pillow/Pillow/pull/2146/commits/c50ebe6459a131a1ea8ca531f10da616d3ceaa0f
+- type: WEB
+  url: http://www.securityfocus.com/bid/94234
+- type: WEB
+  url: http://www.debian.org/security/2016/dsa-3710
+- type: WEB
+  url: https://security.gentoo.org/glsa/201612-52
+aliases:
+- CVE-2016-9189
+modified: "2017-07-01T01:30:00Z"
+published: "2016-11-04T10:59:00Z"

--- a/vulns/pillow/PYSEC-0000-CVE-2016-9190.yaml
+++ b/vulns/pillow/PYSEC-0000-CVE-2016-9190.yaml
@@ -1,0 +1,28 @@
+id: PYSEC-0000-CVE-2016-9190
+package:
+  name: pillow
+  ecosystem: PyPI
+details: Pillow before 3.3.2 allows context-dependent attackers to execute arbitrary
+  code by using the "crafted image file" approach, related to an "Insecure Sign Extension"
+  issue affecting the ImagingNew in Storage.c component.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 3.3.2
+references:
+- type: WEB
+  url: http://pillow.readthedocs.io/en/3.4.x/releasenotes/3.3.2.html
+- type: WEB
+  url: https://github.com/python-pillow/Pillow/issues/2105
+- type: WEB
+  url: https://github.com/python-pillow/Pillow/pull/2146/commits/5d8a0be45aad78c5a22c8d099118ee26ef8144af
+- type: WEB
+  url: http://www.securityfocus.com/bid/94234
+- type: WEB
+  url: http://www.debian.org/security/2016/dsa-3710
+- type: WEB
+  url: https://security.gentoo.org/glsa/201612-52
+aliases:
+- CVE-2016-9190
+modified: "2017-07-01T01:30:00Z"
+published: "2016-11-04T10:59:00Z"

--- a/vulns/pip/PYSEC-0000-CVE-2013-1629.yaml
+++ b/vulns/pip/PYSEC-0000-CVE-2013-1629.yaml
@@ -1,0 +1,28 @@
+id: PYSEC-0000-CVE-2013-1629
+package:
+  name: pip
+  ecosystem: PyPI
+details: pip before 1.3 uses HTTP to retrieve packages from the PyPI repository, and
+  does not perform integrity checks on package contents, which allows man-in-the-middle
+  attackers to execute arbitrary code via a crafted response to a "pip install" operation.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: "1.3"
+references:
+- type: WEB
+  url: https://github.com/pypa/pip/issues/425
+- type: WEB
+  url: https://github.com/pypa/pip/pull/791/files
+- type: WEB
+  url: http://www.pip-installer.org/en/latest/installing.html
+- type: WEB
+  url: http://www.pip-installer.org/en/latest/news.html#changelog
+- type: WEB
+  url: http://www.reddit.com/r/Python/comments/17rfh7/warning_dont_use_pip_in_an_untrusted_network_a/
+- type: WEB
+  url: https://bugzilla.redhat.com/show_bug.cgi?id=968059
+aliases:
+- CVE-2013-1629
+modified: "2021-03-15T16:22:00Z"
+published: "2013-08-06T02:52:00Z"

--- a/vulns/pip/PYSEC-0000-CVE-2013-1888.yaml
+++ b/vulns/pip/PYSEC-0000-CVE-2013-1888.yaml
@@ -1,0 +1,29 @@
+id: PYSEC-0000-CVE-2013-1888
+package:
+  name: pip
+  ecosystem: PyPI
+details: pip before 1.3 allows local users to overwrite arbitrary files via a symlink
+  attack on a file in the /tmp/pip-build temporary directory.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: "1.3"
+references:
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2013/03/22/10
+- type: WEB
+  url: https://github.com/pypa/pip/pull/734/files
+- type: WEB
+  url: https://github.com/pypa/pip/issues/725
+- type: WEB
+  url: https://github.com/pypa/pip/pull/780/files
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2013-May/105952.html
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2013-May/105989.html
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2013-May/106311.html
+aliases:
+- CVE-2013-1888
+modified: "2021-03-15T16:50:00Z"
+published: "2013-08-17T06:54:00Z"

--- a/vulns/pip/PYSEC-0000-CVE-2014-8991.yaml
+++ b/vulns/pip/PYSEC-0000-CVE-2014-8991.yaml
@@ -1,0 +1,28 @@
+id: PYSEC-0000-CVE-2014-8991
+package:
+  name: pip
+  ecosystem: PyPI
+details: pip 1.3 through 1.5.6 allows local users to cause a denial of service (prevention
+  of package installation) by creating a /tmp/pip-build-* file for another user.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    introduced: "1.3"
+    fixed: "6.0"
+references:
+- type: WEB
+  url: https://github.com/pypa/pip/pull/2122
+- type: WEB
+  url: http://www.securityfocus.com/bid/71209
+- type: WEB
+  url: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=725847
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2014/11/19/17
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2014/11/20/6
+- type: WEB
+  url: http://www.oracle.com/technetwork/topics/security/bulletinjul2015-2511963.html
+aliases:
+- CVE-2014-8991
+modified: "2021-03-15T16:17:00Z"
+published: "2014-11-24T15:59:00Z"

--- a/vulns/pyanyapi/PYSEC-0000-CVE-2017-16616.yaml
+++ b/vulns/pyanyapi/PYSEC-0000-CVE-2017-16616.yaml
@@ -1,0 +1,26 @@
+id: PYSEC-0000-CVE-2017-16616
+package:
+  name: pyanyapi
+  ecosystem: PyPI
+details: An exploitable vulnerability exists in the YAML parsing functionality in
+  the YAMLParser method in Interfaces.py in PyAnyAPI before 0.6.1. A YAML parser can
+  execute arbitrary Python commands resulting in command execution because load is
+  used where safe_load should have been used. An attacker can insert Python into loaded
+  YAML to trigger this vulnerability.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 0.6.1
+references:
+- type: WEB
+  url: https://pypi.python.org/pypi/pyanyapi/0.6.1
+- type: WEB
+  url: https://github.com/Stranger6667/pyanyapi/releases/tag/0.6.1
+- type: WEB
+  url: https://github.com/Stranger6667/pyanyapi/issues/41
+- type: WEB
+  url: https://joel-malwarebenchmark.github.io/blog/2017/11/08/cve-2017-16616-yamlparser-in-pyanyapi/
+aliases:
+- CVE-2017-16616
+modified: "2019-10-03T00:03:00Z"
+published: "2017-11-08T03:29:00Z"

--- a/vulns/pyftpdlib/PYSEC-0000-CVE-2008-7262.yaml
+++ b/vulns/pyftpdlib/PYSEC-0000-CVE-2008-7262.yaml
@@ -1,0 +1,21 @@
+id: PYSEC-0000-CVE-2008-7262
+package:
+  name: pyftpdlib
+  ecosystem: PyPI
+details: Multiple directory traversal vulnerabilities in FTPServer.py in pyftpdlib
+  before 0.3.0 allow remote authenticated users to access arbitrary files and directories
+  via vectors involving a symlink in a pathname to a (1) CWD, (2) DELE, (3) STOR,
+  or (4) RETR command.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 0.3.0
+references:
+- type: WEB
+  url: http://code.google.com/p/pyftpdlib/issues/detail?id=55
+- type: WEB
+  url: http://code.google.com/p/pyftpdlib/source/browse/trunk/HISTORY
+aliases:
+- CVE-2008-7262
+modified: "2010-10-20T04:00:00Z"
+published: "2010-10-19T20:00:00Z"

--- a/vulns/pyftpdlib/PYSEC-0000-CVE-2008-7263.yaml
+++ b/vulns/pyftpdlib/PYSEC-0000-CVE-2008-7263.yaml
@@ -1,0 +1,24 @@
+id: PYSEC-0000-CVE-2008-7263
+package:
+  name: pyftpdlib
+  ecosystem: PyPI
+details: ftpserver.py in pyftpdlib before 0.5.0 does not delay its response after
+  receiving an invalid login attempt, which makes it easier for remote attackers to
+  obtain access via a brute-force attack.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 0.5.0
+references:
+- type: WEB
+  url: http://code.google.com/p/pyftpdlib/source/diff?spec=svn348&r=348&format=side&path=/trunk/pyftpdlib/ftpserver.py
+- type: WEB
+  url: http://code.google.com/p/pyftpdlib/issues/detail?id=73
+- type: WEB
+  url: http://code.google.com/p/pyftpdlib/source/detail?r=348
+- type: WEB
+  url: http://code.google.com/p/pyftpdlib/source/browse/trunk/HISTORY
+aliases:
+- CVE-2008-7263
+modified: "2010-10-20T04:00:00Z"
+published: "2010-10-19T20:00:00Z"

--- a/vulns/pyftpdlib/PYSEC-0000-CVE-2008-7264.yaml
+++ b/vulns/pyftpdlib/PYSEC-0000-CVE-2008-7264.yaml
@@ -1,0 +1,24 @@
+id: PYSEC-0000-CVE-2008-7264
+package:
+  name: pyftpdlib
+  ecosystem: PyPI
+details: The ftp_QUIT function in ftpserver.py in pyftpdlib before 0.5.0 allows remote
+  authenticated users to cause a denial of service (file descriptor exhaustion and
+  daemon outage) by sending a QUIT command during a disallowed data-transfer attempt.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 0.5.0
+references:
+- type: WEB
+  url: http://code.google.com/p/pyftpdlib/source/diff?spec=svn344&r=344&format=side&path=/trunk/pyftpdlib/ftpserver.py
+- type: WEB
+  url: http://code.google.com/p/pyftpdlib/issues/detail?id=71
+- type: WEB
+  url: http://code.google.com/p/pyftpdlib/source/browse/trunk/HISTORY
+- type: WEB
+  url: http://code.google.com/p/pyftpdlib/source/detail?r=344
+aliases:
+- CVE-2008-7264
+modified: "2010-10-20T04:00:00Z"
+published: "2010-10-19T20:00:00Z"

--- a/vulns/pyftpdlib/PYSEC-0000-CVE-2009-5010.yaml
+++ b/vulns/pyftpdlib/PYSEC-0000-CVE-2009-5010.yaml
@@ -1,0 +1,37 @@
+id: PYSEC-0000-CVE-2009-5010
+package:
+  name: pyftpdlib
+  ecosystem: PyPI
+details: Race condition in the FTPHandler class in ftpserver.py in pyftpdlib before
+  0.5.1 allows remote attackers to cause a denial of service (daemon outage) by establishing
+  and then immediately closing a TCP connection, leading to the accept function having
+  an unexpected return value of None, a different vulnerability than CVE-2010-3494.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 0.5.1
+references:
+- type: WEB
+  url: http://code.google.com/p/pyftpdlib/source/detail?r=439
+- type: WEB
+  url: https://bugs.launchpad.net/zodb/+bug/135108
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2010/09/24/3
+- type: WEB
+  url: http://code.google.com/p/pyftpdlib/issues/detail?id=91
+- type: WEB
+  url: http://code.google.com/p/pyftpdlib/source/diff?spec=svn439&r=439&format=side&path=/trunk/pyftpdlib/ftpserver.py
+- type: WEB
+  url: http://bugs.python.org/issue6706
+- type: WEB
+  url: http://code.google.com/p/pyftpdlib/source/browse/trunk/HISTORY
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2010/09/09/6
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2010/09/22/3
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2010/09/11/2
+aliases:
+- CVE-2009-5010
+modified: "2010-10-20T04:00:00Z"
+published: "2010-10-19T20:00:00Z"

--- a/vulns/pyftpdlib/PYSEC-0000-CVE-2009-5011.yaml
+++ b/vulns/pyftpdlib/PYSEC-0000-CVE-2009-5011.yaml
@@ -1,0 +1,25 @@
+id: PYSEC-0000-CVE-2009-5011
+package:
+  name: pyftpdlib
+  ecosystem: PyPI
+details: Race condition in the FTPHandler class in ftpserver.py in pyftpdlib before
+  0.5.2 allows remote attackers to cause a denial of service (daemon outage) by establishing
+  and then immediately closing a TCP connection, leading to the getpeername function
+  having an ENOTCONN error, a different vulnerability than CVE-2010-3494.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 0.5.2
+references:
+- type: WEB
+  url: http://code.google.com/p/pyftpdlib/issues/detail?id=100
+- type: WEB
+  url: http://code.google.com/p/pyftpdlib/source/browse/trunk/HISTORY
+- type: WEB
+  url: http://code.google.com/p/pyftpdlib/source/diff?spec=svn543&r=543&format=side&path=/trunk/pyftpdlib/ftpserver.py
+- type: WEB
+  url: http://code.google.com/p/pyftpdlib/source/detail?r=543
+aliases:
+- CVE-2009-5011
+modified: "2010-10-20T04:00:00Z"
+published: "2010-10-19T20:00:00Z"

--- a/vulns/pyftpdlib/PYSEC-0000-CVE-2009-5012.yaml
+++ b/vulns/pyftpdlib/PYSEC-0000-CVE-2009-5012.yaml
@@ -1,0 +1,24 @@
+id: PYSEC-0000-CVE-2009-5012
+package:
+  name: pyftpdlib
+  ecosystem: PyPI
+details: ftpserver.py in pyftpdlib before 0.5.2 does not require the l permission
+  for the MLST command, which allows remote authenticated users to bypass intended
+  access restrictions and list the root directory via an FTP session.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 0.5.2
+references:
+- type: WEB
+  url: http://code.google.com/p/pyftpdlib/source/diff?spec=svn596&r=596&format=side&path=/trunk/pyftpdlib/ftpserver.py
+- type: WEB
+  url: http://code.google.com/p/pyftpdlib/source/browse/trunk/HISTORY
+- type: WEB
+  url: http://code.google.com/p/pyftpdlib/source/detail?r=596
+- type: WEB
+  url: http://code.google.com/p/pyftpdlib/issues/detail?id=114
+aliases:
+- CVE-2009-5012
+modified: "2010-10-20T04:00:00Z"
+published: "2010-10-19T20:00:00Z"

--- a/vulns/pyftpdlib/PYSEC-0000-CVE-2009-5013.yaml
+++ b/vulns/pyftpdlib/PYSEC-0000-CVE-2009-5013.yaml
@@ -1,0 +1,24 @@
+id: PYSEC-0000-CVE-2009-5013
+package:
+  name: pyftpdlib
+  ecosystem: PyPI
+details: Memory leak in the on_dtp_close function in ftpserver.py in pyftpdlib before
+  0.5.2 allows remote authenticated users to cause a denial of service (memory consumption)
+  by sending a QUIT command during a data transfer.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 0.5.2
+references:
+- type: WEB
+  url: http://code.google.com/p/pyftpdlib/source/browse/trunk/HISTORY
+- type: WEB
+  url: http://code.google.com/p/pyftpdlib/source/diff?spec=svn615&r=615&format=side&path=/trunk/pyftpdlib/ftpserver.py
+- type: WEB
+  url: http://code.google.com/p/pyftpdlib/issues/detail?id=119
+- type: WEB
+  url: http://code.google.com/p/pyftpdlib/source/detail?r=615
+aliases:
+- CVE-2009-5013
+modified: "2010-10-20T04:00:00Z"
+published: "2010-10-19T20:00:00Z"

--- a/vulns/pyftpdlib/PYSEC-0000-CVE-2010-3494.yaml
+++ b/vulns/pyftpdlib/PYSEC-0000-CVE-2010-3494.yaml
@@ -1,0 +1,40 @@
+id: PYSEC-0000-CVE-2010-3494
+package:
+  name: pyftpdlib
+  ecosystem: PyPI
+details: Race condition in the FTPHandler class in ftpserver.py in pyftpdlib before
+  0.5.2 allows remote attackers to cause a denial of service (daemon outage) by establishing
+  and then immediately closing a TCP connection, leading to the accept function having
+  an unexpected value of None for the address, or an ECONNABORTED, EAGAIN, or EWOULDBLOCK
+  error, a related issue to CVE-2010-3492.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 0.5.2
+references:
+- type: WEB
+  url: http://code.google.com/p/pyftpdlib/source/diff?spec=svn556&r=556&format=side&path=/trunk/pyftpdlib/ftpserver.py
+- type: WEB
+  url: http://code.google.com/p/pyftpdlib/issues/detail?id=105
+- type: WEB
+  url: http://code.google.com/p/pyftpdlib/source/detail?r=556
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2010/09/24/3
+- type: WEB
+  url: https://bugs.launchpad.net/zodb/+bug/135108
+- type: WEB
+  url: http://bugs.python.org/issue6706
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2010/09/22/3
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2010/09/11/2
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2010/09/09/6
+- type: WEB
+  url: http://code.google.com/p/pyftpdlib/source/browse/trunk/HISTORY
+- type: WEB
+  url: http://code.google.com/p/pyftpdlib/issues/detail?id=104
+aliases:
+- CVE-2010-3494
+modified: "2010-10-20T04:00:00Z"
+published: "2010-10-19T20:00:00Z"

--- a/vulns/pyjwt/PYSEC-0000-CVE-2017-11424.yaml
+++ b/vulns/pyjwt/PYSEC-0000-CVE-2017-11424.yaml
@@ -1,0 +1,23 @@
+id: PYSEC-0000-CVE-2017-11424
+package:
+  name: pyjwt
+  ecosystem: PyPI
+details: In PyJWT 1.5.0 and below the `invalid_strings` check in `HMACAlgorithm.prepare_key`
+  does not account for all PEM encoded public keys. Specifically, the PKCS1 PEM encoded
+  format would be allowed because it is prefaced with the string `-----BEGIN RSA PUBLIC
+  KEY-----` which is not accounted for. This enables symmetric/asymmetric key confusion
+  attacks against users using the PKCS1 PEM encoded public keys, which would allow
+  an attacker to craft JWTs from scratch.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.5.1
+references:
+- type: WEB
+  url: https://github.com/jpadilla/pyjwt/pull/277
+- type: WEB
+  url: http://www.debian.org/security/2017/dsa-3979
+aliases:
+- CVE-2017-11424
+modified: "2019-10-03T00:03:00Z"
+published: "2017-08-24T16:29:00Z"

--- a/vulns/pyrad/PYSEC-0000-CVE-2013-0294.yaml
+++ b/vulns/pyrad/PYSEC-0000-CVE-2013-0294.yaml
@@ -1,0 +1,35 @@
+id: PYSEC-0000-CVE-2013-0294
+package:
+  name: pyrad
+  ecosystem: PyPI
+details: packet.py in pyrad before 2.1 uses weak random numbers to generate RADIUS
+  authenticators and hash passwords, which makes it easier for remote attackers to
+  obtain sensitive information via a brute force attack.
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/wichert/pyrad
+    fixed: 38f74b36814ca5b1a27d9898141126af4953bee5
+  - type: ECOSYSTEM
+    fixed: "2.1"
+references:
+- type: WEB
+  url: http://www.securityfocus.com/bid/57984
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2013/02/15/13
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2013-September/116567.html
+- type: WEB
+  url: https://bugzilla.redhat.com/show_bug.cgi?id=911682
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2013-September/115705.html
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2013-September/115677.html
+- type: WEB
+  url: https://github.com/wichert/pyrad/commit/38f74b36814ca5b1a27d9898141126af4953bee5
+- type: WEB
+  url: https://exchange.xforce.ibmcloud.com/vulnerabilities/82133
+aliases:
+- CVE-2013-0294
+modified: "2020-01-31T19:07:00Z"
+published: "2020-01-28T16:15:00Z"

--- a/vulns/pyrad/PYSEC-0000-CVE-2013-0342.yaml
+++ b/vulns/pyrad/PYSEC-0000-CVE-2013-0342.yaml
@@ -1,0 +1,33 @@
+id: PYSEC-0000-CVE-2013-0342
+package:
+  name: pyrad
+  ecosystem: PyPI
+details: The CreateID function in packet.py in pyrad before 2.1 uses sequential packet
+  IDs, which makes it easier for remote attackers to spoof packets by predicting the
+  next ID, a different vulnerability than CVE-2013-0294.
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/pyradius/pyrad
+    fixed: 38f74b36814ca5b1a27d9898141126af4953bee5
+  - type: ECOSYSTEM
+    fixed: "2.1"
+references:
+- type: WEB
+  url: https://exchange.xforce.ibmcloud.com/vulnerabilities/82134
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2013/02/21/27
+- type: WEB
+  url: http://www.securityfocus.com/bid/57984
+- type: WEB
+  url: https://github.com/pyradius/pyrad/commit/38f74b36814ca5b1a27d9898141126af4953bee5
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2013/02/15/9
+- type: WEB
+  url: https://bugzilla.redhat.com/show_bug.cgi?id=911685
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2013/02/22/2
+aliases:
+- CVE-2013-0342
+modified: "2019-12-11T02:40:00Z"
+published: "2019-12-09T21:15:00Z"

--- a/vulns/pysaml2/PYSEC-0000-CVE-2016-10149.yaml
+++ b/vulns/pysaml2/PYSEC-0000-CVE-2016-10149.yaml
@@ -1,0 +1,38 @@
+id: PYSEC-0000-CVE-2016-10149
+package:
+  name: pysaml2
+  ecosystem: PyPI
+details: XML External Entity (XXE) vulnerability in PySAML2 4.4.0 and earlier allows
+  remote attackers to read arbitrary files via a crafted SAML XML request or response.
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/rohe/pysaml2
+    fixed: 6e09a25d9b4b7aa7a506853210a9a14100b8bc9b
+  - type: ECOSYSTEM
+    fixed: 4.5.0
+references:
+- type: WEB
+  url: https://github.com/rohe/pysaml2/pull/379
+- type: WEB
+  url: https://github.com/rohe/pysaml2/issues/366
+- type: WEB
+  url: https://github.com/rohe/pysaml2/commit/6e09a25d9b4b7aa7a506853210a9a14100b8bc9b
+- type: WEB
+  url: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=850716
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2017/01/19/5
+- type: WEB
+  url: http://www.debian.org/security/2017/dsa-3759
+- type: WEB
+  url: http://www.securityfocus.com/bid/97692
+- type: WEB
+  url: https://access.redhat.com/errata/RHSA-2017:0938
+- type: WEB
+  url: https://access.redhat.com/errata/RHSA-2017:0937
+- type: WEB
+  url: https://access.redhat.com/errata/RHSA-2017:0936
+aliases:
+- CVE-2016-10149
+modified: "2018-01-05T02:30:00Z"
+published: "2017-03-24T14:59:00Z"

--- a/vulns/pysaml2/PYSEC-0000-CVE-2017-1000246.yaml
+++ b/vulns/pysaml2/PYSEC-0000-CVE-2017-1000246.yaml
@@ -1,0 +1,17 @@
+id: PYSEC-0000-CVE-2017-1000246
+package:
+  name: pysaml2
+  ecosystem: PyPI
+details: Python package pysaml2 version 4.4.0 and earlier reuses the initialization
+  vector across encryptions in the IDP server, resulting in weak encryption of data.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 4.6.0
+references:
+- type: WEB
+  url: https://github.com/rohe/pysaml2/issues/417
+aliases:
+- CVE-2017-1000246
+modified: "2019-10-03T00:03:00Z"
+published: "2017-11-17T04:29:00Z"

--- a/vulns/pysaml2/PYSEC-0000-CVE-2017-1000433.yaml
+++ b/vulns/pysaml2/PYSEC-0000-CVE-2017-1000433.yaml
@@ -1,0 +1,24 @@
+id: PYSEC-0000-CVE-2017-1000433
+package:
+  name: pysaml2
+  ecosystem: PyPI
+details: pysaml2 version 4.4.0 and older accept any password when run with python
+  optimizations enabled. This allows attackers to log in as any user without knowing
+  their password.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 4.5.0
+references:
+- type: WEB
+  url: https://github.com/rohe/pysaml2/issues/451
+- type: WEB
+  url: https://security.gentoo.org/glsa/201801-11
+- type: WEB
+  url: https://lists.debian.org/debian-lts-announce/2018/07/msg00000.html
+- type: WEB
+  url: https://lists.debian.org/debian-lts-announce/2021/02/msg00038.html
+aliases:
+- CVE-2017-1000433
+modified: "2021-03-04T21:16:00Z"
+published: "2018-01-02T23:29:00Z"

--- a/vulns/pyshop/PYSEC-0000-CVE-2013-1630.yaml
+++ b/vulns/pyshop/PYSEC-0000-CVE-2013-1630.yaml
@@ -1,0 +1,25 @@
+id: PYSEC-0000-CVE-2013-1630
+package:
+  name: pyshop
+  ecosystem: PyPI
+details: pyshop before 0.7.1 uses HTTP to retrieve packages from the PyPI repository,
+  and does not perform integrity checks on package contents, which allows man-in-the-middle
+  attackers to execute arbitrary code via a crafted response to a download operation.
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/mardiros/pyshop
+    fixed: ffadb0bcdef1e385884571670210cfd6ba351784
+  - type: ECOSYSTEM
+    fixed: 0.7.1
+references:
+- type: WEB
+  url: http://www.reddit.com/r/Python/comments/17rfh7/warning_dont_use_pip_in_an_untrusted_network_a/
+- type: WEB
+  url: https://github.com/mardiros/pyshop/blob/master/CHANGES.txt
+- type: WEB
+  url: https://github.com/mardiros/pyshop/commit/ffadb0bcdef1e385884571670210cfd6ba351784
+aliases:
+- CVE-2013-1630
+modified: "2013-10-07T19:56:00Z"
+published: "2013-08-06T02:52:00Z"

--- a/vulns/python-dbusmock/PYSEC-0000-CVE-2015-1326.yaml
+++ b/vulns/python-dbusmock/PYSEC-0000-CVE-2015-1326.yaml
@@ -1,0 +1,21 @@
+id: PYSEC-0000-CVE-2015-1326
+package:
+  name: python-dbusmock
+  ecosystem: PyPI
+details: python-dbusmock before version 0.15.1 AddTemplate() D-Bus method call or
+  DBusTestCase.spawn_server_template() method could be tricked into executing malicious
+  code if an attacker supplies a .pyc file.
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/martinpitt/python-dbusmock
+    fixed: 4e7d0df9093
+  - type: ECOSYSTEM
+    fixed: 0.15.1
+references:
+- type: WEB
+  url: https://github.com/martinpitt/python-dbusmock/commit/4e7d0df9093
+aliases:
+- CVE-2015-1326
+modified: "2019-10-09T23:13:00Z"
+published: "2019-04-22T16:29:00Z"

--- a/vulns/python-fedora/PYSEC-0000-CVE-2017-1002150.yaml
+++ b/vulns/python-fedora/PYSEC-0000-CVE-2017-1002150.yaml
@@ -1,0 +1,25 @@
+id: PYSEC-0000-CVE-2017-1002150
+package:
+  name: python-fedora
+  ecosystem: PyPI
+details: python-fedora 0.8.0 and lower is vulnerable to an open redirect resulting
+  in loss of CSRF protection
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/fedora-infra/python-fedora
+    fixed: b27f38a67573f4c989710c9bfb726dd4c1eeb929.patch
+  - type: GIT
+    repo: https://github.com/fedora-infra/python-fedora
+    fixed: b27f38a67573f4c989710c9bfb726dd4c1eeb929
+  - type: ECOSYSTEM
+    fixed: 0.9.0
+references:
+- type: WEB
+  url: https://github.com/fedora-infra/python-fedora/commit/b27f38a67573f4c989710c9bfb726dd4c1eeb929.patch
+- type: WEB
+  url: https://github.com/fedora-infra/python-fedora/commit/b27f38a67573f4c989710c9bfb726dd4c1eeb929
+aliases:
+- CVE-2017-1002150
+modified: "2019-10-09T23:21:00Z"
+published: "2017-09-14T13:29:00Z"

--- a/vulns/python-glanceclient/PYSEC-0000-CVE-2013-4111.yaml
+++ b/vulns/python-glanceclient/PYSEC-0000-CVE-2013-4111.yaml
@@ -1,0 +1,32 @@
+id: PYSEC-0000-CVE-2013-4111
+package:
+  name: python-glanceclient
+  ecosystem: PyPI
+details: The Python client library for Glance (python-glanceclient) before 0.10.0
+  does not properly check the preverify_ok value, which prevents the server hostname
+  from being verified with a domain name in the subject's Common Name (CN) or subjectAltName
+  field of the X.509 certificate and allows man-in-the-middle attackers to spoof SSL
+  servers via an arbitrary valid certificate.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 0.10.0
+references:
+- type: WEB
+  url: http://secunia.com/advisories/54525
+- type: WEB
+  url: https://github.com/openstack/python-glanceclient/blob/master/doc/source/index.rst
+- type: WEB
+  url: http://secunia.com/advisories/54313
+- type: WEB
+  url: https://bugs.launchpad.net/ossa/+bug/1192229
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-updates/2013-08/msg00019.html
+- type: WEB
+  url: http://rhn.redhat.com/errata/RHSA-2013-1200.html
+- type: WEB
+  url: http://www.ubuntu.com/usn/USN-2004-1
+aliases:
+- CVE-2013-4111
+modified: "2018-10-30T16:27:00Z"
+published: "2013-08-28T21:55:00Z"

--- a/vulns/python-jose/PYSEC-0000-CVE-2016-7036.yaml
+++ b/vulns/python-jose/PYSEC-0000-CVE-2016-7036.yaml
@@ -1,0 +1,21 @@
+id: PYSEC-0000-CVE-2016-7036
+package:
+  name: python-jose
+  ecosystem: PyPI
+details: python-jose before 1.3.2 allows attackers to have unspecified impact by leveraging
+  failure to use a constant time comparison for HMAC keys.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.3.2
+references:
+- type: WEB
+  url: https://github.com/mpdavis/python-jose/releases/tag/1.3.2
+- type: WEB
+  url: https://github.com/mpdavis/python-jose/pull/35/commits/89b46353b9f611e9da38de3d2fedf52331167b93
+- type: WEB
+  url: http://www.securityfocus.com/bid/95845
+aliases:
+- CVE-2016-7036
+modified: "2017-02-01T02:59:00Z"
+published: "2017-01-23T21:59:00Z"

--- a/vulns/python-swiftclient/PYSEC-0000-CVE-2013-6396.yaml
+++ b/vulns/python-swiftclient/PYSEC-0000-CVE-2013-6396.yaml
@@ -1,0 +1,21 @@
+id: PYSEC-0000-CVE-2013-6396
+package:
+  name: python-swiftclient
+  ecosystem: PyPI
+details: The OpenStack Python client library for Swift (python-swiftclient) 1.0 through
+  1.9.0 does not verify X.509 certificates from SSL servers, which allows man-in-the-middle
+  attackers to spoof servers and obtain sensitive information via a crafted certificate.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    introduced: "1.0"
+    fixed: "2.0"
+references:
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2014/02/17/7
+- type: WEB
+  url: https://bugs.launchpad.net/python-swiftclient/+bug/1199783
+aliases:
+- CVE-2013-6396
+modified: "2014-02-21T00:40:00Z"
+published: "2014-02-18T19:55:00Z"

--- a/vulns/pywebdav/PYSEC-0000-CVE-2011-0432.yaml
+++ b/vulns/pywebdav/PYSEC-0000-CVE-2011-0432.yaml
@@ -1,0 +1,45 @@
+id: PYSEC-0000-CVE-2011-0432
+package:
+  name: pywebdav
+  ecosystem: PyPI
+details: 'Multiple SQL injection vulnerabilities in the get_userinfo method in the
+  MySQLAuthHandler class in DAVServer/mysqlauth.py in PyWebDAV before 0.9.4.1 allow
+  remote attackers to execute arbitrary SQL commands via the (1) user or (2) pw argument.  NOTE:
+  some of these details are obtained from third party information.'
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 0.9.4.1
+references:
+- type: WEB
+  url: http://secunia.com/advisories/43571
+- type: WEB
+  url: http://secunia.com/advisories/43602
+- type: WEB
+  url: http://www.debian.org/security/2011/dsa-2177
+- type: WEB
+  url: https://bugzilla.redhat.com/show_bug.cgi?id=677718
+- type: WEB
+  url: http://www.vupen.com/english/advisories/2011/0553
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2011-March/055444.html
+- type: WEB
+  url: http://www.vupen.com/english/advisories/2011/0554
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2011-March/055412.html
+- type: WEB
+  url: http://code.google.com/p/pywebdav/updates/list
+- type: WEB
+  url: http://secunia.com/advisories/43703
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2011-March/055413.html
+- type: WEB
+  url: http://pywebdav.googlecode.com/files/PyWebDAV-0.9.4.1.tar.gz
+- type: WEB
+  url: http://www.vupen.com/english/advisories/2011/0634
+- type: WEB
+  url: http://www.securityfocus.com/bid/46655
+aliases:
+- CVE-2011-0432
+modified: "2011-03-15T04:00:00Z"
+published: "2011-03-14T19:55:00Z"

--- a/vulns/pyyaml/PYSEC-0000-CVE-2017-18342.yaml
+++ b/vulns/pyyaml/PYSEC-0000-CVE-2017-18342.yaml
@@ -1,0 +1,34 @@
+id: PYSEC-0000-CVE-2017-18342
+package:
+  name: pyyaml
+  ecosystem: PyPI
+details: In PyYAML before 5.1, the yaml.load() API could execute arbitrary code if
+  used with untrusted data. The load() function has been deprecated in version 5.1
+  and the 'UnsafeLoader' has been introduced for backward compatibility with the function.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: "5.1"
+references:
+- type: WEB
+  url: https://github.com/yaml/pyyaml/pull/74
+- type: WEB
+  url: https://github.com/yaml/pyyaml/blob/master/CHANGES
+- type: WEB
+  url: https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/M6JCFGEIEOFMWWIXGHSELMKQDD4CV2BA/
+- type: WEB
+  url: https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/KSQQMRUQSXBSUXLCRD3TSZYQ7SEZRKCE/
+- type: WEB
+  url: https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/JEX7IPV5P2QJITAMA5Z63GQCZA5I6NVZ/
+- type: WEB
+  url: https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation
+- type: WEB
+  url: https://github.com/marshmallow-code/apispec/issues/278
+- type: WEB
+  url: https://github.com/yaml/pyyaml/issues/193
+- type: WEB
+  url: https://security.gentoo.org/glsa/202003-45
+aliases:
+- CVE-2017-18342
+modified: "2020-10-14T13:23:00Z"
+published: "2018-06-27T12:29:00Z"

--- a/vulns/requests/PYSEC-0000-CVE-2014-1829.yaml
+++ b/vulns/requests/PYSEC-0000-CVE-2014-1829.yaml
@@ -1,0 +1,27 @@
+id: PYSEC-0000-CVE-2014-1829
+package:
+  name: requests
+  ecosystem: PyPI
+details: Requests (aka python-requests) before 2.3.0 allows remote servers to obtain
+  a netrc password by reading the Authorization header in a redirected request.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 2.3.0
+references:
+- type: WEB
+  url: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=733108
+- type: WEB
+  url: https://github.com/kennethreitz/requests/issues/1885
+- type: WEB
+  url: http://www.ubuntu.com/usn/USN-2382-1
+- type: WEB
+  url: http://www.debian.org/security/2015/dsa-3146
+- type: WEB
+  url: http://www.mandriva.com/security/advisories?name=MDVSA-2015:133
+- type: WEB
+  url: http://advisories.mageia.org/MGASA-2014-0409.html
+aliases:
+- CVE-2014-1829
+modified: "2016-08-30T17:11:00Z"
+published: "2014-10-15T14:55:00Z"

--- a/vulns/requests/PYSEC-0000-CVE-2014-1830.yaml
+++ b/vulns/requests/PYSEC-0000-CVE-2014-1830.yaml
@@ -1,0 +1,28 @@
+id: PYSEC-0000-CVE-2014-1830
+package:
+  name: requests
+  ecosystem: PyPI
+details: Requests (aka python-requests) before 2.3.0 allows remote servers to obtain
+  sensitive information by reading the Proxy-Authorization header in a redirected
+  request.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 2.3.0
+references:
+- type: WEB
+  url: https://github.com/kennethreitz/requests/issues/1885
+- type: WEB
+  url: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=733108
+- type: WEB
+  url: http://www.debian.org/security/2015/dsa-3146
+- type: WEB
+  url: http://www.mandriva.com/security/advisories?name=MDVSA-2015:133
+- type: WEB
+  url: http://advisories.mageia.org/MGASA-2014-0409.html
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-updates/2016-01/msg00095.html
+aliases:
+- CVE-2014-1830
+modified: "2018-10-30T16:27:00Z"
+published: "2014-10-15T14:55:00Z"

--- a/vulns/requests/PYSEC-0000-CVE-2015-2296.yaml
+++ b/vulns/requests/PYSEC-0000-CVE-2015-2296.yaml
@@ -1,0 +1,36 @@
+id: PYSEC-0000-CVE-2015-2296
+package:
+  name: requests
+  ecosystem: PyPI
+details: The resolve_redirects function in sessions.py in requests 2.1.0 through 2.5.3
+  allows remote attackers to conduct session fixation attacks via a cookie without
+  a host value in a redirect.
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/kennethreitz/requests
+    fixed: 3bd8afbff29e50b38f889b2f688785a669b9aafc
+  - type: ECOSYSTEM
+    introduced: 2.1.0
+    fixed: 2.6.0
+references:
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2015/03/15/1
+- type: WEB
+  url: http://www.ubuntu.com/usn/USN-2531-1
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2015/03/14/4
+- type: WEB
+  url: https://github.com/kennethreitz/requests/commit/3bd8afbff29e50b38f889b2f688785a669b9aafc
+- type: WEB
+  url: https://warehouse.python.org/project/requests/2.6.0/
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2015-March/153594.html
+- type: WEB
+  url: http://advisories.mageia.org/MGASA-2015-0120.html
+- type: WEB
+  url: http://www.mandriva.com/security/advisories?name=MDVSA-2015:133
+aliases:
+- CVE-2015-2296
+modified: "2021-03-18T13:19:00Z"
+published: "2015-03-18T16:59:00Z"

--- a/vulns/roundup/PYSEC-0000-CVE-2012-6130.yaml
+++ b/vulns/roundup/PYSEC-0000-CVE-2012-6130.yaml
@@ -1,0 +1,28 @@
+id: PYSEC-0000-CVE-2012-6130
+package:
+  name: roundup
+  ecosystem: PyPI
+details: Cross-site scripting (XSS) vulnerability in the history display in Roundup
+  before 1.4.20 allows remote attackers to inject arbitrary web script or HTML via
+  a username, related to generating a link.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.4.20
+references:
+- type: WEB
+  url: http://issues.roundup-tracker.org/issue2550684
+- type: WEB
+  url: https://pypi.python.org/pypi/roundup/1.4.20
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2012/11/10/2
+- type: WEB
+  url: https://bugzilla.redhat.com/show_bug.cgi?id=722672
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2013/02/13/8
+- type: WEB
+  url: https://exchange.xforce.ibmcloud.com/vulnerabilities/84189
+aliases:
+- CVE-2012-6130
+modified: "2017-08-29T01:32:00Z"
+published: "2014-04-11T15:55:00Z"

--- a/vulns/roundup/PYSEC-0000-CVE-2012-6131.yaml
+++ b/vulns/roundup/PYSEC-0000-CVE-2012-6131.yaml
@@ -1,0 +1,28 @@
+id: PYSEC-0000-CVE-2012-6131
+package:
+  name: roundup
+  ecosystem: PyPI
+details: Cross-site scripting (XSS) vulnerability in cgi/client.py in Roundup before
+  1.4.20 allows remote attackers to inject arbitrary web script or HTML via the @action
+  parameter to support/issue1.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.4.20
+references:
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2013/02/13/8
+- type: WEB
+  url: http://issues.roundup-tracker.org/issue2550711
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2012/11/10/2
+- type: WEB
+  url: https://pypi.python.org/pypi/roundup/1.4.20
+- type: WEB
+  url: https://bugzilla.redhat.com/show_bug.cgi?id=722672
+- type: WEB
+  url: https://exchange.xforce.ibmcloud.com/vulnerabilities/84190
+aliases:
+- CVE-2012-6131
+modified: "2017-08-29T01:32:00Z"
+published: "2014-04-11T15:55:00Z"

--- a/vulns/roundup/PYSEC-0000-CVE-2012-6133.yaml
+++ b/vulns/roundup/PYSEC-0000-CVE-2012-6133.yaml
@@ -1,0 +1,26 @@
+id: PYSEC-0000-CVE-2012-6133
+package:
+  name: roundup
+  ecosystem: PyPI
+details: Multiple cross-site scripting (XSS) vulnerabilities in Roundup before 1.4.20
+  allow remote attackers to inject arbitrary web script or HTML via the (1) @ok_message
+  or (2) @error_message parameter to issue*.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 1.4.20
+references:
+- type: WEB
+  url: https://pypi.python.org/pypi/roundup/1.4.20
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2013/02/13/8
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2012/11/10/2
+- type: WEB
+  url: https://bugzilla.redhat.com/show_bug.cgi?id=722672
+- type: WEB
+  url: http://issues.roundup-tracker.org/issue2550724
+aliases:
+- CVE-2012-6133
+modified: "2020-01-31T20:48:00Z"
+published: "2020-01-30T21:15:00Z"

--- a/vulns/rply/PYSEC-0000-CVE-2014-1604.yaml
+++ b/vulns/rply/PYSEC-0000-CVE-2014-1604.yaml
@@ -1,0 +1,33 @@
+id: PYSEC-0000-CVE-2014-1604
+package:
+  name: rply
+  ecosystem: PyPI
+details: The parser cache functionality in parsergenerator.py in RPLY (aka python-rply)
+  before 0.7.1 allows local users to spoof cache data by pre-creating a temporary
+  rply-*.json file with a predictable name.
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/alex/rply
+    fixed: fc9bbcd25b0b4f09bbd6339f710ad24c129d5d7c
+  - type: ECOSYSTEM
+    fixed: 0.7.1
+references:
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2014/01/17/8
+- type: WEB
+  url: http://www.osvdb.org/102202
+- type: WEB
+  url: https://github.com/alex/rply/commit/fc9bbcd25b0b4f09bbd6339f710ad24c129d5d7c
+- type: WEB
+  url: http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=735263
+- type: WEB
+  url: http://secunia.com/advisories/56429
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2014/01/18/4
+- type: WEB
+  url: https://exchange.xforce.ibmcloud.com/vulnerabilities/90593
+aliases:
+- CVE-2014-1604
+modified: "2017-08-29T01:34:00Z"
+published: "2014-01-28T00:55:00Z"

--- a/vulns/rsa/PYSEC-0000-CVE-2016-1494.yaml
+++ b/vulns/rsa/PYSEC-0000-CVE-2016-1494.yaml
@@ -1,0 +1,32 @@
+id: PYSEC-0000-CVE-2016-1494
+package:
+  name: rsa
+  ecosystem: PyPI
+details: The verify function in the RSA package for Python (Python-RSA) before 3.3
+  allows attackers to spoof signatures with a small public exponent via crafted signature
+  padding, aka a BERserk attack.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: "3.3"
+references:
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2016/01/05/3
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2016/01/05/1
+- type: WEB
+  url: https://blog.filippo.io/bleichenbacher-06-signature-forgery-in-python-rsa/
+- type: WEB
+  url: https://bitbucket.org/sybren/python-rsa/pull-requests/14/security-fix-bb06-attack-in-verify-by/diff
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2016-January/175897.html
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2016-January/175942.html
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-updates/2016-01/msg00032.html
+- type: WEB
+  url: http://www.securityfocus.com/bid/79829
+aliases:
+- CVE-2016-1494
+modified: "2019-05-31T17:27:00Z"
+published: "2016-01-13T15:59:00Z"

--- a/vulns/salt/PYSEC-0000-CVE-2013-4435.yaml
+++ b/vulns/salt/PYSEC-0000-CVE-2013-4435.yaml
@@ -1,0 +1,21 @@
+id: PYSEC-0000-CVE-2013-4435
+package:
+  name: salt
+  ecosystem: PyPI
+details: Salt (aka SaltStack) 0.15.0 through 0.17.0 allows remote authenticated users
+  who are using external authentication or client ACL to execute restricted routines
+  by embedding the routine in another routine.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    introduced: 0.15.0
+    fixed: 0.17.1
+references:
+- type: WEB
+  url: http://docs.saltstack.com/topics/releases/0.17.1.html
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2013/10/18/3
+aliases:
+- CVE-2013-4435
+modified: "2013-11-07T19:42:00Z"
+published: "2013-11-05T18:55:00Z"

--- a/vulns/salt/PYSEC-0000-CVE-2013-4438.yaml
+++ b/vulns/salt/PYSEC-0000-CVE-2013-4438.yaml
@@ -1,0 +1,21 @@
+id: PYSEC-0000-CVE-2013-4438
+package:
+  name: salt
+  ecosystem: PyPI
+details: 'Salt (aka SaltStack) before 0.17.1 allows remote attackers to execute arbitrary
+  YAML code via unspecified vectors.  NOTE: the vendor states that this might not
+  be a vulnerability because the YAML to be loaded has already been determined to
+  be safe.'
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 0.17.1
+references:
+- type: WEB
+  url: http://docs.saltstack.com/topics/releases/0.17.1.html
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2013/10/18/3
+aliases:
+- CVE-2013-4438
+modified: "2013-11-07T19:30:00Z"
+published: "2013-11-05T18:55:00Z"

--- a/vulns/salt/PYSEC-0000-CVE-2013-4439.yaml
+++ b/vulns/salt/PYSEC-0000-CVE-2013-4439.yaml
@@ -1,0 +1,23 @@
+id: PYSEC-0000-CVE-2013-4439
+package:
+  name: salt
+  ecosystem: PyPI
+details: Salt (aka SaltStack) before 0.15.0 through 0.17.0 allows remote authenticated
+  minions to impersonate arbitrary minions via a crafted minion with a valid key.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 0.15.0
+  - type: ECOSYSTEM
+    fixed: 0.17.1
+references:
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2013/10/18/3
+- type: WEB
+  url: http://docs.saltstack.com/topics/releases/0.17.1.html
+- type: WEB
+  url: https://github.com/saltstack/salt/pull/7356
+aliases:
+- CVE-2013-4439
+modified: "2013-11-07T01:29:00Z"
+published: "2013-11-05T18:55:00Z"

--- a/vulns/salt/PYSEC-0000-CVE-2013-6617.yaml
+++ b/vulns/salt/PYSEC-0000-CVE-2013-6617.yaml
@@ -1,0 +1,18 @@
+id: PYSEC-0000-CVE-2013-6617
+package:
+  name: salt
+  ecosystem: PyPI
+details: The salt master in Salt (aka SaltStack) 0.11.0 through 0.17.0 does not properly
+  drop group privileges, which makes it easier for remote attackers to gain privileges.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    introduced: 0.11.0
+    fixed: 0.17.1
+references:
+- type: WEB
+  url: http://docs.saltstack.com/topics/releases/0.17.1.html
+aliases:
+- CVE-2013-6617
+modified: "2013-11-06T14:36:00Z"
+published: "2013-11-05T18:55:00Z"

--- a/vulns/salt/PYSEC-0000-CVE-2014-3563.yaml
+++ b/vulns/salt/PYSEC-0000-CVE-2014-3563.yaml
@@ -1,0 +1,24 @@
+id: PYSEC-0000-CVE-2014-3563
+package:
+  name: salt
+  ecosystem: PyPI
+details: Multiple unspecified vulnerabilities in Salt (aka SaltStack) before 2014.1.10
+  allow local users to have an unspecified impact via vectors related to temporary
+  file creation in (1) seed.py, (2) salt-ssh, or (3) salt-cloud.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 2014.1.10
+references:
+- type: WEB
+  url: http://seclists.org/oss-sec/2014/q3/428
+- type: WEB
+  url: http://docs.saltstack.com/en/latest/topics/releases/2014.1.10.html
+- type: WEB
+  url: http://www.securityfocus.com/bid/69319
+- type: WEB
+  url: https://exchange.xforce.ibmcloud.com/vulnerabilities/95392
+aliases:
+- CVE-2014-3563
+modified: "2017-08-29T01:34:00Z"
+published: "2014-08-22T17:55:00Z"

--- a/vulns/salt/PYSEC-0000-CVE-2015-1838.yaml
+++ b/vulns/salt/PYSEC-0000-CVE-2015-1838.yaml
@@ -1,0 +1,26 @@
+id: PYSEC-0000-CVE-2015-1838
+package:
+  name: salt
+  ecosystem: PyPI
+details: modules/serverdensity_device.py in SaltStack before 2014.7.4 does not properly
+  handle files in /tmp.
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/saltstack/salt
+    fixed: e11298d7155e9982749483ca5538e46090caef9c
+  - type: ECOSYSTEM
+    fixed: 2014.7.4
+references:
+- type: WEB
+  url: https://github.com/saltstack/salt/commit/e11298d7155e9982749483ca5538e46090caef9c
+- type: WEB
+  url: https://docs.saltstack.com/en/latest/topics/releases/2014.7.4.html
+- type: WEB
+  url: https://bugzilla.redhat.com/show_bug.cgi?id=1212784
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2016-January/175568.html
+aliases:
+- CVE-2015-1838
+modified: "2017-04-19T19:35:00Z"
+published: "2017-04-13T14:59:00Z"

--- a/vulns/salt/PYSEC-0000-CVE-2015-1839.yaml
+++ b/vulns/salt/PYSEC-0000-CVE-2015-1839.yaml
@@ -1,0 +1,31 @@
+id: PYSEC-0000-CVE-2015-1839
+package:
+  name: salt
+  ecosystem: PyPI
+details: modules/chef.py in SaltStack before 2014.7.4 does not properly handle files
+  in /tmp.
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/saltstack/salt
+    fixed: b49d0d4b5ca5c6f31f03e2caf97cef1088eeed81
+  - type: GIT
+    repo: https://github.com/saltstack/salt
+    fixed: 22d2f7a1ec93300c34e8c42d14ec39d51e610b5c
+  - type: ECOSYSTEM
+    fixed: 2014.7.4
+references:
+- type: WEB
+  url: https://github.com/saltstack/salt/commit/b49d0d4b5ca5c6f31f03e2caf97cef1088eeed81
+- type: WEB
+  url: https://github.com/saltstack/salt/commit/22d2f7a1ec93300c34e8c42d14ec39d51e610b5c
+- type: WEB
+  url: https://docs.saltstack.com/en/latest/topics/releases/2014.7.4.html
+- type: WEB
+  url: https://bugzilla.redhat.com/show_bug.cgi?id=1212788
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2016-January/175568.html
+aliases:
+- CVE-2015-1839
+modified: "2017-04-19T19:36:00Z"
+published: "2017-04-13T14:59:00Z"

--- a/vulns/salt/PYSEC-0000-CVE-2015-4017.yaml
+++ b/vulns/salt/PYSEC-0000-CVE-2015-4017.yaml
@@ -1,0 +1,23 @@
+id: PYSEC-0000-CVE-2015-4017
+package:
+  name: salt
+  ecosystem: PyPI
+details: Salt before 2014.7.6 does not verify certificates when connecting via the
+  aliyun, proxmox, and splunk modules.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 2014.7.6
+references:
+- type: WEB
+  url: https://docs.saltstack.com/en/latest/topics/releases/2014.7.6.html
+- type: WEB
+  url: https://bugzilla.redhat.com/show_bug.cgi?id=1222960
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2015/05/19/2
+- type: WEB
+  url: https://groups.google.com/forum/#!topic/salt-users/8Kv1bytGD6c
+aliases:
+- CVE-2015-4017
+modified: "2018-08-13T21:47:00Z"
+published: "2017-08-25T18:29:00Z"

--- a/vulns/salt/PYSEC-0000-CVE-2015-8034.yaml
+++ b/vulns/salt/PYSEC-0000-CVE-2015-8034.yaml
@@ -1,0 +1,20 @@
+id: PYSEC-0000-CVE-2015-8034
+package:
+  name: salt
+  ecosystem: PyPI
+details: The state.sls function in Salt before 2015.8.3 uses weak permissions on the
+  cache data, which allows local users to obtain sensitive information by reading
+  the file.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 2015.8.3
+references:
+- type: WEB
+  url: https://docs.saltstack.com/en/latest/topics/releases/2015.8.3.html
+- type: WEB
+  url: http://www.securityfocus.com/bid/96390
+aliases:
+- CVE-2015-8034
+modified: "2017-03-02T02:59:00Z"
+published: "2017-01-30T22:59:00Z"

--- a/vulns/salt/PYSEC-0000-CVE-2016-3176.yaml
+++ b/vulns/salt/PYSEC-0000-CVE-2016-3176.yaml
@@ -1,0 +1,23 @@
+id: PYSEC-0000-CVE-2016-3176
+package:
+  name: salt
+  ecosystem: PyPI
+details: Salt before 2015.5.10 and 2015.8.x before 2015.8.8, when PAM external authentication
+  is enabled, allows attackers to bypass the configured authentication service by
+  passing an alternate service with a command sent to LocalClient.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 2015.5.10
+  - type: ECOSYSTEM
+    introduced: '2015.8'
+    fixed: 2015.8.8
+references:
+- type: WEB
+  url: https://docs.saltstack.com/en/latest/topics/releases/2015.8.8.html
+- type: WEB
+  url: https://docs.saltstack.com/en/latest/topics/releases/2015.5.10.html
+aliases:
+- CVE-2016-3176
+modified: "2017-02-07T18:41:00Z"
+published: "2017-01-31T19:59:00Z"

--- a/vulns/salt/PYSEC-0000-CVE-2016-9639.yaml
+++ b/vulns/salt/PYSEC-0000-CVE-2016-9639.yaml
@@ -1,0 +1,23 @@
+id: PYSEC-0000-CVE-2016-9639
+package:
+  name: salt
+  ecosystem: PyPI
+details: Salt before 2015.8.11 allows deleted minions to read or write to minions
+  with the same id, related to caching.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 2015.8.11
+references:
+- type: WEB
+  url: https://docs.saltstack.com/en/2015.8/ref/configuration/master.html#rotate-aes-key
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2016/11/25/3
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2016/11/25/2
+- type: WEB
+  url: http://www.securityfocus.com/bid/94553
+aliases:
+- CVE-2016-9639
+modified: "2017-02-09T22:08:00Z"
+published: "2017-02-07T17:59:00Z"

--- a/vulns/salt/PYSEC-0000-CVE-2017-12791.yaml
+++ b/vulns/salt/PYSEC-0000-CVE-2017-12791.yaml
@@ -1,0 +1,31 @@
+id: PYSEC-0000-CVE-2017-12791
+package:
+  name: salt
+  ecosystem: PyPI
+details: Directory traversal vulnerability in minion id validation in SaltStack Salt
+  before 2016.11.7 and 2017.7.x before 2017.7.1 allows remote minions with incorrect
+  credentials to authenticate to a master via a crafted minion ID.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 2016.11.7
+  - type: ECOSYSTEM
+    introduced: '2017.7'
+    fixed: 2016.7.1
+references:
+- type: WEB
+  url: https://github.com/saltstack/salt/pull/42944
+- type: WEB
+  url: https://docs.saltstack.com/en/latest/topics/releases/2017.7.1.html
+- type: WEB
+  url: https://docs.saltstack.com/en/2016.11/topics/releases/2016.11.7.html
+- type: WEB
+  url: https://bugzilla.redhat.com/show_bug.cgi?id=1482006
+- type: WEB
+  url: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=872399
+- type: WEB
+  url: http://www.securityfocus.com/bid/100384
+aliases:
+- CVE-2017-12791
+modified: "2017-08-29T16:43:00Z"
+published: "2017-08-23T14:29:00Z"

--- a/vulns/salt/PYSEC-0000-CVE-2017-14695.yaml
+++ b/vulns/salt/PYSEC-0000-CVE-2017-14695.yaml
@@ -1,0 +1,40 @@
+id: PYSEC-0000-CVE-2017-14695
+package:
+  name: salt
+  ecosystem: PyPI
+details: 'Directory traversal vulnerability in minion id validation in SaltStack Salt
+  before 2016.3.8, 2016.11.x before 2016.11.8, and 2017.7.x before 2017.7.2 allows
+  remote minions with incorrect credentials to authenticate to a master via a crafted
+  minion ID.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2017-12791.'
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/saltstack/salt
+    fixed: 80d90307b07b3703428ecbb7c8bb468e28a9ae6d
+  - type: ECOSYSTEM
+    fixed: 2016.3.8
+  - type: ECOSYSTEM
+    introduced: '2016.11'
+    fixed: 2016.11.8
+  - type: ECOSYSTEM
+    introduced: '2017.7'
+    fixed: 2017.7.2
+references:
+- type: WEB
+  url: https://github.com/saltstack/salt/commit/80d90307b07b3703428ecbb7c8bb468e28a9ae6d
+- type: WEB
+  url: https://docs.saltstack.com/en/latest/topics/releases/2017.7.2.html
+- type: WEB
+  url: https://docs.saltstack.com/en/latest/topics/releases/2016.3.8.html
+- type: WEB
+  url: https://docs.saltstack.com/en/latest/topics/releases/2016.11.8.html
+- type: WEB
+  url: https://bugzilla.redhat.com/show_bug.cgi?id=1500748
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-updates/2017-10/msg00075.html
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-updates/2017-10/msg00073.html
+aliases:
+- CVE-2017-14695
+modified: "2017-11-14T21:49:00Z"
+published: "2017-10-24T17:29:00Z"

--- a/vulns/salt/PYSEC-0000-CVE-2017-14696.yaml
+++ b/vulns/salt/PYSEC-0000-CVE-2017-14696.yaml
@@ -1,0 +1,39 @@
+id: PYSEC-0000-CVE-2017-14696
+package:
+  name: salt
+  ecosystem: PyPI
+details: SaltStack Salt before 2016.3.8, 2016.11.x before 2016.11.8, and 2017.7.x
+  before 2017.7.2 allows remote attackers to cause a denial of service via a crafted
+  authentication request.
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/saltstack/salt
+    fixed: 5f8b5e1a0f23fe0f2be5b3c3e04199b57a53db5b
+  - type: ECOSYSTEM
+    fixed: 2016.3.8
+  - type: ECOSYSTEM
+    introduced: '2016.11'
+    fixed: 2016.11.8
+  - type: ECOSYSTEM
+    introduced: '2017.7'
+    fixed: 2017.7.2
+references:
+- type: WEB
+  url: https://github.com/saltstack/salt/commit/5f8b5e1a0f23fe0f2be5b3c3e04199b57a53db5b
+- type: WEB
+  url: https://docs.saltstack.com/en/latest/topics/releases/2017.7.2.html
+- type: WEB
+  url: https://docs.saltstack.com/en/latest/topics/releases/2016.3.8.html
+- type: WEB
+  url: https://docs.saltstack.com/en/latest/topics/releases/2016.11.8.html
+- type: WEB
+  url: https://bugzilla.redhat.com/show_bug.cgi?id=1500742
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-updates/2017-10/msg00075.html
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-updates/2017-10/msg00073.html
+aliases:
+- CVE-2017-14696
+modified: "2017-11-15T15:38:00Z"
+published: "2017-10-24T17:29:00Z"

--- a/vulns/salt/PYSEC-0000-CVE-2017-5192.yaml
+++ b/vulns/salt/PYSEC-0000-CVE-2017-5192.yaml
@@ -1,0 +1,28 @@
+id: PYSEC-0000-CVE-2017-5192
+package:
+  name: salt
+  ecosystem: PyPI
+details: When using the local_batch client from salt-api in SaltStack Salt before
+  2015.8.13, 2016.3.x before 2016.3.5, and 2016.11.x before 2016.11.2, external authentication
+  is not respected, enabling all authentication to be bypassed.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 2015.8.13
+  - type: ECOSYSTEM
+    introduced: '2016.3'
+    fixed: 2016.3.5
+  - type: ECOSYSTEM
+    introduced: '2016.11'
+    fixed: 2016.11.2
+references:
+- type: WEB
+  url: https://docs.saltstack.com/en/latest/topics/releases/2016.11.2.html
+- type: WEB
+  url: https://docs.saltstack.com/en/2016.3/topics/releases/2016.3.5.html
+- type: WEB
+  url: https://docs.saltstack.com/en/2016.3/topics/releases/2015.8.13.html
+aliases:
+- CVE-2017-5192
+modified: "2017-10-06T18:46:00Z"
+published: "2017-09-26T14:29:00Z"

--- a/vulns/salt/PYSEC-0000-CVE-2017-5200.yaml
+++ b/vulns/salt/PYSEC-0000-CVE-2017-5200.yaml
@@ -1,0 +1,28 @@
+id: PYSEC-0000-CVE-2017-5200
+package:
+  name: salt
+  ecosystem: PyPI
+details: Salt-api in SaltStack Salt before 2015.8.13, 2016.3.x before 2016.3.5, and
+  2016.11.x before 2016.11.2 allows arbitrary command execution on a salt-master via
+  Salt's ssh_client.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 2015.8.13
+  - type: ECOSYSTEM
+    introduced: '2016.3'
+    fixed: 2016.3.5
+  - type: ECOSYSTEM
+    introduced: '2016.11'
+    fixed: 2016.11.2
+references:
+- type: WEB
+  url: https://docs.saltstack.com/en/latest/topics/releases/2016.11.2.html
+- type: WEB
+  url: https://docs.saltstack.com/en/2016.3/topics/releases/2016.3.5.html
+- type: WEB
+  url: https://docs.saltstack.com/en/2016.3/topics/releases/2015.8.13.html
+aliases:
+- CVE-2017-5200
+modified: "2019-10-03T00:03:00Z"
+published: "2017-09-26T14:29:00Z"

--- a/vulns/salt/PYSEC-0000-CVE-2017-7893.yaml
+++ b/vulns/salt/PYSEC-0000-CVE-2017-7893.yaml
@@ -1,0 +1,17 @@
+id: PYSEC-0000-CVE-2017-7893
+package:
+  name: salt
+  ecosystem: PyPI
+details: In SaltStack Salt before 2016.3.6, compromised salt-minions can impersonate
+  the salt-master.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 2016.3.6
+references:
+- type: WEB
+  url: https://docs.saltstack.com/en/2017.7/topics/releases/2016.3.6.html
+aliases:
+- CVE-2017-7893
+modified: "2019-10-03T00:03:00Z"
+published: "2018-04-23T22:29:00Z"

--- a/vulns/sanic/PYSEC-0000-CVE-2017-16762.yaml
+++ b/vulns/sanic/PYSEC-0000-CVE-2017-16762.yaml
@@ -1,0 +1,19 @@
+id: PYSEC-0000-CVE-2017-16762
+package:
+  name: sanic
+  ecosystem: PyPI
+details: Sanic before 0.5.1 allows reading arbitrary files with directory traversal,
+  as demonstrated by the /static/..%2f substring.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 0.5.1
+references:
+- type: WEB
+  url: https://github.com/channelcat/sanic/releases/tag/0.5.1
+- type: WEB
+  url: https://github.com/channelcat/sanic/issues/633
+aliases:
+- CVE-2017-16762
+modified: "2017-11-30T15:15:00Z"
+published: "2017-11-10T09:29:00Z"

--- a/vulns/scipy/PYSEC-0000-CVE-2013-4251.yaml
+++ b/vulns/scipy/PYSEC-0000-CVE-2013-4251.yaml
@@ -1,0 +1,38 @@
+id: PYSEC-0000-CVE-2013-4251
+package:
+  name: scipy
+  ecosystem: PyPI
+details: The scipy.weave component in SciPy before 0.12.1 creates insecure temporary
+  directories.
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/scipy/scipy
+    fixed: bd296e0336420b840fcd2faabb97084fd252a973
+  - type: ECOSYSTEM
+    fixed: 0.12.1
+references:
+- type: WEB
+  url: https://security-tracker.debian.org/tracker/CVE-2013-4251
+- type: WEB
+  url: https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2013-4251
+- type: WEB
+  url: https://access.redhat.com/security/cve/cve-2013-4251
+- type: WEB
+  url: https://bugzilla.suse.com/show_bug.cgi?id=CVE-2013-4251
+- type: WEB
+  url: https://exchange.xforce.ibmcloud.com/vulnerabilities/88052
+- type: WEB
+  url: https://github.com/scipy/scipy/commit/bd296e0336420b840fcd2faabb97084fd252a973
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2013-October/119759.html
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2013-October/119771.html
+- type: WEB
+  url: http://www.securityfocus.com/bid/63008
+- type: WEB
+  url: http://lists.fedoraproject.org/pipermail/package-announce/2013-November/120696.html
+aliases:
+- CVE-2013-4251
+modified: "2019-11-08T18:51:00Z"
+published: "2019-11-04T20:15:00Z"

--- a/vulns/supervisor/PYSEC-0000-CVE-2017-11610.yaml
+++ b/vulns/supervisor/PYSEC-0000-CVE-2017-11610.yaml
@@ -1,0 +1,50 @@
+id: PYSEC-0000-CVE-2017-11610
+package:
+  name: supervisor
+  ecosystem: PyPI
+details: The XML-RPC server in supervisor before 3.0.1, 3.1.x before 3.1.4, 3.2.x
+  before 3.2.4, and 3.3.x before 3.3.3 allows remote authenticated users to execute
+  arbitrary commands via a crafted XML-RPC request, related to nested supervisord
+  namespace lookups.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 3.0.1
+  - type: ECOSYSTEM
+    introduced: '3.1'
+    fixed: 3.1.4
+  - type: ECOSYSTEM
+    introduced: '3.2'
+    fixed: 3.2.4
+  - type: ECOSYSTEM
+    introduced: '3.3'
+    fixed: 3.3.3
+references:
+- type: WEB
+  url: https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/JXGWOJNSWWK2TTWQJZJUP66FLFIWDMBQ/
+- type: WEB
+  url: https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/DTPDZV4ZRICDYAYZVUHSYZAYDLRMG2IM/
+- type: WEB
+  url: https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/4GMSCGMM477N64Z3BM34RWYBGSLK466B/
+- type: WEB
+  url: https://github.com/Supervisor/supervisor/issues/964
+- type: WEB
+  url: https://github.com/Supervisor/supervisor/blob/3.3.3/CHANGES.txt
+- type: WEB
+  url: https://github.com/Supervisor/supervisor/blob/3.2.4/CHANGES.txt
+- type: WEB
+  url: https://github.com/Supervisor/supervisor/blob/3.1.4/CHANGES.txt
+- type: WEB
+  url: https://github.com/Supervisor/supervisor/blob/3.0.1/CHANGES.txt
+- type: WEB
+  url: http://www.debian.org/security/2017/dsa-3942
+- type: WEB
+  url: https://security.gentoo.org/glsa/201709-06
+- type: WEB
+  url: https://www.exploit-db.com/exploits/42779/
+- type: WEB
+  url: https://access.redhat.com/errata/RHSA-2017:3005
+aliases:
+- CVE-2017-11610
+modified: "2019-10-03T00:03:00Z"
+published: "2017-08-23T14:29:00Z"

--- a/vulns/tornado/PYSEC-0000-CVE-2012-2374.yaml
+++ b/vulns/tornado/PYSEC-0000-CVE-2012-2374.yaml
@@ -1,0 +1,26 @@
+id: PYSEC-0000-CVE-2012-2374
+package:
+  name: tornado
+  ecosystem: PyPI
+details: CRLF injection vulnerability in the tornado.web.RequestHandler.set_header
+  function in Tornado before 2.2.1 allows remote attackers to inject arbitrary HTTP
+  headers and conduct HTTP response splitting attacks via crafted input.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 2.2.1
+references:
+- type: WEB
+  url: http://www.tornadoweb.org/documentation/releases/v2.2.1.html
+- type: WEB
+  url: http://openwall.com/lists/oss-security/2012/05/18/12
+- type: WEB
+  url: http://secunia.com/advisories/49185
+- type: WEB
+  url: http://www.securityfocus.com/bid/53612
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2012/05/18/6
+aliases:
+- CVE-2012-2374
+modified: "2012-09-05T03:23:00Z"
+published: "2012-05-23T20:55:00Z"

--- a/vulns/tornado/PYSEC-0000-CVE-2014-9720.yaml
+++ b/vulns/tornado/PYSEC-0000-CVE-2014-9720.yaml
@@ -1,0 +1,29 @@
+id: PYSEC-0000-CVE-2014-9720
+package:
+  name: tornado
+  ecosystem: PyPI
+details: Tornado before 3.2.2 sends arbitrary responses that contain a fixed CSRF
+  token and may be sent with HTTP compression, which makes it easier for remote attackers
+  to conduct a BREACH attack and determine this token via a series of crafted requests.
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/tornadoweb/tornado
+    fixed: 1c36307463b1e8affae100bf9386948e6c1b2308
+  - type: ECOSYSTEM
+    fixed: 3.2.2
+references:
+- type: WEB
+  url: https://github.com/tornadoweb/tornado/commit/1c36307463b1e8affae100bf9386948e6c1b2308
+- type: WEB
+  url: https://bugzilla.novell.com/show_bug.cgi?id=930362
+- type: WEB
+  url: http://openwall.com/lists/oss-security/2015/05/19/4
+- type: WEB
+  url: https://bugzilla.redhat.com/show_bug.cgi?id=1222816
+- type: WEB
+  url: http://www.tornadoweb.org/en/stable/releases/v3.2.2.html
+aliases:
+- CVE-2014-9720
+modified: "2020-01-28T16:42:00Z"
+published: "2020-01-24T18:15:00Z"

--- a/vulns/trytond/PYSEC-0000-CVE-2012-0215.yaml
+++ b/vulns/trytond/PYSEC-0000-CVE-2012-0215.yaml
@@ -1,0 +1,25 @@
+id: PYSEC-0000-CVE-2012-0215
+package:
+  name: trytond
+  ecosystem: PyPI
+details: model/modelstorage.py in the Tryton application framework (trytond) before
+  2.4.0 for Python does not properly restrict access to the Many2Many field in the
+  relation model, which allows remote authenticated users to modify the privileges
+  of arbitrary users via a (1) create, (2) write, (3) delete, or (4) copy rpc call.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 2.2.4
+references:
+- type: WEB
+  url: http://www.debian.org/security/2012/dsa-2444
+- type: WEB
+  url: http://news.tryton.org/2012/03/security-releases-for-all-supported.html
+- type: WEB
+  url: https://bugs.tryton.org/issue2476
+- type: WEB
+  url: http://hg.tryton.org/trytond/rev/8e64d52ecea4
+aliases:
+- CVE-2012-0215
+modified: "2012-08-09T04:00:00Z"
+published: "2012-07-12T20:55:00Z"

--- a/vulns/trytond/PYSEC-0000-CVE-2015-0861.yaml
+++ b/vulns/trytond/PYSEC-0000-CVE-2015-0861.yaml
@@ -1,0 +1,33 @@
+id: PYSEC-0000-CVE-2015-0861
+package:
+  name: trytond
+  ecosystem: PyPI
+details: model/modelstorage.py in trytond 3.2.x before 3.2.10, 3.4.x before 3.4.8,
+  3.6.x before 3.6.5, and 3.8.x before 3.8.1 allows remote authenticated users to
+  bypass intended access restrictions and write to arbitrary fields via a sequence
+  of records.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    introduced: 3.2.0
+    fixed: 3.2.10
+  - type: ECOSYSTEM
+    introduced: 3.4.0
+    fixed: 3.4.8
+  - type: ECOSYSTEM
+    introduced: 3.6.0
+    fixed: 3.6.5
+  - type: ECOSYSTEM
+    introduced: 3.8.0
+    fixed: 3.8.1
+references:
+- type: WEB
+  url: http://www.debian.org/security/2015/dsa-3425
+- type: WEB
+  url: https://bugs.tryton.org/issue5167
+- type: WEB
+  url: http://www.tryton.org/posts/security-release-for-issue5167.html
+aliases:
+- CVE-2015-0861
+modified: "2019-02-01T16:42:00Z"
+published: "2016-04-13T15:59:00Z"

--- a/vulns/trytond/PYSEC-0000-CVE-2016-1241.yaml
+++ b/vulns/trytond/PYSEC-0000-CVE-2016-1241.yaml
@@ -1,0 +1,34 @@
+id: PYSEC-0000-CVE-2016-1241
+package:
+  name: tryton
+  ecosystem: PyPI
+details: Tryton 3.x before 3.2.17, 3.4.x before 3.4.14, 3.6.x before 3.6.12, 3.8.x
+  before 3.8.8, and 4.x before 4.0.4 allow remote authenticated users to discover
+  user password hashes via unspecified vectors.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 3.2.17
+  - type: ECOSYSTEM
+    introduced: '3.4'
+    fixed: 3.4.14
+  - type: ECOSYSTEM
+    introduced: '3.6'
+    fixed: 3.6.12
+  - type: ECOSYSTEM
+    introduced: '3.8'
+    fixed: 3.8.8
+  - type: ECOSYSTEM
+    introduced: '4.0'
+    fixed: 4.0.4
+references:
+- type: WEB
+  url: https://bugs.tryton.org/issue5795
+- type: WEB
+  url: http://www.debian.org/security/2016/dsa-3656
+- type: WEB
+  url: http://www.tryton.org/posts/security-release-for-issue5795-and-issue5808.html
+aliases:
+- CVE-2016-1241
+modified: "2016-09-08T19:06:00Z"
+published: "2016-09-07T19:28:00Z"

--- a/vulns/trytond/PYSEC-0000-CVE-2016-1242.yaml
+++ b/vulns/trytond/PYSEC-0000-CVE-2016-1242.yaml
@@ -1,0 +1,35 @@
+id: PYSEC-0000-CVE-2016-1242
+package:
+  name: tryton
+  ecosystem: PyPI
+details: file_open in Tryton before 3.2.17, 3.4.x before 3.4.14, 3.6.x before 3.6.12,
+  3.8.x before 3.8.8, and 4.x before 4.0.4 allows remote authenticated users with
+  certain permissions to read arbitrary files via the name parameter or unspecified
+  other vectors.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 3.2.17
+  - type: ECOSYSTEM
+    introduced: '3.4'
+    fixed: 3.4.14
+  - type: ECOSYSTEM
+    introduced: '3.6'
+    fixed: 3.6.12
+  - type: ECOSYSTEM
+    introduced: '3.8'
+    fixed: 3.8.8
+  - type: ECOSYSTEM
+    introduced: '4.0'
+    fixed: 4.0.4
+references:
+- type: WEB
+  url: https://bugs.tryton.org/issue5808
+- type: WEB
+  url: http://www.debian.org/security/2016/dsa-3656
+- type: WEB
+  url: http://www.tryton.org/posts/security-release-for-issue5795-and-issue5808.html
+aliases:
+- CVE-2016-1242
+modified: "2017-01-13T02:59:00Z"
+published: "2016-09-07T19:28:00Z"

--- a/vulns/twisted/PYSEC-0000-CVE-2016-1000111.yaml
+++ b/vulns/twisted/PYSEC-0000-CVE-2016-1000111.yaml
@@ -1,0 +1,26 @@
+id: PYSEC-0000-CVE-2016-1000111
+package:
+  name: twisted
+  ecosystem: PyPI
+details: Twisted before 16.3.1 does not attempt to address RFC 3875 section 4.1.18
+  namespace conflicts and therefore does not protect CGI applications from the presence
+  of untrusted client data in the HTTP_PROXY environment variable, which might allow
+  remote attackers to redirect a CGI application's outbound HTTP traffic to an arbitrary
+  proxy server via a crafted Proxy header in an HTTP request, aka an "httpoxy" issue.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 16.3.1
+references:
+- type: WEB
+  url: http://www.oracle.com/technetwork/topics/security/linuxbulletinoct2016-3090545.html
+- type: WEB
+  url: https://www.openwall.com/lists/oss-security/2016/07/18/6
+- type: WEB
+  url: https://twistedmatrix.com/trac/ticket/8623
+- type: WEB
+  url: https://twistedmatrix.com/pipermail/twisted-web/2016-August/005268.html
+aliases:
+- CVE-2016-1000111
+modified: "2020-03-13T20:04:00Z"
+published: "2020-03-11T20:15:00Z"

--- a/vulns/weblate/PYSEC-0000-CVE-2017-5537.yaml
+++ b/vulns/weblate/PYSEC-0000-CVE-2017-5537.yaml
@@ -1,0 +1,31 @@
+id: PYSEC-0000-CVE-2017-5537
+package:
+  name: weblate
+  ecosystem: PyPI
+details: The password reset form in Weblate before 2.10.1 provides different error
+  messages depending on whether the email address is associated with an account, which
+  allows remote attackers to enumerate user accounts via a series of requests.
+affects:
+  ranges:
+  - type: GIT
+    repo: https://github.com/WeblateOrg/weblate
+    fixed: abe0d2a29a1d8e896bfe829c8461bf8b391f1079
+  - type: ECOSYSTEM
+    fixed: 2.10.1
+references:
+- type: WEB
+  url: https://github.com/WeblateOrg/weblate/issues/1317
+- type: WEB
+  url: https://github.com/WeblateOrg/weblate/commit/abe0d2a29a1d8e896bfe829c8461bf8b391f1079
+- type: WEB
+  url: https://github.com/WeblateOrg/weblate/blob/weblate-2.10.1/docs/changes.rst
+- type: WEB
+  url: http://www.securityfocus.com/bid/95676
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2017/01/20/1
+- type: WEB
+  url: http://www.openwall.com/lists/oss-security/2017/01/18/11
+aliases:
+- CVE-2017-5537
+modified: "2017-03-21T18:56:00Z"
+published: "2017-03-15T15:59:00Z"

--- a/vulns/werkzeug/PYSEC-0000-CVE-2016-10516.yaml
+++ b/vulns/werkzeug/PYSEC-0000-CVE-2016-10516.yaml
@@ -1,0 +1,23 @@
+id: PYSEC-0000-CVE-2016-10516
+package:
+  name: werkzeug
+  ecosystem: PyPI
+details: Cross-site scripting (XSS) vulnerability in the render_full function in debug/tbtools.py
+  in the debugger in Pallets Werkzeug before 0.11.11 (as used in Pallets Flask and
+  other products) allows remote attackers to inject arbitrary web script or HTML via
+  a field that contains an exception message.
+affects:
+  ranges:
+  - type: ECOSYSTEM
+    fixed: 0.11.11
+references:
+- type: WEB
+  url: https://github.com/pallets/werkzeug/pull/1001
+- type: WEB
+  url: http://blog.neargle.com/2016/09/21/flask-src-review-get-a-xss-from-debuger/
+- type: WEB
+  url: https://lists.debian.org/debian-lts-announce/2017/11/msg00037.html
+aliases:
+- CVE-2016-10516
+modified: "2018-02-04T02:29:00Z"
+published: "2017-10-23T16:29:00Z"


### PR DESCRIPTION
All of these were discovered using the standard triage tool with the `-without_notes` option.  I'm slowly working my way through all of them, but wanted to go ahead and get what I have so far merged.  Once I've made it through all of them, I'll run again without the `-without_notes` option and work my way through those.