### PR TITLE
use modified cve feed for auto-import

### DIFF
--- a/.github/workflows/auto_import.yaml
+++ b/.github/workflows/auto_import.yaml
@@ -17,12 +17,12 @@ jobs:
         wget http://pypa-advisory-db.storage.googleapis.com/triage/pypi_links.json
         wget http://pypa-advisory-db.storage.googleapis.com/triage/pypi_versions.json
     - run: |
-        wget https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-recent.json.zip
-        unzip nvdcve-1.1-recent.json.zip
+        wget https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-modified.json.zip
+        unzip nvdcve-1.1-modified.json.zip
     - run: |
         go get -u github.com/google/osv/vulnfeeds/cmd/pypi
         pypi -false_positives triage/false_positives.yaml \
-            -nvd_json nvdcve-1.1-recent.json \
+            -nvd_json nvdcve-1.1-modified.json \
             -pypi_links pypi_links.json \
             -pypi_versions pypi_versions.json \
             -out_dir vulns \


### PR DESCRIPTION
The modified feed contains all CVEs published or modified within the last 8 days, whereas the recent feed only contains CVEs published within the last 8 days.  This change would allow the automation to pick up anything which didn't match any of the heuristics originally, but is later modified such that it does match.
