### PR TITLE
apply all tensorflow advisories to tensorflow-cpu and tensorflow-gpu

### DIFF
--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2018-10055.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2018-10055.yaml
@@ -1,0 +1,21 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 1.7.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2018-10055
+details: Invalid memory access and/or a heap buffer overflow in the TensorFlow XLA
+  compiler in Google TensorFlow before 1.7.1 could cause a crash or read from other
+  parts of process memory via a crafted configuration file.
+id: PYSEC-0000-CVE-2018-10055
+modified: '2021-08-27T03:22:22.150023Z'
+published: '2019-04-24T17:29:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/security/advisory/tfsa-2018-006.md

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2018-21233.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2018-21233.yaml
@@ -1,0 +1,28 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 49f73c55d56edffebde4bca4a407ad69c1cae433
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2018-21233
+details: TensorFlow before 1.7.0 has an integer overflow that causes an out-of-bounds
+  read, possibly causing disclosure of the contents of process memory. This occurs
+  in the DecodeBmp feature of the BMP decoder in core/kernels/decode_bmp_op.cc.
+id: PYSEC-0000-CVE-2018-21233
+modified: '2021-08-27T03:22:22.195752Z'
+published: '2020-05-04T15:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/49f73c55d56edffebde4bca4a407ad69c1cae433
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/security/advisory/tfsa-2018-001.md

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2018-7575.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2018-7575.yaml
@@ -1,0 +1,20 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 1.7.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2018-7575
+details: Google TensorFlow 1.7.x and earlier is affected by a Buffer Overflow vulnerability.
+  The type of exploitation is context-dependent.
+id: PYSEC-0000-CVE-2018-7575
+modified: '2021-08-27T03:22:22.242054Z'
+published: '2019-04-24T21:29:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/security/advisory/tfsa-2018-004.md

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2018-7576.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2018-7576.yaml
@@ -1,0 +1,20 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 1.7.0rc0
+    type: ECOSYSTEM
+aliases:
+- CVE-2018-7576
+details: 'Google TensorFlow 1.6.x and earlier is affected by: Null Pointer Dereference.
+  The type of exploitation is: context-dependent.'
+id: PYSEC-0000-CVE-2018-7576
+modified: '2021-08-27T03:22:22.321158Z'
+published: '2019-04-23T21:29:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/security/advisory/tfsa-2018-002.md

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2018-7577.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2018-7577.yaml
@@ -1,0 +1,21 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 1.7.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2018-7577
+details: Memcpy parameter overlap in Google Snappy library 1.1.4, as used in Google
+  TensorFlow before 1.7.1, could result in a crash or read from other parts of process
+  memory.
+id: PYSEC-0000-CVE-2018-7577
+modified: '2021-08-27T03:22:22.362937Z'
+published: '2019-04-24T17:29:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/security/advisory/tfsa-2018-005.md

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2018-8825.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2018-8825.yaml
@@ -1,0 +1,20 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 1.7.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2018-8825
+details: 'Google TensorFlow 1.7 and below is affected by: Buffer Overflow. The impact
+  is: execute arbitrary code (local).'
+id: PYSEC-0000-CVE-2018-8825
+modified: '2021-08-27T03:22:22.407658Z'
+published: '2019-04-23T21:29:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/security/advisory/tfsa-2018-003.md

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2019-16778.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2019-16778.yaml
@@ -1,0 +1,33 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: db4f9717c41bccc3ce10099ab61996b246099892
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 1.0.0
+    - fixed: 1.15.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2019-16778
+- GHSA-844w-j86r-4x2j
+details: In TensorFlow before 1.15, a heap buffer overflow in UnsortedSegmentSum can
+  be produced when the Index template argument is int32. In this case data_size and
+  num_segments fields are truncated from int64 to int32 and can produce negative numbers,
+  resulting in accessing out of bounds heap memory. This is unlikely to be exploitable
+  and was detected and fixed internally in TensorFlow 1.15 and 2.0.
+id: PYSEC-0000-CVE-2019-16778
+modified: '2021-08-27T03:22:22.453759Z'
+published: '2019-12-16T21:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/db4f9717c41bccc3ce10099ab61996b246099892
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/security/advisory/tfsa-2019-002.md
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-844w-j86r-4x2j

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2019-9635.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2019-9635.yaml
@@ -1,0 +1,20 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 1.12.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2019-9635
+details: NULL pointer dereference in Google TensorFlow before 1.12.2 could cause a
+  denial of service via an invalid GIF file.
+id: PYSEC-0000-CVE-2019-9635
+modified: '2021-08-27T03:22:22.500832Z'
+published: '2019-04-24T17:29:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/security/advisory/tfsa-2019-001.md

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15190.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15190.yaml
@@ -1,0 +1,47 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: da8558533d925694483d2c136a9220d6d49d843c
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.4
+    - introduced: 2.0.0
+    - fixed: 2.0.3
+    - introduced: 2.1.0
+    - fixed: 2.1.2
+    - introduced: 2.2.0
+    - fixed: 2.2.1
+    - introduced: 2.3.0
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15190
+- GHSA-4g9f-63rx-5cw4
+details: In Tensorflow before versions 1.15.4, 2.0.3, 2.1.2, 2.2.1 and 2.3.1, the
+  `tf.raw_ops.Switch` operation takes as input a tensor and a boolean and outputs
+  two tensors. Depending on the boolean value, one of the tensors is exactly the input
+  tensor whereas the other one should be an empty tensor. However, the eager runtime
+  traverses all tensors in the output. Since only one of the tensors is defined, the
+  other one is `nullptr`, hence we are binding a reference to `nullptr`. This is undefined
+  behavior and reported as an error if compiling with `-fsanitize=null`. In this case,
+  this results in a segmentation fault The issue is patched in commit da8558533d925694483d2c136a9220d6d49d843c,
+  and is released in TensorFlow versions 1.15.4, 2.0.3, 2.1.2, 2.2.1, or 2.3.1.
+id: PYSEC-0000-CVE-2020-15190
+modified: '2020-10-29T16:15:00Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/da8558533d925694483d2c136a9220d6d49d843c
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-4g9f-63rx-5cw4
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00065.html

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15191.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15191.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 22e07fb204386768e5bcbea563641ea11f96ceb8
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.1
+    - introduced: 2.3.0rc0
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15191
+- GHSA-q8qj-fc9q-cphr
+details: In Tensorflow before versions 2.2.1 and 2.3.1, if a user passes an invalid
+  argument to `dlpack.to_dlpack` the expected validations will cause variables to
+  bind to `nullptr` while setting a `status` variable to the error condition. However,
+  this `status` argument is not properly checked. Hence, code following these methods
+  will bind references to null pointers. This is undefined behavior and reported as
+  an error if compiling with `-fsanitize=null`. The issue is patched in commit 22e07fb204386768e5bcbea563641ea11f96ceb8
+  and is released in TensorFlow versions 2.2.1, or 2.3.1.
+id: PYSEC-0000-CVE-2020-15191
+modified: '2021-09-01T08:19:32.360913Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-q8qj-fc9q-cphr
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/22e07fb204386768e5bcbea563641ea11f96ceb8
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00065.html

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15192.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15192.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 22e07fb204386768e5bcbea563641ea11f96ceb8
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.1
+    - introduced: 2.3.0rc0
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15192
+- GHSA-8fxw-76px-3rxv
+details: In Tensorflow before versions 2.2.1 and 2.3.1, if a user passes a list of
+  strings to `dlpack.to_dlpack` there is a memory leak following an expected validation
+  failure. The issue occurs because the `status` argument during validation failures
+  is not properly checked. Since each of the above methods can return an error status,
+  the `status` value must be checked before continuing. The issue is patched in commit
+  22e07fb204386768e5bcbea563641ea11f96ceb8 and is released in TensorFlow versions
+  2.2.1, or 2.3.1.
+id: PYSEC-0000-CVE-2020-15192
+modified: '2021-09-01T08:19:32.462320Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-8fxw-76px-3rxv
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/22e07fb204386768e5bcbea563641ea11f96ceb8
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00065.html

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15193.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15193.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 22e07fb204386768e5bcbea563641ea11f96ceb8
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.1
+    - introduced: 2.3.0rc0
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15193
+- GHSA-rjjg-hgv6-h69v
+details: In Tensorflow before versions 2.2.1 and 2.3.1, the implementation of `dlpack.to_dlpack`
+  can be made to use uninitialized memory resulting in further memory corruption.
+  This is because the pybind11 glue code assumes that the argument is a tensor. However,
+  there is nothing stopping users from passing in a Python object instead of a tensor.
+  The uninitialized memory address is due to a `reinterpret_cast` Since the `PyObject`
+  is a Python object, not a TensorFlow Tensor, the cast to `EagerTensor` fails. The
+  issue is patched in commit 22e07fb204386768e5bcbea563641ea11f96ceb8 and is released
+  in TensorFlow versions 2.2.1, or 2.3.1.
+id: PYSEC-0000-CVE-2020-15193
+modified: '2021-09-01T08:19:32.562362Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-rjjg-hgv6-h69v
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/22e07fb204386768e5bcbea563641ea11f96ceb8
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00065.html

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15194.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15194.yaml
@@ -1,0 +1,46 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 390611e0d45c5793c7066110af37c8514e6a6c54
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.4
+    - introduced: 2.0.0
+    - fixed: 2.0.3
+    - introduced: 2.1.0
+    - fixed: 2.1.2
+    - introduced: 2.2.0
+    - fixed: 2.2.1
+    - introduced: 2.3.0
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15194
+- GHSA-9mqp-7v2h-2382
+details: In Tensorflow before versions 1.15.4, 2.0.3, 2.1.2, 2.2.1 and 2.3.1, the
+  `SparseFillEmptyRowsGrad` implementation has incomplete validation of the shapes
+  of its arguments. Although `reverse_index_map_t` and `grad_values_t` are accessed
+  in a similar pattern, only `reverse_index_map_t` is validated to be of proper shape.
+  Hence, malicious users can pass a bad `grad_values_t` to trigger an assertion failure
+  in `vec`, causing denial of service in serving installations. The issue is patched
+  in commit 390611e0d45c5793c7066110af37c8514e6a6c54, and is released in TensorFlow
+  versions 1.15.4, 2.0.3, 2.1.2, 2.2.1, or 2.3.1."
+id: PYSEC-0000-CVE-2020-15194
+modified: '2020-12-23T18:33:00Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/390611e0d45c5793c7066110af37c8514e6a6c54
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-9mqp-7v2h-2382
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00065.html

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15195.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15195.yaml
@@ -1,0 +1,43 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 390611e0d45c5793c7066110af37c8514e6a6c54
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.4
+    - introduced: 2.0.0
+    - fixed: 2.0.3
+    - introduced: 2.1.0
+    - fixed: 2.1.2
+    - introduced: 2.2.0
+    - fixed: 2.2.1
+    - introduced: 2.3.0
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15195
+- GHSA-63xm-rx5p-xvqr
+details: In Tensorflow before versions 1.15.4, 2.0.3, 2.1.2, 2.2.1 and 2.3.1, the
+  implementation of `SparseFillEmptyRowsGrad` uses a double indexing pattern. It is
+  possible for `reverse_index_map(i)` to be an index outside of bounds of `grad_values`,
+  thus resulting in a heap buffer overflow. The issue is patched in commit 390611e0d45c5793c7066110af37c8514e6a6c54,
+  and is released in TensorFlow versions 1.15.4, 2.0.3, 2.1.2, 2.2.1, or 2.3.1.
+id: PYSEC-0000-CVE-2020-15195
+modified: '2020-10-29T16:15:00Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/390611e0d45c5793c7066110af37c8514e6a6c54
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-63xm-rx5p-xvqr
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00065.html

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15196.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15196.yaml
@@ -1,0 +1,36 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 3cbb917b4714766030b28eba9fb41bb97ce9ee02
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15196
+- GHSA-pg59-2f92-5cph
+details: In Tensorflow version 2.3.0, the `SparseCountSparseOutput` and `RaggedCountSparseOutput`
+  implementations don't validate that the `weights` tensor has the same shape as the
+  data. The check exists for `DenseCountSparseOutput`, where both tensors are fully
+  specified. In the sparse and ragged count weights are still accessed in parallel
+  with the data. But, since there is no validation, a user passing fewer weights than
+  the values for the tensors can generate a read from outside the bounds of the heap
+  buffer allocated for the weights. The issue is patched in commit 3cbb917b4714766030b28eba9fb41bb97ce9ee02
+  and is released in TensorFlow version 2.3.1.
+id: PYSEC-0000-CVE-2020-15196
+modified: '2021-09-01T08:19:33.034745Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-pg59-2f92-5cph
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/3cbb917b4714766030b28eba9fb41bb97ce9ee02

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15197.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15197.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 3cbb917b4714766030b28eba9fb41bb97ce9ee02
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15197
+- GHSA-qc53-44cj-vfvx
+details: In Tensorflow before version 2.3.1, the `SparseCountSparseOutput` implementation
+  does not validate that the input arguments form a valid sparse tensor. In particular,
+  there is no validation that the `indices` tensor has rank 2. This tensor must be
+  a matrix because code assumes its elements are accessed as elements of a matrix.
+  However, malicious users can pass in tensors of different rank, resulting in a `CHECK`
+  assertion failure and a crash. This can be used to cause denial of service in serving
+  installations, if users are allowed to control the components of the input sparse
+  tensor. The issue is patched in commit 3cbb917b4714766030b28eba9fb41bb97ce9ee02
+  and is released in TensorFlow version 2.3.1.
+id: PYSEC-0000-CVE-2020-15197
+modified: '2021-09-01T08:19:33.096342Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-qc53-44cj-vfvx
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/3cbb917b4714766030b28eba9fb41bb97ce9ee02

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15198.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15198.yaml
@@ -1,0 +1,35 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 3cbb917b4714766030b28eba9fb41bb97ce9ee02
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15198
+- GHSA-jc87-6vpp-7ff3
+details: In Tensorflow before version 2.3.1, the `SparseCountSparseOutput` implementation
+  does not validate that the input arguments form a valid sparse tensor. In particular,
+  there is no validation that the `indices` tensor has the same shape as the `values`
+  one. The values in these tensors are always accessed in parallel. Thus, a shape
+  mismatch can result in accesses outside the bounds of heap allocated buffers. The
+  issue is patched in commit 3cbb917b4714766030b28eba9fb41bb97ce9ee02 and is released
+  in TensorFlow version 2.3.1.
+id: PYSEC-0000-CVE-2020-15198
+modified: '2021-09-01T08:19:33.154302Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/3cbb917b4714766030b28eba9fb41bb97ce9ee02
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-jc87-6vpp-7ff3

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15199.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15199.yaml
@@ -1,0 +1,36 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 3cbb917b4714766030b28eba9fb41bb97ce9ee02
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15199
+- GHSA-x5cp-9pcf-pp3h
+details: In Tensorflow before version 2.3.1, the `RaggedCountSparseOutput` does not
+  validate that the input arguments form a valid ragged tensor. In particular, there
+  is no validation that the `splits` tensor has the minimum required number of elements.
+  Code uses this quantity to initialize a different data structure. Since `BatchedMap`
+  is equivalent to a vector, it needs to have at least one element to not be `nullptr`.
+  If user passes a `splits` tensor that is empty or has exactly one element, we get
+  a `SIGABRT` signal raised by the operating system. The issue is patched in commit
+  3cbb917b4714766030b28eba9fb41bb97ce9ee02 and is released in TensorFlow version 2.3.1.
+id: PYSEC-0000-CVE-2020-15199
+modified: '2021-09-01T08:19:33.217572Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-x5cp-9pcf-pp3h
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/3cbb917b4714766030b28eba9fb41bb97ce9ee02

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15200.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15200.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 3cbb917b4714766030b28eba9fb41bb97ce9ee02
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15200
+- GHSA-x7rp-74x2-mjf3
+details: In Tensorflow before version 2.3.1, the `RaggedCountSparseOutput` implementation
+  does not validate that the input arguments form a valid ragged tensor. In particular,
+  there is no validation that the values in the `splits` tensor generate a valid partitioning
+  of the `values` tensor. Thus, the code sets up conditions to cause a heap buffer
+  overflow. A `BatchedMap` is equivalent to a vector where each element is a hashmap.
+  However, if the first element of `splits_values` is not 0, `batch_idx` will never
+  be 1, hence there will be no hashmap at index 0 in `per_batch_counts`. Trying to
+  access that in the user code results in a segmentation fault. The issue is patched
+  in commit 3cbb917b4714766030b28eba9fb41bb97ce9ee02 and is released in TensorFlow
+  version 2.3.1.
+id: PYSEC-0000-CVE-2020-15200
+modified: '2021-09-01T08:19:33.281926Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-x7rp-74x2-mjf3
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/3cbb917b4714766030b28eba9fb41bb97ce9ee02

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15201.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15201.yaml
@@ -1,0 +1,36 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 3cbb917b4714766030b28eba9fb41bb97ce9ee02
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15201
+- GHSA-p5f8-gfw5-33w4
+details: In Tensorflow before version 2.3.1, the `RaggedCountSparseOutput` implementation
+  does not validate that the input arguments form a valid ragged tensor. In particular,
+  there is no validation that the values in the `splits` tensor generate a valid partitioning
+  of the `values` tensor. Hence, the code is prone to heap buffer overflow. If `split_values`
+  does not end with a value at least `num_values` then the `while` loop condition
+  will trigger a read outside of the bounds of `split_values` once `batch_idx` grows
+  too large. The issue is patched in commit 3cbb917b4714766030b28eba9fb41bb97ce9ee02
+  and is released in TensorFlow version 2.3.1.
+id: PYSEC-0000-CVE-2020-15201
+modified: '2021-09-01T08:19:33.344299Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-p5f8-gfw5-33w4
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/3cbb917b4714766030b28eba9fb41bb97ce9ee02

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15202.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15202.yaml
@@ -1,0 +1,50 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 27b417360cbd671ef55915e4bb6bb06af8b8a832
+    - fixed: ca8c013b5e97b1373b3bb1c97ea655e69f31a575
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.4
+    - introduced: 2.0.0
+    - fixed: 2.0.3
+    - introduced: 2.1.0
+    - fixed: 2.1.2
+    - introduced: 2.2.0
+    - fixed: 2.2.1
+    - introduced: 2.3.0
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15202
+- GHSA-h6fg-mjxg-hqq4
+details: In Tensorflow before versions 1.15.4, 2.0.3, 2.1.2, 2.2.1 and 2.3.1, the
+  `Shard` API in TensorFlow expects the last argument to be a function taking two
+  `int64` (i.e., `long long`) arguments. However, there are several places in TensorFlow
+  where a lambda taking `int` or `int32` arguments is being used. In these cases,
+  if the amount of work to be parallelized is large enough, integer truncation occurs.
+  Depending on how the two arguments of the lambda are used, this can result in segfaults,
+  read/write outside of heap allocated arrays, stack overflows, or data corruption.
+  The issue is patched in commits 27b417360cbd671ef55915e4bb6bb06af8b8a832 and ca8c013b5e97b1373b3bb1c97ea655e69f31a575,
+  and is released in TensorFlow versions 1.15.4, 2.0.3, 2.1.2, 2.2.1, or 2.3.1.
+id: PYSEC-0000-CVE-2020-15202
+modified: '2020-10-29T16:15:00Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/27b417360cbd671ef55915e4bb6bb06af8b8a832
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-h6fg-mjxg-hqq4
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/ca8c013b5e97b1373b3bb1c97ea655e69f31a575
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00065.html

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15203.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15203.yaml
@@ -1,0 +1,44 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 33be22c65d86256e6826666662e40dbdfe70ee83
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.4
+    - introduced: 2.0.0
+    - fixed: 2.0.3
+    - introduced: 2.1.0
+    - fixed: 2.1.2
+    - introduced: 2.2.0
+    - fixed: 2.2.1
+    - introduced: 2.3.0
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15203
+- GHSA-xmq7-7fxm-rr79
+details: In Tensorflow before versions 1.15.4, 2.0.3, 2.1.2, 2.2.1 and 2.3.1, by controlling
+  the `fill` argument of tf.strings.as_string, a malicious attacker is able to trigger
+  a format string vulnerability due to the way the internal format use in a `printf`
+  call is constructed. This may result in segmentation fault. The issue is patched
+  in commit 33be22c65d86256e6826666662e40dbdfe70ee83, and is released in TensorFlow
+  versions 1.15.4, 2.0.3, 2.1.2, 2.2.1, or 2.3.1.
+id: PYSEC-0000-CVE-2020-15203
+modified: '2020-10-29T16:15:00Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/33be22c65d86256e6826666662e40dbdfe70ee83
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-xmq7-7fxm-rr79
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00065.html

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15204.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15204.yaml
@@ -1,0 +1,44 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 9a133d73ae4b4664d22bd1aa6d654fec13c52ee1
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.4
+    - introduced: 2.0.0
+    - fixed: 2.0.3
+    - introduced: 2.1.0
+    - fixed: 2.1.2
+    - introduced: 2.2.0
+    - fixed: 2.2.1
+    - introduced: 2.3.0
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15204
+- GHSA-q8gv-q7wr-9jf8
+details: In eager mode, TensorFlow before versions 1.15.4, 2.0.3, 2.1.2, 2.2.1 and
+  2.3.1 does not set the session state. Hence, calling `tf.raw_ops.GetSessionHandle`
+  or `tf.raw_ops.GetSessionHandleV2` results in a null pointer dereference In linked
+  snippet, in eager mode, `ctx->session_state()` returns `nullptr`. Since code immediately
+  dereferences this, we get a segmentation fault. The issue is patched in commit 9a133d73ae4b4664d22bd1aa6d654fec13c52ee1,
+  and is released in TensorFlow versions 1.15.4, 2.0.3, 2.1.2, 2.2.1, or 2.3.1.
+id: PYSEC-0000-CVE-2020-15204
+modified: '2020-10-29T16:15:00Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-q8gv-q7wr-9jf8
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/9a133d73ae4b4664d22bd1aa6d654fec13c52ee1
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00065.html

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15205.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15205.yaml
@@ -1,0 +1,45 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 0462de5b544ed4731aa2fb23946ac22c01856b80
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.4
+    - introduced: 2.0.0
+    - fixed: 2.0.3
+    - introduced: 2.1.0
+    - fixed: 2.1.2
+    - introduced: 2.2.0
+    - fixed: 2.2.1
+    - introduced: 2.3.0
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15205
+- GHSA-g7p5-5759-qv46
+details: In Tensorflow before versions 1.15.4, 2.0.3, 2.1.2, 2.2.1 and 2.3.1, the
+  `data_splits` argument of `tf.raw_ops.StringNGrams` lacks validation. This allows
+  a user to pass values that can cause heap overflow errors and even leak contents
+  of memory In the linked code snippet, all the binary strings after `ee ff` are contents
+  from the memory stack. Since these can contain return addresses, this data leak
+  can be used to defeat ASLR. The issue is patched in commit 0462de5b544ed4731aa2fb23946ac22c01856b80,
+  and is released in TensorFlow versions 1.15.4, 2.0.3, 2.1.2, 2.2.1, or 2.3.1.
+id: PYSEC-0000-CVE-2020-15205
+modified: '2020-10-29T16:15:00Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-g7p5-5759-qv46
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/0462de5b544ed4731aa2fb23946ac22c01856b80
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00065.html

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15206.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15206.yaml
@@ -1,0 +1,47 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: adf095206f25471e864a8e63a0f1caef53a0e3a6
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.4
+    - introduced: 2.0.0
+    - fixed: 2.0.3
+    - introduced: 2.1.0
+    - fixed: 2.1.2
+    - introduced: 2.2.0
+    - fixed: 2.2.1
+    - introduced: 2.3.0
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15206
+- GHSA-w5gh-2wr2-pm6g
+details: 'In Tensorflow before versions 1.15.4, 2.0.3, 2.1.2, 2.2.1 and 2.3.1, changing
+  the TensorFlow''s `SavedModel` protocol buffer and altering the name of required
+  keys results in segfaults and data corruption while loading the model. This can
+  cause a denial of service in products using `tensorflow-serving` or other inference-as-a-service
+  installments. Fixed were added in commits f760f88b4267d981e13f4b302c437ae800445968
+  and fcfef195637c6e365577829c4d67681695956e7d (both going into TensorFlow 2.2.0 and
+  2.3.0 but not yet backported to earlier versions). However, this was not enough,
+  as #41097 reports a different failure mode. The issue is patched in commit adf095206f25471e864a8e63a0f1caef53a0e3a6,
+  and is released in TensorFlow versions 1.15.4, 2.0.3, 2.1.2, 2.2.1, or 2.3.1.'
+id: PYSEC-0000-CVE-2020-15206
+modified: '2020-10-29T16:15:00Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-w5gh-2wr2-pm6g
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/adf095206f25471e864a8e63a0f1caef53a0e3a6
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00065.html

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15207.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15207.yaml
@@ -1,0 +1,46 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 2d88f470dea2671b430884260f3626b1fe99830a
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.4
+    - introduced: 2.0.0
+    - fixed: 2.0.3
+    - introduced: 2.1.0
+    - fixed: 2.1.2
+    - introduced: 2.2.0
+    - fixed: 2.2.1
+    - introduced: 2.3.0
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15207
+- GHSA-q4qf-3fc6-8x34
+details: In tensorflow-lite before versions 1.15.4, 2.0.3, 2.1.2, 2.2.1 and 2.3.1,
+  to mimic Python's indexing with negative values, TFLite uses `ResolveAxis` to convert
+  negative values to positive indices. However, the only check that the converted
+  index is now valid is only present in debug builds. If the `DCHECK` does not trigger,
+  then code execution moves ahead with a negative index. This, in turn, results in
+  accessing data out of bounds which results in segfaults and/or data corruption.
+  The issue is patched in commit 2d88f470dea2671b430884260f3626b1fe99830a, and is
+  released in TensorFlow versions 1.15.4, 2.0.3, 2.1.2, 2.2.1, or 2.3.1.
+id: PYSEC-0000-CVE-2020-15207
+modified: '2020-10-29T16:15:00Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/2d88f470dea2671b430884260f3626b1fe99830a
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-q4qf-3fc6-8x34
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00065.html

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15208.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15208.yaml
@@ -1,0 +1,46 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 8ee24e7949a203d234489f9da2c5bf45a7d5157d
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.4
+    - introduced: 2.0.0
+    - fixed: 2.0.3
+    - introduced: 2.1.0
+    - fixed: 2.1.2
+    - introduced: 2.2.0
+    - fixed: 2.2.1
+    - introduced: 2.3.0
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15208
+- GHSA-mxjj-953w-2c2v
+details: In tensorflow-lite before versions 1.15.4, 2.0.3, 2.1.2, 2.2.1 and 2.3.1,
+  when determining the common dimension size of two tensors, TFLite uses a `DCHECK`
+  which is no-op outside of debug compilation modes. Since the function always returns
+  the dimension of the first tensor, malicious attackers can craft cases where this
+  is larger than that of the second tensor. In turn, this would result in reads/writes
+  outside of bounds since the interpreter will wrongly assume that there is enough
+  data in both tensors. The issue is patched in commit 8ee24e7949a203d234489f9da2c5bf45a7d5157d,
+  and is released in TensorFlow versions 1.15.4, 2.0.3, 2.1.2, 2.2.1, or 2.3.1.
+id: PYSEC-0000-CVE-2020-15208
+modified: '2020-10-29T16:15:00Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/8ee24e7949a203d234489f9da2c5bf45a7d5157d
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-mxjj-953w-2c2v
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00065.html

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15209.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15209.yaml
@@ -1,0 +1,47 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 0b5662bc2be13a8c8f044d925d87fb6e56247cd8
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.4
+    - introduced: 2.0.0
+    - fixed: 2.0.3
+    - introduced: 2.1.0
+    - fixed: 2.1.2
+    - introduced: 2.2.0
+    - fixed: 2.2.1
+    - introduced: 2.3.0
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15209
+- GHSA-qh32-6jjc-qprm
+details: In tensorflow-lite before versions 1.15.4, 2.0.3, 2.1.2, 2.2.1 and 2.3.1,
+  a crafted TFLite model can force a node to have as input a tensor backed by a `nullptr`
+  buffer. This can be achieved by changing a buffer index in the flatbuffer serialization
+  to convert a read-only tensor to a read-write one. The runtime assumes that these
+  buffers are written to before a possible read, hence they are initialized with `nullptr`.
+  However, by changing the buffer index for a tensor and implicitly converting that
+  tensor to be a read-write one, as there is nothing in the model that writes to it,
+  we get a null pointer dereference. The issue is patched in commit 0b5662bc, and
+  is released in TensorFlow versions 1.15.4, 2.0.3, 2.1.2, 2.2.1, or 2.3.1.
+id: PYSEC-0000-CVE-2020-15209
+modified: '2020-10-29T16:15:00Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-qh32-6jjc-qprm
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/0b5662bc2be13a8c8f044d925d87fb6e56247cd8
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00065.html

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15210.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15210.yaml
@@ -1,0 +1,44 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: d58c96946b2880991d63d1dacacb32f0a4dfa453
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.4
+    - introduced: 2.0.0
+    - fixed: 2.0.3
+    - introduced: 2.1.0
+    - fixed: 2.1.2
+    - introduced: 2.2.0
+    - fixed: 2.2.1
+    - introduced: 2.3.0
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15210
+- GHSA-x9j7-x98r-r4w2
+details: In tensorflow-lite before versions 1.15.4, 2.0.3, 2.1.2, 2.2.1 and 2.3.1,
+  if a TFLite saved model uses the same tensor as both input and output of an operator,
+  then, depending on the operator, we can observe a segmentation fault or just memory
+  corruption. We have patched the issue in d58c96946b and will release patch releases
+  for all versions between 1.15 and 2.3. We recommend users to upgrade to TensorFlow
+  1.15.4, 2.0.3, 2.1.2, 2.2.1, or 2.3.1.
+id: PYSEC-0000-CVE-2020-15210
+modified: '2020-10-29T16:15:00Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/d58c96946b2880991d63d1dacacb32f0a4dfa453
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-x9j7-x98r-r4w2
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00065.html

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15211.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15211.yaml
@@ -1,0 +1,73 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: e11f55585f614645b360563072ffeb5c3eeff162
+    - fixed: cd31fd0ce0449a9e0f83dcad08d6ed7f1d6bef3f
+    - fixed: 46d5b0852528ddfd614ded79bccc75589f801bd9
+    - fixed: 00302787b788c5ff04cb6f62aed5a74d936e86c0
+    - fixed: fff2c8326280c07733828f990548979bdc893859
+    - fixed: 1970c2158b1ffa416d159d03c3370b9a462aee35
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.4
+    - introduced: 2.0.0
+    - fixed: 2.0.3
+    - introduced: 2.1.0
+    - fixed: 2.1.2
+    - introduced: 2.2.0
+    - fixed: 2.2.1
+    - introduced: 2.3.0
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15211
+- GHSA-cvpc-8phh-8f45
+details: 'In TensorFlow Lite before versions 1.15.4, 2.0.3, 2.1.2, 2.2.1 and 2.3.1,
+  saved models in the flatbuffer format use a double indexing scheme: a model has
+  a set of subgraphs, each subgraph has a set of operators and each operator has a
+  set of input/output tensors. The flatbuffer format uses indices for the tensors,
+  indexing into an array of tensors that is owned by the subgraph. This results in
+  a pattern of double array indexing when trying to get the data of each tensor. However,
+  some operators can have some tensors be optional. To handle this scenario, the flatbuffer
+  model uses a negative `-1` value as index for these tensors. This results in special
+  casing during validation at model loading time. Unfortunately, this means that the
+  `-1` index is a valid tensor index for any operator, including those that don''t
+  expect optional inputs and including for output tensors. Thus, this allows writing
+  and reading from outside the bounds of heap allocated arrays, although only at a
+  specific offset from the start of these arrays. This results in both read and write
+  gadgets, albeit very limited in scope. The issue is patched in several commits (46d5b0852,
+  00302787b7, e11f5558, cd31fd0ce, 1970c21, and fff2c83), and is released in TensorFlow
+  versions 1.15.4, 2.0.3, 2.1.2, 2.2.1, or 2.3.1. A potential workaround would be
+  to add a custom `Verifier` to the model loading code to ensure that only operators
+  which accept optional inputs use the `-1` special value and only for the tensors
+  that they expect to be optional. Since this allow-list type approach is erro-prone,
+  we advise upgrading to the patched code.'
+id: PYSEC-0000-CVE-2020-15211
+modified: '2020-10-29T16:15:00Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/e11f55585f614645b360563072ffeb5c3eeff162
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/cd31fd0ce0449a9e0f83dcad08d6ed7f1d6bef3f
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/46d5b0852528ddfd614ded79bccc75589f801bd9
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/00302787b788c5ff04cb6f62aed5a74d936e86c0
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-cvpc-8phh-8f45
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/fff2c8326280c07733828f990548979bdc893859
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/1970c2158b1ffa416d159d03c3370b9a462aee35
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00065.html

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15212.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15212.yaml
@@ -1,0 +1,44 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 204945b19e44b57906c9344c0d00120eeeae178a
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.1
+    - introduced: 2.2.0
+    - fixed: 2.2.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15212
+- GHSA-hx2x-85gr-wrpq
+details: In TensorFlow Lite before versions 2.2.1 and 2.3.1, models using segment
+  sum can trigger writes outside of bounds of heap allocated buffers by inserting
+  negative elements in the segment ids tensor. Users having access to `segment_ids_data`
+  can alter `output_index` and then write to outside of `output_data` buffer. This
+  might result in a segmentation fault but it can also be used to further corrupt
+  the memory and can be chained with other vulnerabilities to create more advanced
+  exploits. The issue is patched in commit 204945b19e44b57906c9344c0d00120eeeae178a
+  and is released in TensorFlow versions 2.2.1, or 2.3.1. A potential workaround would
+  be to add a custom `Verifier` to the model loading code to ensure that the segment
+  ids are all positive, although this only handles the case when the segment ids are
+  stored statically in the model. A similar validation could be done if the segment
+  ids are generated at runtime between inference steps. If the segment ids are generated
+  as outputs of a tensor during inference steps, then there are no possible workaround
+  and users are advised to upgrade to patched code.
+id: PYSEC-0000-CVE-2020-15212
+modified: '2020-10-01T18:20:00Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-hx2x-85gr-wrpq
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/204945b19e44b57906c9344c0d00120eeeae178a

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15213.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15213.yaml
@@ -1,0 +1,42 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 204945b19e44b57906c9344c0d00120eeeae178a
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.2.0
+    - fixed: 2.2.1
+    - introduced: 2.3.0
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15213
+- GHSA-hjmq-236j-8m87
+details: In TensorFlow Lite before versions 2.2.1 and 2.3.1, models using segment
+  sum can trigger a denial of service by causing an out of memory allocation in the
+  implementation of segment sum. Since code uses the last element of the tensor holding
+  them to determine the dimensionality of output tensor, attackers can use a very
+  large value to trigger a large allocation. The issue is patched in commit 204945b19e44b57906c9344c0d00120eeeae178a
+  and is released in TensorFlow versions 2.2.1, or 2.3.1. A potential workaround would
+  be to add a custom `Verifier` to limit the maximum value in the segment ids tensor.
+  This only handles the case when the segment ids are stored statically in the model,
+  but a similar validation could be done if the segment ids are generated at runtime,
+  between inference steps. However, if the segment ids are generated as outputs of
+  a tensor during inference steps, then there are no possible workaround and users
+  are advised to upgrade to patched code.
+id: PYSEC-0000-CVE-2020-15213
+modified: '2020-10-01T23:15:00Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-hjmq-236j-8m87
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/204945b19e44b57906c9344c0d00120eeeae178a

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15214.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15214.yaml
@@ -1,0 +1,45 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 204945b19e44b57906c9344c0d00120eeeae178a
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.2.0
+    - fixed: 2.2.1
+    - introduced: 2.3.0
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15214
+- GHSA-p2cq-cprg-frvm
+details: In TensorFlow Lite before versions 2.2.1 and 2.3.1, models using segment
+  sum can trigger a write out bounds / segmentation fault if the segment ids are not
+  sorted. Code assumes that the segment ids are in increasing order, using the last
+  element of the tensor holding them to determine the dimensionality of output tensor.
+  This results in allocating insufficient memory for the output tensor and in a write
+  outside the bounds of the output array. This usually results in a segmentation fault,
+  but depending on runtime conditions it can provide for a write gadget to be used
+  in future memory corruption-based exploits. The issue is patched in commit 204945b19e44b57906c9344c0d00120eeeae178a
+  and is released in TensorFlow versions 2.2.1, or 2.3.1. A potential workaround would
+  be to add a custom `Verifier` to the model loading code to ensure that the segment
+  ids are sorted, although this only handles the case when the segment ids are stored
+  statically in the model. A similar validation could be done if the segment ids are
+  generated at runtime between inference steps. If the segment ids are generated as
+  outputs of a tensor during inference steps, then there are no possible workaround
+  and users are advised to upgrade to patched code.
+id: PYSEC-0000-CVE-2020-15214
+modified: '2020-10-01T18:36:00Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-p2cq-cprg-frvm
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/204945b19e44b57906c9344c0d00120eeeae178a

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15265.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15265.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: eccb7ec454e6617738554a255d77f08e60ee0808
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15265
+- GHSA-rrfp-j2mp-hq9c
+details: In Tensorflow before version 2.4.0, an attacker can pass an invalid `axis`
+  value to `tf.quantization.quantize_and_dequantize`. This results in accessing a
+  dimension outside the rank of the input tensor in the C++ kernel implementation.
+  However, dim_size only does a DCHECK to validate the argument and then uses it to
+  access the corresponding element of an array. Since in normal builds, `DCHECK`-like
+  macros are no-ops, this results in segfault and access out of bounds of the array.
+  The issue is patched in eccb7ec454e6617738554a255d77f08e60ee0808 and TensorFlow
+  2.4.0 will be released containing the patch. TensorFlow nightly packages after this
+  commit will also have the issue resolved.
+id: PYSEC-0000-CVE-2020-15265
+modified: '2021-09-01T08:19:35.574576Z'
+published: '2020-10-21T21:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/eccb7ec454e6617738554a255d77f08e60ee0808
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-rrfp-j2mp-hq9c
+- type: REPORT
+  url: https://github.com/tensorflow/tensorflow/issues/42105

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15266.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-15266.yaml
@@ -1,0 +1,29 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15266
+- GHSA-xwhf-g6j5-j5gc
+details: In Tensorflow before version 2.4.0, when the `boxes` argument of `tf.image.crop_and_resize`
+  has a very large value, the CPU kernel implementation receives it as a C++ `nan`
+  floating point value. Attempting to operate on this is undefined behavior which
+  later produces a segmentation fault. The issue is patched in eccb7ec454e6617738554a255d77f08e60ee0808
+  and TensorFlow 2.4.0 will be released containing the patch. TensorFlow nightly packages
+  after this commit will also have the issue resolved.
+id: PYSEC-0000-CVE-2020-15266
+modified: '2021-09-01T08:19:35.637564Z'
+published: '2020-10-21T21:15:00Z'
+references:
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/pull/42143/commits/3ade2efec2e90c6237de32a19680caaa3ebc2845
+- type: REPORT
+  url: https://github.com/tensorflow/tensorflow/issues/42129
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-xwhf-g6j5-j5gc

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-26266.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-26266.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: ace0c15a22f7f054abcc1f53eabbcb0a1239a9e2
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.5
+    - introduced: 2.0.0
+    - fixed: 2.0.4
+    - introduced: 2.1.0
+    - fixed: 2.1.3
+    - introduced: 2.2.0
+    - fixed: 2.2.2
+    - introduced: 2.3.0
+    - fixed: 2.3.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-26266
+- GHSA-qhxx-j73r-qpm2
+details: In affected versions of TensorFlow under certain cases a saved model can
+  trigger use of uninitialized values during code execution. This is caused by having
+  tensor buffers be filled with the default value of the type but forgetting to default
+  initialize the quantized floating point types in Eigen. This is fixed in versions
+  1.15.5, 2.0.4, 2.1.3, 2.2.2, 2.3.2, and 2.4.0.
+id: PYSEC-0000-CVE-2020-26266
+modified: '2021-08-27T03:22:22.698179Z'
+published: '2020-12-10T23:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/ace0c15a22f7f054abcc1f53eabbcb0a1239a9e2
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-qhxx-j73r-qpm2

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-26267.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-26267.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: ebc70b7a592420d3d2f359e4b1694c236b82c7ae
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.5
+    - introduced: 2.0.0
+    - fixed: 2.0.4
+    - introduced: 2.1.0
+    - fixed: 2.1.3
+    - introduced: 2.2.0
+    - fixed: 2.2.2
+    - introduced: 2.3.0
+    - fixed: 2.3.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-26267
+- GHSA-c9f3-9wfr-wgh7
+details: In affected versions of TensorFlow the tf.raw_ops.DataFormatVecPermute API
+  does not validate the src_format and dst_format attributes. The code assumes that
+  these two arguments define a permutation of NHWC. This can result in uninitialized
+  memory accesses, read outside of bounds and even crashes. This is fixed in versions
+  1.15.5, 2.0.4, 2.1.3, 2.2.2, 2.3.2, and 2.4.0.
+id: PYSEC-0000-CVE-2020-26267
+modified: '2020-12-14T19:08:00Z'
+published: '2020-12-10T23:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/ebc70b7a592420d3d2f359e4b1694c236b82c7ae
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-c9f3-9wfr-wgh7

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-26268.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-26268.yaml
@@ -1,0 +1,44 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: c1e1fc899ad5f8c725dcbb6470069890b5060bc7
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.5
+    - introduced: 2.0.0
+    - fixed: 2.0.4
+    - introduced: 2.1.0
+    - fixed: 2.1.3
+    - introduced: 2.2.0
+    - fixed: 2.2.2
+    - introduced: 2.3.0
+    - fixed: 2.3.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-26268
+- GHSA-hhvc-g5hv-48c6
+details: In affected versions of TensorFlow the tf.raw_ops.ImmutableConst operation
+  returns a constant tensor created from a memory mapped file which is assumed immutable.
+  However, if the type of the tensor is not an integral type, the operation crashes
+  the Python interpreter as it tries to write to the memory area. If the file is too
+  small, TensorFlow properly returns an error as the memory area has fewer bytes than
+  what is needed for the tensor it creates. However, as soon as there are enough bytes,
+  the above snippet causes a segmentation fault. This is because the allocator used
+  to return the buffer data is not marked as returning an opaque handle since the
+  needed virtual method is not overridden. This is fixed in versions 1.15.5, 2.0.4,
+  2.1.3, 2.2.2, 2.3.2, and 2.4.0.
+id: PYSEC-0000-CVE-2020-26268
+modified: '2021-08-27T03:22:22.907995Z'
+published: '2020-12-10T23:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/c1e1fc899ad5f8c725dcbb6470069890b5060bc7
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-hhvc-g5hv-48c6

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-26269.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-26269.yaml
@@ -1,0 +1,34 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 8b5b9dc96666a3a5d27fad7179ff215e3b74b67c
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.4.0rc0
+    - fixed: 2.4.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-26269
+- GHSA-9jjw-hf72-3mxw
+details: 'In TensorFlow release candidate versions 2.4.0rc*, the general implementation
+  for matching filesystem paths to globbing pattern is vulnerable to an access out
+  of bounds of the array holding the directories. There are multiple invariants and
+  preconditions that are assumed by the parallel implementation of GetMatchingPaths
+  but are not verified by the PRs introducing it (#40861 and #44310). Thus, we are
+  completely rewriting the implementation to fully specify and validate these. This
+  is patched in version 2.4.0. This issue only impacts master branch and the release
+  candidates for TF version 2.4. The final release of the 2.4 release will be patched.'
+id: PYSEC-0000-CVE-2020-26269
+modified: '2020-12-14T17:42:00Z'
+published: '2020-12-10T23:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-9jjw-hf72-3mxw
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/8b5b9dc96666a3a5d27fad7179ff215e3b74b67c

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-26270.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-26270.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 14755416e364f17fb1870882fa778c7fec7f16e3
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.5
+    - introduced: 2.0.0
+    - fixed: 2.0.4
+    - introduced: 2.1.0
+    - fixed: 2.1.3
+    - introduced: 2.2.0
+    - fixed: 2.2.2
+    - introduced: 2.3.0
+    - fixed: 2.3.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-26270
+- GHSA-m648-33qf-v3gp
+details: In affected versions of TensorFlow running an LSTM/GRU model where the LSTM/GRU
+  layer receives an input with zero-length results in a CHECK failure when using the
+  CUDA backend. This can result in a query-of-death vulnerability, via denial of service,
+  if users can control the input to the layer. This is fixed in versions 1.15.5, 2.0.4,
+  2.1.3, 2.2.2, 2.3.2, and 2.4.0.
+id: PYSEC-0000-CVE-2020-26270
+modified: '2021-08-27T03:22:23.120464Z'
+published: '2020-12-10T23:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-m648-33qf-v3gp
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/14755416e364f17fb1870882fa778c7fec7f16e3

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-26271.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-26271.yaml
@@ -1,0 +1,46 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 0cc38aaa4064fd9e79101994ce9872c6d91f816b
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.5
+    - introduced: 2.0.0
+    - fixed: 2.0.4
+    - introduced: 2.1.0
+    - fixed: 2.1.3
+    - introduced: 2.2.0
+    - fixed: 2.2.2
+    - introduced: 2.3.0
+    - fixed: 2.3.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-26271
+- GHSA-q263-fvxm-m5mw
+details: In affected versions of TensorFlow under certain cases, loading a saved model
+  can result in accessing uninitialized memory while building the computation graph.
+  The MakeEdge function creates an edge between one output tensor of the src node
+  (given by output_index) and the input slot of the dst node (given by input_index).
+  This is only possible if the types of the tensors on both sides coincide, so the
+  function begins by obtaining the corresponding DataType values and comparing these
+  for equality. However, there is no check that the indices point to inside of the
+  arrays they index into. Thus, this can result in accessing data out of bounds of
+  the corresponding heap allocated arrays. In most scenarios, this can manifest as
+  unitialized data access, but if the index points far away from the boundaries of
+  the arrays this can be used to leak addresses from the library. This is fixed in
+  versions 1.15.5, 2.0.4, 2.1.3, 2.2.2, 2.3.2, and 2.4.0.
+id: PYSEC-0000-CVE-2020-26271
+modified: '2021-08-27T03:22:23.329750Z'
+published: '2020-12-10T22:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-q263-fvxm-m5mw
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/0cc38aaa4064fd9e79101994ce9872c6d91f816b

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-5215.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2020-5215.yaml
@@ -1,0 +1,43 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 5ac1b9e24ff6afc465756edf845d2e9660bd34bf
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.2
+    - introduced: 2.0.0
+    - fixed: 2.0.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-5215
+- GHSA-977j-xj7q-2jr9
+details: In TensorFlow before 1.15.2 and 2.0.1, converting a string (from Python)
+  to a tf.float16 value results in a segmentation fault in eager mode as the format
+  checks for this use case are only in the graph mode. This issue can lead to denial
+  of service in inference/training where a malicious attacker can send a data point
+  which contains a string instead of a tf.float16 value. Similar effects can be obtained
+  by manipulating saved models and checkpoints whereby replacing a scalar tf.float16
+  value with a scalar string will trigger this issue due to automatic conversions.
+  This can be easily reproduced by tf.constant("hello", tf.float16), if eager execution
+  is enabled. This issue is patched in TensorFlow 1.15.1 and 2.0.1 with this vulnerability
+  patched. TensorFlow 2.1.0 was released after we fixed the issue, thus it is not
+  affected. Users are encouraged to switch to TensorFlow 1.15.1, 2.0.1 or 2.1.0.
+id: PYSEC-0000-CVE-2020-5215
+modified: '2021-08-27T03:22:23.423115Z'
+published: '2020-01-28T22:15:00Z'
+references:
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v1.15.2
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/5ac1b9e24ff6afc465756edf845d2e9660bd34bf
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.0.1
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-977j-xj7q-2jr9

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29512.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29512.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: eebb96c2830d48597d055d247c0e9aebaea94cd5
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29512
+- GHSA-4278-2v5v-65r4
+details: TensorFlow is an end-to-end open source platform for machine learning. If
+  the `splits` argument of `RaggedBincount` does not specify a valid `SparseTensor`(https://www.tensorflow.org/api_docs/python/tf/sparse/SparseTensor),
+  then an attacker can trigger a heap buffer overflow. This will cause a read from
+  outside the bounds of the `splits` tensor buffer in the implementation of the `RaggedBincount`
+  op(https://github.com/tensorflow/tensorflow/blob/8b677d79167799f71c42fd3fa074476e0295413a/tensorflow/core/kernels/bincount_op.cc#L430-L433).
+  Before the `for` loop, `batch_idx` is set to 0. The user controls the `splits` array,
+  making it contain only one element, 0. Thus, the code in the `while` loop would
+  increment `batch_idx` and then try to read `splits(1)`, which is outside of bounds.
+  The fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit
+  on TensorFlow 2.4.2 and TensorFlow 2.3.3, as these are also affected.
+id: PYSEC-0000-CVE-2021-29512
+modified: '2021-08-27T03:22:23.518786Z'
+published: '2021-05-14T19:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-4278-2v5v-65r4
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/eebb96c2830d48597d055d247c0e9aebaea94cd5

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29513.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29513.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 030af767d357d1b4088c4a25c72cb3906abac489
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29513
+- GHSA-452g-f7fp-9jf7
+details: TensorFlow is an end-to-end open source platform for machine learning. Calling
+  TF operations with tensors of non-numeric types when the operations expect numeric
+  tensors result in null pointer dereferences. The conversion from Python array to
+  C++ array(https://github.com/tensorflow/tensorflow/blob/ff70c47a396ef1e3cb73c90513da4f5cb71bebba/tensorflow/python/lib/core/ndarray_tensor.cc#L113-L169)
+  is vulnerable to a type confusion. The fix will be included in TensorFlow 2.5.0.
+  We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow
+  2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29513
+modified: '2021-08-27T03:22:23.682962Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/030af767d357d1b4088c4a25c72cb3906abac489
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-452g-f7fp-9jf7

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29514.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29514.yaml
@@ -1,0 +1,43 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: eebb96c2830d48597d055d247c0e9aebaea94cd5
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29514
+- GHSA-8h46-5m9h-7553
+details: TensorFlow is an end-to-end open source platform for machine learning. If
+  the `splits` argument of `RaggedBincount` does not specify a valid `SparseTensor`(https://www.tensorflow.org/api_docs/python/tf/sparse/SparseTensor),
+  then an attacker can trigger a heap buffer overflow. This will cause a read from
+  outside the bounds of the `splits` tensor buffer in the implementation of the `RaggedBincount`
+  op(https://github.com/tensorflow/tensorflow/blob/8b677d79167799f71c42fd3fa074476e0295413a/tensorflow/core/kernels/bincount_op.cc#L430-L446).
+  Before the `for` loop, `batch_idx` is set to 0. The attacker sets `splits(0)` to
+  be 7, hence the `while` loop does not execute and `batch_idx` remains 0. This then
+  results in writing to `out(-1, bin)`, which is before the heap allocated buffer
+  for the output tensor. The fix will be included in TensorFlow 2.5.0. We will also
+  cherrypick this commit on TensorFlow 2.4.2 and TensorFlow 2.3.3, as these are also
+  affected.
+id: PYSEC-0000-CVE-2021-29514
+modified: '2021-08-27T03:22:23.861341Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/eebb96c2830d48597d055d247c0e9aebaea94cd5
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-8h46-5m9h-7553

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29515.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29515.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: a7116dd3913c4a4afd2a3a938573aa7c785fdfc6
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29515
+- GHSA-hc6c-75p4-hmq4
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of `MatrixDiag*` operations(https://github.com/tensorflow/tensorflow/blob/4c4f420e68f1cfaf8f4b6e8e3eb857e9e4c3ff33/tensorflow/core/kernels/linalg/matrix_diag_op.cc#L195-L197)
+  does not validate that the tensor arguments are non-empty. The fix will be included
+  in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow
+  2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-29515
+modified: '2021-08-27T03:22:24.038004Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/a7116dd3913c4a4afd2a3a938573aa7c785fdfc6
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-hc6c-75p4-hmq4

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29516.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29516.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: b055b9c474cd376259dde8779908f9eeaf097d93
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29516
+- GHSA-84mw-34w6-2q43
+details: TensorFlow is an end-to-end open source platform for machine learning. Calling
+  `tf.raw_ops.RaggedTensorToVariant` with arguments specifying an invalid ragged tensor
+  results in a null pointer dereference. The implementation of `RaggedTensorToVariant`
+  operations(https://github.com/tensorflow/tensorflow/blob/904b3926ed1c6c70380d5313d282d248a776baa1/tensorflow/core/kernels/ragged_tensor_to_variant_op.cc#L39-L40)
+  does not validate that the ragged tensor argument is non-empty. Since `batched_ragged`
+  contains no elements, `batched_ragged.splits` is a null vector, thus `batched_ragged.splits(0)`
+  will result in dereferencing `nullptr`. The fix will be included in TensorFlow 2.5.0.
+  We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow
+  2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29516
+modified: '2021-08-27T03:22:24.214869Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-84mw-34w6-2q43
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/b055b9c474cd376259dde8779908f9eeaf097d93

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29517.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29517.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 799f835a3dfa00a4d852defa29b15841eea9d64f
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29517
+- GHSA-772p-x54p-hjrv
+details: TensorFlow is an end-to-end open source platform for machine learning. A
+  malicious user could trigger a division by 0 in `Conv3D` implementation. The implementation(https://github.com/tensorflow/tensorflow/blob/42033603003965bffac51ae171b51801565e002d/tensorflow/core/kernels/conv_ops_3d.cc#L143-L145)
+  does a modulo operation based on user controlled input. Thus, when `filter` has
+  a 0 as the fifth element, this results in a division by 0. Additionally, if the
+  shape of the two tensors is not valid, an Eigen assertion can be triggered, resulting
+  in a program crash. The fix will be included in TensorFlow 2.5.0. We will also cherrypick
+  this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow
+  2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29517
+modified: '2021-08-27T03:22:24.411852Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-772p-x54p-hjrv
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/799f835a3dfa00a4d852defa29b15841eea9d64f

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29518.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29518.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: ff70c47a396ef1e3cb73c90513da4f5cb71bebba
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29518
+- GHSA-62gx-355r-9fhg
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  eager mode (default in TF 2.0 and later), session operations are invalid. However,
+  users could still call the raw ops associated with them and trigger a null pointer
+  dereference. The implementation(https://github.com/tensorflow/tensorflow/blob/eebb96c2830d48597d055d247c0e9aebaea94cd5/tensorflow/core/kernels/session_ops.cc#L104)
+  dereferences the session state pointer without checking if it is valid. Thus, in
+  eager mode, `ctx->session_state()` is nullptr and the call of the member function
+  is undefined behavior. The fix will be included in TensorFlow 2.5.0. We will also
+  cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and
+  TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29518
+modified: '2021-08-27T03:22:24.585448Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/ff70c47a396ef1e3cb73c90513da4f5cb71bebba
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-62gx-355r-9fhg

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29519.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29519.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: b1cc5e5a50e7cee09f2c6eb48eb40ee9c4125025
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29519
+- GHSA-772j-h9xw-ffp5
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  API of `tf.raw_ops.SparseCross` allows combinations which would result in a `CHECK`-failure
+  and denial of service. This is because the implementation(https://github.com/tensorflow/tensorflow/blob/3d782b7d47b1bf2ed32bd4a246d6d6cadc4c903d/tensorflow/core/kernels/sparse_cross_op.cc#L114-L116)
+  is tricked to consider a tensor of type `tstring` which in fact contains integral
+  elements. Fixing the type confusion by preventing mixing `DT_STRING` and `DT_INT64`
+  types solves this issue. The fix will be included in TensorFlow 2.5.0. We will also
+  cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and
+  TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29519
+modified: '2021-08-27T03:22:24.765492Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-772j-h9xw-ffp5
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/b1cc5e5a50e7cee09f2c6eb48eb40ee9c4125025

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29520.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29520.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 8f37b52e1320d8d72a9529b2468277791a261197
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29520
+- GHSA-wcv5-qrj6-9pfm
+details: TensorFlow is an end-to-end open source platform for machine learning. Missing
+  validation between arguments to `tf.raw_ops.Conv3DBackprop*` operations can result
+  in heap buffer overflows. This is because the implementation(https://github.com/tensorflow/tensorflow/blob/4814fafb0ca6b5ab58a09411523b2193fed23fed/tensorflow/core/kernels/conv_grad_shape_utils.cc#L94-L153)
+  assumes that the `input`, `filter_sizes` and `out_backprop` tensors have the same
+  shape, as they are accessed in parallel. The fix will be included in TensorFlow
+  2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3,
+  TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported
+  range.
+id: PYSEC-0000-CVE-2021-29520
+modified: '2021-08-27T03:22:24.934633Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/8f37b52e1320d8d72a9529b2468277791a261197
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-wcv5-qrj6-9pfm

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29521.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29521.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: c57c0b9f3a4f8684f3489dd9a9ec627ad8b599f5
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29521
+- GHSA-hr84-fqvp-48mm
+details: TensorFlow is an end-to-end open source platform for machine learning. Specifying
+  a negative dense shape in `tf.raw_ops.SparseCountSparseOutput` results in a segmentation
+  fault being thrown out from the standard library as `std::vector` invariants are
+  broken. This is because the implementation(https://github.com/tensorflow/tensorflow/blob/8f7b60ee8c0206a2c99802e3a4d1bb55d2bc0624/tensorflow/core/kernels/count_ops.cc#L199-L213)
+  assumes the first element of the dense shape is always positive and uses it to initialize
+  a `BatchedMap<T>` (i.e., `std::vector<absl::flat_hash_map<int64,T>>`(https://github.com/tensorflow/tensorflow/blob/8f7b60ee8c0206a2c99802e3a4d1bb55d2bc0624/tensorflow/core/kernels/count_ops.cc#L27))
+  data structure. If the `shape` tensor has more than one element, `num_batches` is
+  the first value in `shape`. Ensuring that the `dense_shape` argument is a valid
+  tensor shape (that is, all elements are non-negative) solves this issue. The fix
+  will be included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2 and TensorFlow 2.3.3.
+id: PYSEC-0000-CVE-2021-29521
+modified: '2021-08-27T03:22:25.027733Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/c57c0b9f3a4f8684f3489dd9a9ec627ad8b599f5
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-hr84-fqvp-48mm

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29522.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29522.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 311403edbc9816df80274bd1ea8b3c0c0f22c3fa
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29522
+- GHSA-c968-pq7h-7fxv
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  `tf.raw_ops.Conv3DBackprop*` operations fail to validate that the input tensors
+  are not empty. In turn, this would result in a division by 0. This is because the
+  implementation(https://github.com/tensorflow/tensorflow/blob/a91bb59769f19146d5a0c20060244378e878f140/tensorflow/core/kernels/conv_grad_ops_3d.cc#L430-L450)
+  does not check that the divisor used in computing the shard size is not zero. Thus,
+  if attacker controls the input sizes, they can trigger a denial of service via a
+  division by zero error. The fix will be included in TensorFlow 2.5.0. We will also
+  cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and
+  TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29522
+modified: '2021-08-27T03:22:25.206676Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-c968-pq7h-7fxv
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/311403edbc9816df80274bd1ea8b3c0c0f22c3fa

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29523.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29523.yaml
@@ -1,0 +1,43 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 69c68ecbb24dff3fa0e46da0d16c821a2dd22d7c
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29523
+- GHSA-2cpx-427x-q2c6
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a denial of service via a `CHECK`-fail in `tf.raw_ops.AddManySparseToTensorsMap`.
+  This is because the implementation(https://github.com/tensorflow/tensorflow/blob/6f9896890c4c703ae0a0845394086e2e1e523299/tensorflow/core/kernels/sparse_tensors_map_ops.cc#L257)
+  takes the values specified in `sparse_shape` as dimensions for the output shape.
+  The `TensorShape` constructor(https://github.com/tensorflow/tensorflow/blob/6f9896890c4c703ae0a0845394086e2e1e523299/tensorflow/core/framework/tensor_shape.cc#L183-L188)
+  uses a `CHECK` operation which triggers when `InitDims`(https://github.com/tensorflow/tensorflow/blob/6f9896890c4c703ae0a0845394086e2e1e523299/tensorflow/core/framework/tensor_shape.cc#L212-L296)
+  returns a non-OK status. This is a legacy implementation of the constructor and
+  operations should use `BuildTensorShapeBase` or `AddDimWithStatus` to prevent `CHECK`-failures
+  in the presence of overflows. The fix will be included in TensorFlow 2.5.0. We will
+  also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3
+  and TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29523
+modified: '2021-08-27T03:22:25.367237Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/69c68ecbb24dff3fa0e46da0d16c821a2dd22d7c
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-2cpx-427x-q2c6

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29524.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29524.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: fca9874a9b42a2134f907d2fb46ab774a831404a
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29524
+- GHSA-r4pj-74mg-8868
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a division by 0 in `tf.raw_ops.Conv2DBackpropFilter`. This
+  is because the implementation(https://github.com/tensorflow/tensorflow/blob/496c2630e51c1a478f095b084329acedb253db6b/tensorflow/core/kernels/conv_grad_shape_utils.cc#L130)
+  does a modulus operation where the divisor is controlled by the caller. The fix
+  will be included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29524
+modified: '2021-08-27T03:22:25.604287Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/fca9874a9b42a2134f907d2fb46ab774a831404a
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-r4pj-74mg-8868

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29525.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29525.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 2be2cdf3a123e231b16f766aa0e27d56b4606535
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29525
+- GHSA-xm2v-8rrw-w9pm
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a division by 0 in `tf.raw_ops.Conv2DBackpropInput`. This is
+  because the implementation(https://github.com/tensorflow/tensorflow/blob/b40060c9f697b044e3107917c797ba052f4506ab/tensorflow/core/kernels/conv_grad_input_ops.h#L625-L655)
+  does a division by a quantity that is controlled by the caller. The fix will be
+  included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29525
+modified: '2021-08-27T03:22:25.775857Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-xm2v-8rrw-w9pm
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/2be2cdf3a123e231b16f766aa0e27d56b4606535

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29526.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29526.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: b12aa1d44352de21d1a6faaf04172d8c2508b42b
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29526
+- GHSA-4vf2-4xcg-65cx
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a division by 0 in `tf.raw_ops.Conv2D`. This is because the
+  implementation(https://github.com/tensorflow/tensorflow/blob/988087bd83f144af14087fe4fecee2d250d93737/tensorflow/core/kernels/conv_ops.cc#L261-L263)
+  does a division by a quantity that is controlled by the caller. The fix will be
+  included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29526
+modified: '2021-08-27T03:22:25.990763Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-4vf2-4xcg-65cx
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/b12aa1d44352de21d1a6faaf04172d8c2508b42b

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29527.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29527.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: cfa91be9863a91d5105a3b4941096044ab32036b
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29527
+- GHSA-x4g7-fvjj-prg8
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a division by 0 in `tf.raw_ops.QuantizedConv2D`. This is because
+  the implementation(https://github.com/tensorflow/tensorflow/blob/00e9a4d67d76703fa1aee33dac582acf317e0e81/tensorflow/core/kernels/quantized_conv_ops.cc#L257-L259)
+  does a division by a quantity that is controlled by the caller. The fix will be
+  included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29527
+modified: '2021-08-27T03:22:26.181060Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/cfa91be9863a91d5105a3b4941096044ab32036b
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-x4g7-fvjj-prg8

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29528.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29528.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: a1b11d2fdd1e51bfe18bb1ede804f60abfa92da6
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29528
+- GHSA-6f84-42vf-ppwp
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a division by 0 in `tf.raw_ops.QuantizedMul`. This is because
+  the implementation(https://github.com/tensorflow/tensorflow/blob/55900e961ed4a23b438392024912154a2c2f5e85/tensorflow/core/kernels/quantized_mul_op.cc#L188-L198)
+  does a division by a quantity that is controlled by the caller. The fix will be
+  included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29528
+modified: '2021-08-27T03:22:26.348588Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/a1b11d2fdd1e51bfe18bb1ede804f60abfa92da6
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-6f84-42vf-ppwp

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29529.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29529.yaml
@@ -1,0 +1,45 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: f851613f8f0fb0c838d160ced13c134f778e3ce7
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29529
+- GHSA-jfp7-4j67-8r3q
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a heap buffer overflow in `tf.raw_ops.QuantizedResizeBilinear`
+  by manipulating input values so that float rounding results in off-by-one error
+  in accessing image elements. This is because the implementation(https://github.com/tensorflow/tensorflow/blob/44b7f486c0143f68b56c34e2d01e146ee445134a/tensorflow/core/kernels/quantized_resize_bilinear_op.cc#L62-L66)
+  computes two integers (representing the upper and lower bounds for interpolation)
+  by ceiling and flooring a floating point value. For some values of `in`, `interpolation->upper[i]`
+  might be smaller than `interpolation->lower[i]`. This is an issue if `interpolation->upper[i]`
+  is capped at `in_size-1` as it means that `interpolation->lower[i]` points outside
+  of the image. Then, in the interpolation code(https://github.com/tensorflow/tensorflow/blob/44b7f486c0143f68b56c34e2d01e146ee445134a/tensorflow/core/kernels/quantized_resize_bilinear_op.cc#L245-L264),
+  this would result in heap buffer overflow. The fix will be included in TensorFlow
+  2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3,
+  TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported
+  range.
+id: PYSEC-0000-CVE-2021-29529
+modified: '2021-08-27T03:22:26.519373Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/f851613f8f0fb0c838d160ced13c134f778e3ce7
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-jfp7-4j67-8r3q

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29530.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29530.yaml
@@ -1,0 +1,45 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: e6a7c7cc18c3aaad1ae0872cb0a959f5c923d2bd
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29530
+- GHSA-xcwj-wfcm-m23c
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a null pointer dereference by providing an invalid `permutation`
+  to `tf.raw_ops.SparseMatrixSparseCholesky`. This is because the implementation(https://github.com/tensorflow/tensorflow/blob/080f1d9e257589f78b3ffb75debf584168aa6062/tensorflow/core/kernels/sparse/sparse_cholesky_op.cc#L85-L86)
+  fails to properly validate the input arguments. Although `ValidateInputs` is called
+  and there are checks in the body of this function, the code proceeds to the next
+  line in `ValidateInputs` since `OP_REQUIRES`(https://github.com/tensorflow/tensorflow/blob/080f1d9e257589f78b3ffb75debf584168aa6062/tensorflow/core/framework/op_requires.h#L41-L48)
+  is a macro that only exits the current function. Thus, the first validation condition
+  that fails in `ValidateInputs` will cause an early return from that function. However,
+  the caller will continue execution from the next line. The fix is to either explicitly
+  check `context->status()` or to convert `ValidateInputs` to return a `Status`. The
+  fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit on
+  TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29530
+modified: '2021-08-27T03:22:26.683297Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-xcwj-wfcm-m23c
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/e6a7c7cc18c3aaad1ae0872cb0a959f5c923d2bd

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29531.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29531.yaml
@@ -1,0 +1,45 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 26eb323554ffccd173e8a79a8c05c15b685ae4d1
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29531
+- GHSA-3qxp-qjq7-w4hf
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a `CHECK` fail in PNG encoding by providing an empty input
+  tensor as the pixel data. This is because the implementation(https://github.com/tensorflow/tensorflow/blob/e312e0791ce486a80c9d23110841525c6f7c3289/tensorflow/core/kernels/image/encode_png_op.cc#L57-L60)
+  only validates that the total number of pixels in the image does not overflow. Thus,
+  an attacker can send an empty matrix for encoding. However, if the tensor is empty,
+  then the associated buffer is `nullptr`. Hence, when calling `png::WriteImageToBuffer`(https://github.com/tensorflow/tensorflow/blob/e312e0791ce486a80c9d23110841525c6f7c3289/tensorflow/core/kernels/image/encode_png_op.cc#L79-L93),
+  the first argument (i.e., `image.flat<T>().data()`) is `NULL`. This then triggers
+  the `CHECK_NOTNULL` in the first line of `png::WriteImageToBuffer`(https://github.com/tensorflow/tensorflow/blob/e312e0791ce486a80c9d23110841525c6f7c3289/tensorflow/core/lib/png/png_io.cc#L345-L349).
+  Since `image` is null, this results in `abort` being called after printing the stacktrace.
+  Effectively, this allows an attacker to mount a denial of service attack. The fix
+  will be included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29531
+modified: '2021-08-27T03:22:26.851089Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/26eb323554ffccd173e8a79a8c05c15b685ae4d1
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-3qxp-qjq7-w4hf

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29532.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29532.yaml
@@ -1,0 +1,42 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 44b7f486c0143f68b56c34e2d01e146ee445134a
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29532
+- GHSA-j47f-4232-hvv8
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can force accesses outside the bounds of heap allocated arrays by passing
+  in invalid tensor values to `tf.raw_ops.RaggedCross`. This is because the implementation(https://github.com/tensorflow/tensorflow/blob/efea03b38fb8d3b81762237dc85e579cc5fc6e87/tensorflow/core/kernels/ragged_cross_op.cc#L456-L487)
+  lacks validation for the user supplied arguments. Each of the above branches call
+  a helper function after accessing array elements via a `*_list[next_*]` pattern,
+  followed by incrementing the `next_*` index. However, as there is no validation
+  that the `next_*` values are in the valid range for the corresponding `*_list` arrays,
+  this results in heap OOB reads. The fix will be included in TensorFlow 2.5.0. We
+  will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow
+  2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29532
+modified: '2021-08-27T03:22:27.051975Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/44b7f486c0143f68b56c34e2d01e146ee445134a
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-j47f-4232-hvv8

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29533.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29533.yaml
@@ -1,0 +1,43 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: b432a38fe0e1b4b904a6c222cbce794c39703e87
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29533
+- GHSA-393f-2jr3-cp69
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a denial of service via a `CHECK` failure by passing an empty
+  image to `tf.raw_ops.DrawBoundingBoxes`. This is because the implementation(https://github.com/tensorflow/tensorflow/blob/ea34a18dc3f5c8d80a40ccca1404f343b5d55f91/tensorflow/core/kernels/image/draw_bounding_box_op.cc#L148-L165)
+  uses `CHECK_*` assertions instead of `OP_REQUIRES` to validate user controlled inputs.
+  Whereas `OP_REQUIRES` allows returning an error condition back to the user, the
+  `CHECK_*` macros result in a crash if the condition is false, similar to `assert`.
+  In this case, `height` is 0 from the `images` input. This results in `max_box_row_clamp`
+  being negative and the assertion being falsified, followed by aborting program execution.
+  The fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit
+  on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as
+  these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29533
+modified: '2021-08-27T03:22:27.240459Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-393f-2jr3-cp69
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/b432a38fe0e1b4b904a6c222cbce794c39703e87

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29534.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29534.yaml
@@ -1,0 +1,43 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 69c68ecbb24dff3fa0e46da0d16c821a2dd22d7c
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29534
+- GHSA-6j9c-grc6-5m6g
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a denial of service via a `CHECK`-fail in `tf.raw_ops.SparseConcat`.
+  This is because the implementation(https://github.com/tensorflow/tensorflow/blob/b432a38fe0e1b4b904a6c222cbce794c39703e87/tensorflow/core/kernels/sparse_concat_op.cc#L76)
+  takes the values specified in `shapes[0]` as dimensions for the output shape. The
+  `TensorShape` constructor(https://github.com/tensorflow/tensorflow/blob/6f9896890c4c703ae0a0845394086e2e1e523299/tensorflow/core/framework/tensor_shape.cc#L183-L188)
+  uses a `CHECK` operation which triggers when `InitDims`(https://github.com/tensorflow/tensorflow/blob/6f9896890c4c703ae0a0845394086e2e1e523299/tensorflow/core/framework/tensor_shape.cc#L212-L296)
+  returns a non-OK status. This is a legacy implementation of the constructor and
+  operations should use `BuildTensorShapeBase` or `AddDimWithStatus` to prevent `CHECK`-failures
+  in the presence of overflows. The fix will be included in TensorFlow 2.5.0. We will
+  also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3
+  and TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29534
+modified: '2021-08-27T03:22:27.421981Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/69c68ecbb24dff3fa0e46da0d16c821a2dd22d7c
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-6j9c-grc6-5m6g

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29535.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29535.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: efea03b38fb8d3b81762237dc85e579cc5fc6e87
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29535
+- GHSA-m3f9-w3p3-p669
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a heap buffer overflow in `QuantizedMul` by passing in invalid
+  thresholds for the quantization. This is because the implementation(https://github.com/tensorflow/tensorflow/blob/87cf4d3ea9949051e50ca3f071fc909538a51cd0/tensorflow/core/kernels/quantized_mul_op.cc#L287-L290)
+  assumes that the 4 arguments are always valid scalars and tries to access the numeric
+  value directly. However, if any of these tensors is empty, then `.flat<T>()` is
+  an empty buffer and accessing the element at position 0 results in overflow. The
+  fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit on
+  TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29535
+modified: '2021-08-27T03:22:27.629630Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-m3f9-w3p3-p669
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/efea03b38fb8d3b81762237dc85e579cc5fc6e87

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29536.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29536.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: a324ac84e573fba362a5e53d4e74d5de6729933e
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29536
+- GHSA-2gfx-95x2-5v3x
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a heap buffer overflow in `QuantizedReshape` by passing in invalid
+  thresholds for the quantization. This is because the implementation(https://github.com/tensorflow/tensorflow/blob/a324ac84e573fba362a5e53d4e74d5de6729933e/tensorflow/core/kernels/quantized_reshape_op.cc#L38-L55)
+  assumes that the 2 arguments are always valid scalars and tries to access the numeric
+  value directly. However, if any of these tensors is empty, then `.flat<T>()` is
+  an empty buffer and accessing the element at position 0 results in overflow. The
+  fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit on
+  TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29536
+modified: '2021-08-27T03:22:27.845923Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-2gfx-95x2-5v3x
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/a324ac84e573fba362a5e53d4e74d5de6729933e

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29537.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29537.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: f6c40f0c6cbf00d46c7717a26419f2062f2f8694
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29537
+- GHSA-8c89-2vwr-chcq
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a heap buffer overflow in `QuantizedResizeBilinear` by passing
+  in invalid thresholds for the quantization. This is because the implementation(https://github.com/tensorflow/tensorflow/blob/50711818d2e61ccce012591eeb4fdf93a8496726/tensorflow/core/kernels/quantized_resize_bilinear_op.cc#L705-L706)
+  assumes that the 2 arguments are always valid scalars and tries to access the numeric
+  value directly. The fix will be included in TensorFlow 2.5.0. We will also cherrypick
+  this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow
+  2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29537
+modified: '2021-08-27T03:22:28.012732Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-8c89-2vwr-chcq
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/f6c40f0c6cbf00d46c7717a26419f2062f2f8694

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29538.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29538.yaml
@@ -1,0 +1,42 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: c570e2ecfc822941335ad48f6e10df4e21f11c96
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29538
+- GHSA-j8qc-5fqr-52fp
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a division by zero to occur in `Conv2DBackpropFilter`. This is
+  because the implementation(https://github.com/tensorflow/tensorflow/blob/1b0296c3b8dd9bd948f924aa8cd62f87dbb7c3da/tensorflow/core/kernels/conv_grad_filter_ops.cc#L513-L522)
+  computes a divisor based on user provided data (i.e., the shape of the tensors given
+  as arguments). If all shapes are empty then `work_unit_size` is 0. Since there is
+  no check for this case before division, this results in a runtime exception, with
+  potential to be abused for a denial of service. The fix will be included in TensorFlow
+  2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3,
+  TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported
+  range.
+id: PYSEC-0000-CVE-2021-29538
+modified: '2021-08-27T03:22:28.180235Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/c570e2ecfc822941335ad48f6e10df4e21f11c96
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-j8qc-5fqr-52fp

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29539.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29539.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 4f663d4b8f0bec1b48da6fa091a7d29609980fa4
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29539
+- GHSA-g4h2-gqm3-c9wq
+details: TensorFlow is an end-to-end open source platform for machine learning. Calling
+  `tf.raw_ops.ImmutableConst`(https://www.tensorflow.org/api_docs/python/tf/raw_ops/ImmutableConst)
+  with a `dtype` of `tf.resource` or `tf.variant` results in a segfault in the implementation
+  as code assumes that the tensor contents are pure scalars. We have patched the issue
+  in 4f663d4b8f0bec1b48da6fa091a7d29609980fa4 and will release TensorFlow 2.5.0 containing
+  the patch. TensorFlow nightly packages after this commit will also have the issue
+  resolved. If using `tf.raw_ops.ImmutableConst` in code, you can prevent the segfault
+  by inserting a filter for the `dtype` argument.
+id: PYSEC-0000-CVE-2021-29539
+modified: '2021-08-27T03:22:28.395200Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-g4h2-gqm3-c9wq
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/4f663d4b8f0bec1b48da6fa091a7d29609980fa4

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29540.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29540.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: c570e2ecfc822941335ad48f6e10df4e21f11c96
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29540
+- GHSA-xgc3-m89p-vr3x
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a heap buffer overflow to occur in `Conv2DBackpropFilter`. This
+  is because the implementation(https://github.com/tensorflow/tensorflow/blob/1b0296c3b8dd9bd948f924aa8cd62f87dbb7c3da/tensorflow/core/kernels/conv_grad_filter_ops.cc#L495-L497)
+  computes the size of the filter tensor but does not validate that it matches the
+  number of elements in `filter_sizes`. Later, when reading/writing to this buffer,
+  code uses the value computed here, instead of the number of elements in the tensor.
+  The fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit
+  on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as
+  these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29540
+modified: '2021-08-27T03:22:28.584780Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-xgc3-m89p-vr3x
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/c570e2ecfc822941335ad48f6e10df4e21f11c96

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29541.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29541.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: ba424dd8f16f7110eea526a8086f1a155f14f22b
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29541
+- GHSA-xqfj-35wv-m3cr
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a dereference of a null pointer in `tf.raw_ops.StringNGrams`.
+  This is because the implementation(https://github.com/tensorflow/tensorflow/blob/1cdd4da14282210cc759e468d9781741ac7d01bf/tensorflow/core/kernels/string_ngrams_op.cc#L67-L74)
+  does not fully validate the `data_splits` argument. This would result in `ngrams_data`(https://github.com/tensorflow/tensorflow/blob/1cdd4da14282210cc759e468d9781741ac7d01bf/tensorflow/core/kernels/string_ngrams_op.cc#L106-L110)
+  to be a null pointer when the output would be computed to have 0 or negative size.
+  Later writes to the output tensor would then cause a null pointer dereference. The
+  fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit on
+  TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29541
+modified: '2021-08-27T03:22:28.768951Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/ba424dd8f16f7110eea526a8086f1a155f14f22b
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-xqfj-35wv-m3cr

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29542.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29542.yaml
@@ -1,0 +1,42 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: ba424dd8f16f7110eea526a8086f1a155f14f22b
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29542
+- GHSA-4hrh-9vmp-2jgg
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a heap buffer overflow by passing crafted inputs to `tf.raw_ops.StringNGrams`.
+  This is because the implementation(https://github.com/tensorflow/tensorflow/blob/1cdd4da14282210cc759e468d9781741ac7d01bf/tensorflow/core/kernels/string_ngrams_op.cc#L171-L185)
+  fails to consider corner cases where input would be split in such a way that the
+  generated tokens should only contain padding elements. If input is such that `num_tokens`
+  is 0, then, for `data_start_index=0` (when left padding is present), the marked
+  line would result in reading `data[-1]`. The fix will be included in TensorFlow
+  2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3,
+  TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported
+  range.
+id: PYSEC-0000-CVE-2021-29542
+modified: '2021-08-27T03:22:28.937409Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-4hrh-9vmp-2jgg
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/ba424dd8f16f7110eea526a8086f1a155f14f22b

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29543.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29543.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: ea3b43e98c32c97b35d52b4c66f9107452ca8fb2
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29543
+- GHSA-fphq-gw9m-ghrv
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a denial of service via a `CHECK`-fail in `tf.raw_ops.CTCGreedyDecoder`.
+  This is because the implementation(https://github.com/tensorflow/tensorflow/blob/1615440b17b364b875eb06f43d087381f1460a65/tensorflow/core/kernels/ctc_decoder_ops.cc#L37-L50)
+  has a `CHECK_LT` inserted to validate some invariants. When this condition is false,
+  the program aborts, instead of returning a valid error to the user. This abnormal
+  termination can be weaponized in denial of service attacks. The fix will be included
+  in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow
+  2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-29543
+modified: '2021-08-27T03:22:29.100995Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/ea3b43e98c32c97b35d52b4c66f9107452ca8fb2
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-fphq-gw9m-ghrv

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29544.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29544.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 20431e9044cf2ad3c0323c34888b192f3289af6b
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29544
+- GHSA-6g85-3hm8-83f9
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a denial of service via a `CHECK`-fail in `tf.raw_ops.QuantizeAndDequantizeV4Grad`.
+  This is because the implementation(https://github.com/tensorflow/tensorflow/blob/95078c145b5a7a43ee046144005f733092756ab5/tensorflow/core/kernels/quantize_and_dequantize_op.cc#L162-L163)
+  does not validate the rank of the `input_*` tensors. In turn, this results in the
+  tensors being passes as they are to `QuantizeAndDequantizePerChannelGradientImpl`(https://github.com/tensorflow/tensorflow/blob/95078c145b5a7a43ee046144005f733092756ab5/tensorflow/core/kernels/quantize_and_dequantize_op.h#L295-L306).
+  However, the `vec<T>` method, requires the rank to 1 and triggers a `CHECK` failure
+  otherwise. The fix will be included in TensorFlow 2.5.0. We will also cherrypick
+  this commit on TensorFlow 2.4.2 as this is the only other affected version.
+id: PYSEC-0000-CVE-2021-29544
+modified: '2021-08-27T03:22:29.285990Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/20431e9044cf2ad3c0323c34888b192f3289af6b
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-6g85-3hm8-83f9

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29545.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29545.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 1e922ccdf6bf46a3a52641f99fd47d54c1decd13
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29545
+- GHSA-hmg3-c7xj-6qwm
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a denial of service via a `CHECK`-fail in converting sparse
+  tensors to CSR Sparse matrices. This is because the implementation(https://github.com/tensorflow/tensorflow/blob/800346f2c03a27e182dd4fba48295f65e7790739/tensorflow/core/kernels/sparse/kernels.cc#L66)
+  does a double redirection to access an element of an array allocated on the heap.
+  If the value at `indices(i, 0)` is such that `indices(i, 0) + 1` is outside the
+  bounds of `csr_row_ptr`, this results in writing outside of bounds of heap allocated
+  data. The fix will be included in TensorFlow 2.5.0. We will also cherrypick this
+  commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4,
+  as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29545
+modified: '2021-08-27T03:22:29.446413Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-hmg3-c7xj-6qwm
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/1e922ccdf6bf46a3a52641f99fd47d54c1decd13

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29546.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29546.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 67784700869470d65d5f2ef20aeb5e97c31673cb
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29546
+- GHSA-m34j-p8rj-wjxq
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger an integer division by zero undefined behavior in `tf.raw_ops.QuantizedBiasAdd`.
+  This is because the implementation of the Eigen kernel(https://github.com/tensorflow/tensorflow/blob/61bca8bd5ba8a68b2d97435ddfafcdf2b85672cd/tensorflow/core/kernels/quantization_utils.h#L812-L849)
+  does a division by the number of elements of the smaller input (based on shape)
+  without checking that this is not zero. The fix will be included in TensorFlow 2.5.0.
+  We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow
+  2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29546
+modified: '2021-08-27T03:22:29.613359Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/67784700869470d65d5f2ef20aeb5e97c31673cb
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-m34j-p8rj-wjxq

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29547.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29547.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: d6ed5bcfe1dcab9e85a4d39931bd18d99018e75b
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29547
+- GHSA-4fg4-p75j-w5xj
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a segfault and denial of service via accessing data outside of
+  bounds in `tf.raw_ops.QuantizedBatchNormWithGlobalNormalization`. This is because
+  the implementation(https://github.com/tensorflow/tensorflow/blob/55a97caa9e99c7f37a0bbbeb414dc55553d3ae7f/tensorflow/core/kernels/quantized_batch_norm_op.cc#L176-L189)
+  assumes the inputs are not empty. If any of these inputs is empty, `.flat<T>()`
+  is an empty buffer, so accessing the element at index 0 is accessing data outside
+  of bounds. The fix will be included in TensorFlow 2.5.0. We will also cherrypick
+  this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow
+  2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29547
+modified: '2021-08-27T03:22:29.791310Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-4fg4-p75j-w5xj
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/d6ed5bcfe1dcab9e85a4d39931bd18d99018e75b

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29548.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29548.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: d6ed5bcfe1dcab9e85a4d39931bd18d99018e75b
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29548
+- GHSA-p45v-v4pw-77jr
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a runtime division by zero error and denial of service in `tf.raw_ops.QuantizedBatchNormWithGlobalNormalization`.
+  This is because the implementation(https://github.com/tensorflow/tensorflow/blob/55a97caa9e99c7f37a0bbbeb414dc55553d3ae7f/tensorflow/core/kernels/quantized_batch_norm_op.cc)
+  does not validate all constraints specified in the op's contract(https://www.tensorflow.org/api_docs/python/tf/raw_ops/QuantizedBatchNormWithGlobalNormalization).
+  The fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit
+  on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as
+  these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29548
+modified: '2021-08-27T03:22:29.986611Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/d6ed5bcfe1dcab9e85a4d39931bd18d99018e75b
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-p45v-v4pw-77jr

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29549.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29549.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 744009c9e5cc5d0447f0dc39d055f917e1fd9e16
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29549
+- GHSA-x83m-p7pv-ch8v
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a runtime division by zero error and denial of service in `tf.raw_ops.QuantizedBatchNormWithGlobalNormalization`.
+  This is because the implementation(https://github.com/tensorflow/tensorflow/blob/6f26b3f3418201479c264f2a02000880d8df151c/tensorflow/core/kernels/quantized_add_op.cc#L289-L295)
+  computes a modulo operation without validating that the divisor is not zero. Since
+  `vector_num_elements` is determined based on input shapes(https://github.com/tensorflow/tensorflow/blob/6f26b3f3418201479c264f2a02000880d8df151c/tensorflow/core/kernels/quantized_add_op.cc#L522-L544),
+  a user can trigger scenarios where this quantity is 0. The fix will be included
+  in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow
+  2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-29549
+modified: '2021-08-27T03:22:30.167299Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-x83m-p7pv-ch8v
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/744009c9e5cc5d0447f0dc39d055f917e1fd9e16

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29550.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29550.yaml
@@ -1,0 +1,47 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 548b5eaf23685d86f722233d8fbc21d0a4aecb96
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29550
+- GHSA-f78g-q7r4-9wcv
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a runtime division by zero error and denial of service in `tf.raw_ops.FractionalAvgPool`.
+  This is because the implementation(https://github.com/tensorflow/tensorflow/blob/acc8ee69f5f46f92a3f1f11230f49c6ac266f10c/tensorflow/core/kernels/fractional_avg_pool_op.cc#L85-L89)
+  computes a divisor quantity by dividing two user controlled values. The user controls
+  the values of `input_size[i]` and `pooling_ratio_[i]` (via the `value.shape()` and
+  `pooling_ratio` arguments). If the value in `input_size[i]` is smaller than the
+  `pooling_ratio_[i]`, then the floor operation results in `output_size[i]` being
+  0. The `DCHECK_GT` line is a no-op outside of debug mode, so in released versions
+  of TF this does not trigger. Later, these computed values are used as arguments(https://github.com/tensorflow/tensorflow/blob/acc8ee69f5f46f92a3f1f11230f49c6ac266f10c/tensorflow/core/kernels/fractional_avg_pool_op.cc#L96-L99)
+  to `GeneratePoolingSequence`(https://github.com/tensorflow/tensorflow/blob/acc8ee69f5f46f92a3f1f11230f49c6ac266f10c/tensorflow/core/kernels/fractional_pool_common.cc#L100-L108).
+  There, the first computation is a division in a modulo operation. Since `output_length`
+  can be 0, this results in runtime crashing. The fix will be included in TensorFlow
+  2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3,
+  TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported
+  range.
+id: PYSEC-0000-CVE-2021-29550
+modified: '2021-08-27T03:22:30.332227Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-f78g-q7r4-9wcv
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/548b5eaf23685d86f722233d8fbc21d0a4aecb96

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29551.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29551.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 480641e3599775a8895254ffbc0fc45621334f68
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29551
+- GHSA-vqw6-72r7-fgw7
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of `MatrixTriangularSolve`(https://github.com/tensorflow/tensorflow/blob/8cae746d8449c7dda5298327353d68613f16e798/tensorflow/core/kernels/linalg/matrix_triangular_solve_op_impl.h#L160-L240)
+  fails to terminate kernel execution if one validation condition fails. The fix will
+  be included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29551
+modified: '2021-08-27T03:22:30.499582Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/480641e3599775a8895254ffbc0fc45621334f68
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-vqw6-72r7-fgw7

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29552.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29552.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 704866eabe03a9aeda044ec91a8d0c83fc1ebdbe
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29552
+- GHSA-jhq9-wm9m-cf89
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a denial of service by controlling the values of `num_segments`
+  tensor argument for `UnsortedSegmentJoin`. This is because the implementation(https://github.com/tensorflow/tensorflow/blob/a2a607db15c7cd01d754d37e5448d72a13491bdb/tensorflow/core/kernels/unsorted_segment_join_op.cc#L92-L93)
+  assumes that the `num_segments` tensor is a valid scalar. Since the tensor is empty
+  the `CHECK` involved in `.scalar<T>()()` that checks that the number of elements
+  is exactly 1 will be invalidated and this would result in process termination. The
+  fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit on
+  TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29552
+modified: '2021-08-27T03:22:30.663551Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-jhq9-wm9m-cf89
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/704866eabe03a9aeda044ec91a8d0c83fc1ebdbe

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29553.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29553.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 99085e8ff02c3763a0ec2263e44daec416f6a387
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29553
+- GHSA-h9px-9vqg-222h
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can read data outside of bounds of heap allocated buffer in `tf.raw_ops.QuantizeAndDequantizeV3`.
+  This is because the implementation(https://github.com/tensorflow/tensorflow/blob/11ff7f80667e6490d7b5174aa6bf5e01886e770f/tensorflow/core/kernels/quantize_and_dequantize_op.cc#L237)
+  does not validate the value of user supplied `axis` attribute before using it to
+  index in the array backing the `input` argument. The fix will be included in TensorFlow
+  2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3,
+  TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported
+  range.
+id: PYSEC-0000-CVE-2021-29553
+modified: '2021-08-27T03:22:30.834118Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/99085e8ff02c3763a0ec2263e44daec416f6a387
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-h9px-9vqg-222h

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29554.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29554.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: da5ff2daf618591f64b2b62d9d9803951b945e9f
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29554
+- GHSA-qg48-85hg-mqc5
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a denial of service via a FPE runtime error in `tf.raw_ops.DenseCountSparseOutput`.
+  This is because the implementation(https://github.com/tensorflow/tensorflow/blob/efff014f3b2d8ef6141da30c806faf141297eca1/tensorflow/core/kernels/count_ops.cc#L123-L127)
+  computes a divisor value from user data but does not check that the result is 0
+  before doing the division. Since `data` is given by the `values` argument, `num_batch_elements`
+  is 0. The fix will be included in TensorFlow 2.5.0. We will also cherrypick this
+  commit on TensorFlow 2.4.2, and TensorFlow 2.3.3, as these are also affected.
+id: PYSEC-0000-CVE-2021-29554
+modified: '2021-08-27T03:22:31.001831Z'
+published: '2021-05-14T19:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-qg48-85hg-mqc5
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/da5ff2daf618591f64b2b62d9d9803951b945e9f

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29555.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29555.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 1a2a87229d1d61e23a39373777c056161eb4084d
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29555
+- GHSA-r35g-4525-29fq
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a denial of service via a FPE runtime error in `tf.raw_ops.FusedBatchNorm`.
+  This is because the implementation(https://github.com/tensorflow/tensorflow/blob/828f346274841fa7505f7020e88ca36c22e557ab/tensorflow/core/kernels/fused_batch_norm_op.cc#L295-L297)
+  performs a division based on the last dimension of the `x` tensor. Since this is
+  controlled by the user, an attacker can trigger a denial of service. The fix will
+  be included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29555
+modified: '2021-08-27T03:22:31.200110Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-r35g-4525-29fq
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/1a2a87229d1d61e23a39373777c056161eb4084d

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29556.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29556.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 4071d8e2f6c45c1955a811fee757ca2adbe462c1
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29556
+- GHSA-fxqh-cfjm-fp93
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a denial of service via a FPE runtime error in `tf.raw_ops.Reverse`.
+  This is because the implementation(https://github.com/tensorflow/tensorflow/blob/36229ea9e9451dac14a8b1f4711c435a1d84a594/tensorflow/core/kernels/reverse_op.cc#L75-L76)
+  performs a division based on the first dimension of the tensor argument. The fix
+  will be included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29556
+modified: '2021-08-27T03:22:31.368222Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-fxqh-cfjm-fp93
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/4071d8e2f6c45c1955a811fee757ca2adbe462c1

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29557.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29557.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 7f283ff806b2031f407db64c4d3edcda8fb9f9f5
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29557
+- GHSA-xw93-v57j-fcgh
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a denial of service via a FPE runtime error in `tf.raw_ops.SparseMatMul`.
+  The division by 0 occurs deep in Eigen code because the `b` tensor is empty. The
+  fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit on
+  TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29557
+modified: '2021-08-27T03:22:31.559796Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/7f283ff806b2031f407db64c4d3edcda8fb9f9f5
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-xw93-v57j-fcgh

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29558.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29558.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 8ba6fa29cd8bf9cef9b718dc31c78c73081f5b31
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29558
+- GHSA-mqh2-9wrp-vx84
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a heap buffer overflow in `tf.raw_ops.SparseSplit`. This is because
+  the implementation(https://github.com/tensorflow/tensorflow/blob/699bff5d961f0abfde8fa3f876e6d241681fbef8/tensorflow/core/util/sparse/sparse_tensor.h#L528-L530)
+  accesses an array element based on a user controlled offset. The fix will be included
+  in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow
+  2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-29558
+modified: '2021-08-27T03:22:31.758663Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-mqh2-9wrp-vx84
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/8ba6fa29cd8bf9cef9b718dc31c78c73081f5b31

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29559.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29559.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 51300ba1cc2f487aefec6e6631fef03b0e08b298
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29559
+- GHSA-59q2-x2qc-4c97
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can access data outside of bounds of heap allocated array in `tf.raw_ops.UnicodeEncode`.
+  This is because the implementation(https://github.com/tensorflow/tensorflow/blob/472c1f12ad9063405737679d4f6bd43094e1d36d/tensorflow/core/kernels/unicode_ops.cc)
+  assumes that the `input_value`/`input_splits` pair specify a valid sparse tensor.
+  The fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit
+  on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as
+  these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29559
+modified: '2021-08-27T03:22:31.940947Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/51300ba1cc2f487aefec6e6631fef03b0e08b298
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-59q2-x2qc-4c97

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29560.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29560.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: a84358aa12f0b1518e606095ab9cfddbf597c121
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29560
+- GHSA-8gv3-57p6-g35r
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a heap buffer overflow in `tf.raw_ops.RaggedTensorToTensor`.
+  This is because the implementation(https://github.com/tensorflow/tensorflow/blob/d94227d43aa125ad8b54115c03cece54f6a1977b/tensorflow/core/kernels/ragged_tensor_to_tensor_op.cc#L219-L222)
+  uses the same index to access two arrays in parallel. Since the user controls the
+  shape of the input arguments, an attacker could trigger a heap OOB access when `parent_output_index`
+  is shorter than `row_split`. The fix will be included in TensorFlow 2.5.0. We will
+  also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3
+  and TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29560
+modified: '2021-08-27T03:22:32.127822Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-8gv3-57p6-g35r
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/a84358aa12f0b1518e606095ab9cfddbf597c121

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29561.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29561.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 77dd114513d7796e1e2b8aece214a380af26fbf4
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29561
+- GHSA-gvm4-h8j3-rjrq
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a denial of service by exploiting a `CHECK`-failure coming from
+  `tf.raw_ops.LoadAndRemapMatrix`. This is because the implementation(https://github.com/tensorflow/tensorflow/blob/d94227d43aa125ad8b54115c03cece54f6a1977b/tensorflow/core/kernels/ragged_tensor_to_tensor_op.cc#L219-L222)
+  assumes that the `ckpt_path` is always a valid scalar. However, an attacker can
+  send any other tensor as the first argument of `LoadAndRemapMatrix`. This would
+  cause the rank `CHECK` in `scalar<T>()()` to trigger and terminate the process.
+  The fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit
+  on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as
+  these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29561
+modified: '2021-08-27T03:22:32.310582Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/77dd114513d7796e1e2b8aece214a380af26fbf4
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-gvm4-h8j3-rjrq

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29562.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29562.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 1c56f53be0b722ca657cbc7df461ed676c8642a2
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29562
+- GHSA-36vm-xw34-x4pj
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a denial of service by exploiting a `CHECK`-failure coming from
+  the implementation of `tf.raw_ops.IRFFT`. The fix will be included in TensorFlow
+  2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3,
+  TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported
+  range.
+id: PYSEC-0000-CVE-2021-29562
+modified: '2021-08-27T03:22:32.482991Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/1c56f53be0b722ca657cbc7df461ed676c8642a2
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-36vm-xw34-x4pj

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29563.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29563.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 31bd5026304677faa8a0b77602c6154171b9aec1
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29563
+- GHSA-ph87-fvjr-v33w
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a denial of service by exploiting a `CHECK`-failure coming from
+  the implementation of `tf.raw_ops.RFFT`. Eigen code operating on an empty matrix
+  can trigger on an assertion and will cause program termination. The fix will be
+  included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29563
+modified: '2021-08-27T03:22:32.655132Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-ph87-fvjr-v33w
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/31bd5026304677faa8a0b77602c6154171b9aec1

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29564.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29564.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: f4c364a5d6880557f6f5b6eb5cee2c407f0186b3
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29564
+- GHSA-75f6-78jr-4656
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a null pointer dereference in the implementation of `tf.raw_ops.EditDistance`.
+  This is because the implementation(https://github.com/tensorflow/tensorflow/blob/79865b542f9ffdc9caeb255631f7c56f1d4b6517/tensorflow/core/kernels/edit_distance_op.cc#L103-L159)
+  has incomplete validation of the input parameters. The fix will be included in TensorFlow
+  2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3,
+  TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported
+  range.
+id: PYSEC-0000-CVE-2021-29564
+modified: '2021-08-27T03:22:32.823380Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-75f6-78jr-4656
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/f4c364a5d6880557f6f5b6eb5cee2c407f0186b3

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29565.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29565.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: faa76f39014ed3b5e2c158593b1335522e573c7f
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29565
+- GHSA-r6pg-pjwc-j585
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a null pointer dereference in the implementation of `tf.raw_ops.SparseFillEmptyRows`.
+  This is because of missing validation(https://github.com/tensorflow/tensorflow/blob/fdc82089d206e281c628a93771336bf87863d5e8/tensorflow/core/kernels/sparse_fill_empty_rows_op.cc#L230-L231)
+  that was covered under a `TODO`. If the `dense_shape` tensor is empty, then `dense_shape_t.vec<>()`
+  would cause a null pointer dereference in the implementation of the op. The fix
+  will be included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29565
+modified: '2021-08-27T03:22:32.984830Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-r6pg-pjwc-j585
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/faa76f39014ed3b5e2c158593b1335522e573c7f

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29566.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29566.yaml
@@ -1,0 +1,42 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 3f6fe4dfef6f57e768260b48166c27d148f3015f
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29566
+- GHSA-pvrc-hg3f-58r6
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can write outside the bounds of heap allocated arrays by passing invalid
+  arguments to `tf.raw_ops.Dilation2DBackpropInput`. This is because the implementation(https://github.com/tensorflow/tensorflow/blob/afd954e65f15aea4d438d0a219136fc4a63a573d/tensorflow/core/kernels/dilation_ops.cc#L321-L322)
+  does not validate before writing to the output array. The values for `h_out` and
+  `w_out` are guaranteed to be in range for `out_backprop` (as they are loop indices
+  bounded by the size of the array). However, there are no similar guarantees relating
+  `h_in_max`/`w_in_max` and `in_backprop`. The fix will be included in TensorFlow
+  2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3,
+  TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported
+  range.
+id: PYSEC-0000-CVE-2021-29566
+modified: '2021-08-27T03:22:33.149908Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/3f6fe4dfef6f57e768260b48166c27d148f3015f
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-pvrc-hg3f-58r6

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29567.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29567.yaml
@@ -1,0 +1,42 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 7ae2af34087fb4b5c8915279efd03da3b81028bc
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29567
+- GHSA-wp3c-xw9g-gpcg
+details: TensorFlow is an end-to-end open source platform for machine learning. Due
+  to lack of validation in `tf.raw_ops.SparseDenseCwiseMul`, an attacker can trigger
+  denial of service via `CHECK`-fails or accesses to outside the bounds of heap allocated
+  data. Since the implementation(https://github.com/tensorflow/tensorflow/blob/38178a2f7a681a7835bb0912702a134bfe3b4d84/tensorflow/core/kernels/sparse_dense_binary_op_shared.cc#L68-L80)
+  only validates the rank of the input arguments but no constraints between dimensions(https://www.tensorflow.org/api_docs/python/tf/raw_ops/SparseDenseCwiseMul),
+  an attacker can abuse them to trigger internal `CHECK` assertions (and cause program
+  termination, denial of service) or to write to memory outside of bounds of heap
+  allocated tensor buffers. The fix will be included in TensorFlow 2.5.0. We will
+  also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3
+  and TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29567
+modified: '2021-08-27T03:22:33.334705Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-wp3c-xw9g-gpcg
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/7ae2af34087fb4b5c8915279efd03da3b81028bc

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29568.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29568.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 5e52ef5a461570cfb68f3bdbbebfe972cb4e0fd8
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29568
+- GHSA-4p4p-www8-8fv9
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger undefined behavior by binding to null pointer in `tf.raw_ops.ParameterizedTruncatedNormal`.
+  This is because the implementation(https://github.com/tensorflow/tensorflow/blob/3f6fe4dfef6f57e768260b48166c27d148f3015f/tensorflow/core/kernels/parameterized_truncated_normal_op.cc#L630)
+  does not validate input arguments before accessing the first element of `shape`.
+  If `shape` argument is empty, then `shape_tensor.flat<T>()` is an empty array. The
+  fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit on
+  TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29568
+modified: '2021-08-27T03:22:33.499981Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-4p4p-www8-8fv9
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/5e52ef5a461570cfb68f3bdbbebfe972cb4e0fd8

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29569.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29569.yaml
@@ -1,0 +1,42 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: ef0c008ee84bad91ec6725ddc42091e19a30cf0e
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29569
+- GHSA-3h8m-483j-7xxm
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of `tf.raw_ops.MaxPoolGradWithArgmax` can cause reads outside of
+  bounds of heap allocated data if attacker supplies specially crafted inputs. The
+  implementation(https://github.com/tensorflow/tensorflow/blob/ac328eaa3870491ababc147822cd04e91a790643/tensorflow/core/kernels/requantization_range_op.cc#L49-L50)
+  assumes that the `input_min` and `input_max` tensors have at least one element,
+  as it accesses the first element in two arrays. If the tensors are empty, `.flat<T>()`
+  is an empty object, backed by an empty array. Hence, accesing even the 0th element
+  is a read outside the bounds. The fix will be included in TensorFlow 2.5.0. We will
+  also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3
+  and TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29569
+modified: '2021-08-27T03:22:33.683964Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-3h8m-483j-7xxm
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/ef0c008ee84bad91ec6725ddc42091e19a30cf0e

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29570.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29570.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: dcd7867de0fea4b72a2b34bd41eb74548dc23886
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29570
+- GHSA-545v-42p7-98fq
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of `tf.raw_ops.MaxPoolGradWithArgmax` can cause reads outside of
+  bounds of heap allocated data if attacker supplies specially crafted inputs. The
+  implementation(https://github.com/tensorflow/tensorflow/blob/ef0c008ee84bad91ec6725ddc42091e19a30cf0e/tensorflow/core/kernels/maxpooling_op.cc#L1016-L1017)
+  uses the same value to index in two different arrays but there is no guarantee that
+  the sizes are identical. The fix will be included in TensorFlow 2.5.0. We will also
+  cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and
+  TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29570
+modified: '2021-08-27T03:22:33.847369Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/dcd7867de0fea4b72a2b34bd41eb74548dc23886
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-545v-42p7-98fq

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29571.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29571.yaml
@@ -1,0 +1,44 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 79865b542f9ffdc9caeb255631f7c56f1d4b6517
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29571
+- GHSA-whr9-vfh2-7hm6
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of `tf.raw_ops.MaxPoolGradWithArgmax` can cause reads outside of
+  bounds of heap allocated data if attacker supplies specially crafted inputs. The
+  implementation(https://github.com/tensorflow/tensorflow/blob/31bd5026304677faa8a0b77602c6154171b9aec1/tensorflow/core/kernels/image/draw_bounding_box_op.cc#L116-L130)
+  assumes that the last element of `boxes` input is 4, as required by [the op](https://www.tensorflow.org/api_docs/python/tf/raw_ops/DrawBoundingBoxesV2).
+  Since this is not checked attackers passing values less than 4 can write outside
+  of bounds of heap allocated objects and cause memory corruption. If the last dimension
+  in `boxes` is less than 4, accesses similar to `tboxes(b, bb, 3)` will access data
+  outside of bounds. Further during code execution there are also writes to these
+  indices. The fix will be included in TensorFlow 2.5.0. We will also cherrypick this
+  commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4,
+  as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29571
+modified: '2021-08-27T03:22:34.015475Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/79865b542f9ffdc9caeb255631f7c56f1d4b6517
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-whr9-vfh2-7hm6

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29572.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29572.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: f7cc8755ac6683131fdfa7a8a121f9d7a9dec6fb
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29572
+- GHSA-5gqf-456p-4836
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of `tf.raw_ops.SdcaOptimizer` triggers undefined behavior due to
+  dereferencing a null pointer. The implementation(https://github.com/tensorflow/tensorflow/blob/60a45c8b6192a4699f2e2709a2645a751d435cc3/tensorflow/core/kernels/sdca_internal.cc)
+  does not validate that the user supplied arguments satisfy all constraints expected
+  by the op(https://www.tensorflow.org/api_docs/python/tf/raw_ops/SdcaOptimizer).
+  The fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit
+  on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as
+  these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29572
+modified: '2021-08-27T03:22:34.191182Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/f7cc8755ac6683131fdfa7a8a121f9d7a9dec6fb
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-5gqf-456p-4836

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29573.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29573.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 376c352a37ce5a68b721406dc7e77ac4b6cf483d
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29573
+- GHSA-9vpm-rcf4-9wqw
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of `tf.raw_ops.MaxPoolGradWithArgmax` is vulnerable to a division
+  by 0. The implementation(https://github.com/tensorflow/tensorflow/blob/279bab6efa22752a2827621b7edb56a730233bd8/tensorflow/core/kernels/maxpooling_op.cc#L1033-L1034)
+  fails to validate that the batch dimension of the tensor is non-zero, before dividing
+  by this quantity. The fix will be included in TensorFlow 2.5.0. We will also cherrypick
+  this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow
+  2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29573
+modified: '2021-08-27T03:22:34.367051Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-9vpm-rcf4-9wqw
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/376c352a37ce5a68b721406dc7e77ac4b6cf483d

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29574.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29574.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: a3d9f9be9ac2296615644061b40cefcee341dcc4
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29574
+- GHSA-828x-qc2p-wprq
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of `tf.raw_ops.MaxPool3DGradGrad` exhibits undefined behavior by
+  dereferencing null pointers backing attacker-supplied empty tensors. The implementation(https://github.com/tensorflow/tensorflow/blob/72fe792967e7fd25234342068806707bbc116618/tensorflow/core/kernels/pooling_ops_3d.cc#L679-L703)
+  fails to validate that the 3 tensor inputs are not empty. If any of them is empty,
+  then accessing the elements in the tensor results in dereferencing a null pointer.
+  The fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit
+  on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as
+  these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29574
+modified: '2021-08-27T03:22:34.535736Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-828x-qc2p-wprq
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/a3d9f9be9ac2296615644061b40cefcee341dcc4

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29575.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29575.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: ecf768cbe50cedc0a45ce1ee223146a3d3d26d23
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29575
+- GHSA-6qgm-fv6v-rfpv
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of `tf.raw_ops.ReverseSequence` allows for stack overflow and/or
+  `CHECK`-fail based denial of service. The implementation(https://github.com/tensorflow/tensorflow/blob/5b3b071975e01f0d250c928b2a8f901cd53b90a7/tensorflow/core/kernels/reverse_sequence_op.cc#L114-L118)
+  fails to validate that `seq_dim` and `batch_dim` arguments are valid. Negative values
+  for `seq_dim` can result in stack overflow or `CHECK`-failure, depending on the
+  version of Eigen code used to implement the operation. Similar behavior can be exhibited
+  by invalid values of `batch_dim`. The fix will be included in TensorFlow 2.5.0.
+  We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow
+  2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29575
+modified: '2021-08-27T03:22:34.716646Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-6qgm-fv6v-rfpv
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/ecf768cbe50cedc0a45ce1ee223146a3d3d26d23

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29576.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29576.yaml
@@ -1,0 +1,43 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 63c6a29d0f2d692b247f7bf81f8732d6442fad09
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29576
+- GHSA-7cqx-92hp-x6wh
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of `tf.raw_ops.MaxPool3DGradGrad` is vulnerable to a heap buffer
+  overflow. The implementation(https://github.com/tensorflow/tensorflow/blob/596c05a159b6fbb9e39ca10b3f7753b7244fa1e9/tensorflow/core/kernels/pooling_ops_3d.cc#L694-L696)
+  does not check that the initialization of `Pool3dParameters` completes successfully.
+  Since the constructor(https://github.com/tensorflow/tensorflow/blob/596c05a159b6fbb9e39ca10b3f7753b7244fa1e9/tensorflow/core/kernels/pooling_ops_3d.cc#L48-L88)
+  uses `OP_REQUIRES` to validate conditions, the first assertion that fails interrupts
+  the initialization of `params`, making it contain invalid data. In turn, this might
+  cause a heap buffer overflow, depending on default initialized values. The fix will
+  be included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29576
+modified: '2021-08-27T03:22:34.891385Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-7cqx-92hp-x6wh
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/63c6a29d0f2d692b247f7bf81f8732d6442fad09

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29577.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29577.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 6fc9141f42f6a72180ecd24021c3e6b36165fe0d
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29577
+- GHSA-v6r6-84gr-92rm
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of `tf.raw_ops.AvgPool3DGrad` is vulnerable to a heap buffer overflow.
+  The implementation(https://github.com/tensorflow/tensorflow/blob/d80ffba9702dc19d1fac74fc4b766b3fa1ee976b/tensorflow/core/kernels/pooling_ops_3d.cc#L376-L450)
+  assumes that the `orig_input_shape` and `grad` tensors have similar first and last
+  dimensions but does not check that this assumption is validated. The fix will be
+  included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29577
+modified: '2021-08-27T03:22:35.059356Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-v6r6-84gr-92rm
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/6fc9141f42f6a72180ecd24021c3e6b36165fe0d

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29578.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29578.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 12c727cee857fa19be717f336943d95fca4ffe4f
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29578
+- GHSA-6f89-8j54-29xf
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of `tf.raw_ops.FractionalAvgPoolGrad` is vulnerable to a heap buffer
+  overflow. The implementation(https://github.com/tensorflow/tensorflow/blob/dcba796a28364d6d7f003f6fe733d82726dda713/tensorflow/core/kernels/fractional_avg_pool_op.cc#L216)
+  fails to validate that the pooling sequence arguments have enough elements as required
+  by the `out_backprop` tensor shape. The fix will be included in TensorFlow 2.5.0.
+  We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow
+  2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29578
+modified: '2021-08-27T03:22:35.223640Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/12c727cee857fa19be717f336943d95fca4ffe4f
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-6f89-8j54-29xf

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29579.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29579.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: a74768f8e4efbda4def9f16ee7e13cf3922ac5f7
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29579
+- GHSA-79fv-9865-4qcv
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of `tf.raw_ops.MaxPoolGrad` is vulnerable to a heap buffer overflow.
+  The implementation(https://github.com/tensorflow/tensorflow/blob/ab1e644b48c82cb71493f4362b4dd38f4577a1cf/tensorflow/core/kernels/maxpooling_op.cc#L194-L203)
+  fails to validate that indices used to access elements of input/output arrays are
+  valid. Whereas accesses to `input_backprop_flat` are guarded by `FastBoundsCheck`,
+  the indexing in `out_backprop_flat` can result in OOB access. The fix will be included
+  in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow
+  2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-29579
+modified: '2021-08-27T03:22:35.384566Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-79fv-9865-4qcv
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/a74768f8e4efbda4def9f16ee7e13cf3922ac5f7

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29580.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29580.yaml
@@ -1,0 +1,42 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 32fdcbff9d06d010d908fcc4bd4b36eb3ce15925
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29580
+- GHSA-x8h6-xgqx-jqgp
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of `tf.raw_ops.FractionalMaxPoolGrad` triggers an undefined behavior
+  if one of the input tensors is empty. The code is also vulnerable to a denial of
+  service attack as a `CHECK` condition becomes false and aborts the process. The
+  implementation(https://github.com/tensorflow/tensorflow/blob/169054888d50ce488dfde9ca55d91d6325efbd5b/tensorflow/core/kernels/fractional_max_pool_op.cc#L215)
+  fails to validate that input and output tensors are not empty and are of the same
+  rank. Each of these unchecked assumptions is responsible for the above issues. The
+  fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit on
+  TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29580
+modified: '2021-08-27T03:22:35.567916Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-x8h6-xgqx-jqgp
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/32fdcbff9d06d010d908fcc4bd4b36eb3ce15925

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29581.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29581.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: b1b323042264740c398140da32e93fb9c2c9f33e
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29581
+- GHSA-vq2r-5xvm-3hc3
+details: TensorFlow is an end-to-end open source platform for machine learning. Due
+  to lack of validation in `tf.raw_ops.CTCBeamSearchDecoder`, an attacker can trigger
+  denial of service via segmentation faults. The implementation(https://github.com/tensorflow/tensorflow/blob/a74768f8e4efbda4def9f16ee7e13cf3922ac5f7/tensorflow/core/kernels/ctc_decoder_ops.cc#L68-L79)
+  fails to detect cases when the input tensor is empty and proceeds to read data from
+  a null buffer. The fix will be included in TensorFlow 2.5.0. We will also cherrypick
+  this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow
+  2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29581
+modified: '2021-08-27T03:22:35.737731Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-vq2r-5xvm-3hc3
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/b1b323042264740c398140da32e93fb9c2c9f33e

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29582.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29582.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 5899741d0421391ca878da47907b1452f06aaf1b
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29582
+- GHSA-c45w-2wxr-pp53
+details: TensorFlow is an end-to-end open source platform for machine learning. Due
+  to lack of validation in `tf.raw_ops.Dequantize`, an attacker can trigger a read
+  from outside of bounds of heap allocated data. The implementation(https://github.com/tensorflow/tensorflow/blob/26003593aa94b1742f34dc22ce88a1e17776a67d/tensorflow/core/kernels/dequantize_op.cc#L106-L131)
+  accesses the `min_range` and `max_range` tensors in parallel but fails to check
+  that they have the same shape. The fix will be included in TensorFlow 2.5.0. We
+  will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow
+  2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29582
+modified: '2021-08-27T03:22:35.924594Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/5899741d0421391ca878da47907b1452f06aaf1b
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-c45w-2wxr-pp53

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29583.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29583.yaml
@@ -1,0 +1,44 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 6972f9dfe325636b3db4e0bc517ee22a159365c0
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29583
+- GHSA-9xh4-23q4-v6wr
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of `tf.raw_ops.FusedBatchNorm` is vulnerable to a heap buffer overflow.
+  If the tensors are empty, the same implementation can trigger undefined behavior
+  by dereferencing null pointers. The implementation(https://github.com/tensorflow/tensorflow/blob/57d86e0db5d1365f19adcce848dfc1bf89fdd4c7/tensorflow/core/kernels/fused_batch_norm_op.cc)
+  fails to validate that `scale`, `offset`, `mean` and `variance` (the last two only
+  when required) all have the same number of elements as the number of channels of
+  `x`. This results in heap out of bounds reads when the buffers backing these tensors
+  are indexed past their boundary. If the tensors are empty, the validation mentioned
+  in the above paragraph would also trigger and prevent the undefined behavior. The
+  fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit on
+  TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29583
+modified: '2021-08-27T03:22:36.144215Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/6972f9dfe325636b3db4e0bc517ee22a159365c0
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-9xh4-23q4-v6wr

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29584.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29584.yaml
@@ -1,0 +1,43 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 4c0ee937c0f61c4fc5f5d32d9bb4c67428012a60
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29584
+- GHSA-xvjm-fvxx-q3hv
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a denial of service via a `CHECK`-fail in caused by an integer
+  overflow in constructing a new tensor shape. This is because the implementation(https://github.com/tensorflow/tensorflow/blob/0908c2f2397c099338b901b067f6495a5b96760b/tensorflow/core/kernels/sparse_split_op.cc#L66-L70)
+  builds a dense shape without checking that the dimensions would not result in overflow.
+  The `TensorShape` constructor(https://github.com/tensorflow/tensorflow/blob/6f9896890c4c703ae0a0845394086e2e1e523299/tensorflow/core/framework/tensor_shape.cc#L183-L188)
+  uses a `CHECK` operation which triggers when `InitDims`(https://github.com/tensorflow/tensorflow/blob/6f9896890c4c703ae0a0845394086e2e1e523299/tensorflow/core/framework/tensor_shape.cc#L212-L296)
+  returns a non-OK status. This is a legacy implementation of the constructor and
+  operations should use `BuildTensorShapeBase` or `AddDimWithStatus` to prevent `CHECK`-failures
+  in the presence of overflows. The fix will be included in TensorFlow 2.5.0. We will
+  also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3
+  and TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29584
+modified: '2021-08-27T03:22:36.340283Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-xvjm-fvxx-q3hv
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/4c0ee937c0f61c4fc5f5d32d9bb4c67428012a60

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29585.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29585.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 49847ae69a4e1a97ae7f2db5e217c77721e37948
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29585
+- GHSA-mv78-g7wq-mhp4
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  TFLite computation for size of output after padding, `ComputeOutSize`(https://github.com/tensorflow/tensorflow/blob/0c9692ae7b1671c983569e5d3de5565843d500cf/tensorflow/lite/kernels/padding.h#L43-L55),
+  does not check that the `stride` argument is not 0 before doing the division. Users
+  can craft special models such that `ComputeOutSize` is called with `stride` set
+  to 0. The fix will be included in TensorFlow 2.5.0. We will also cherrypick this
+  commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4,
+  as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29585
+modified: '2021-08-27T03:22:36.517027Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/49847ae69a4e1a97ae7f2db5e217c77721e37948
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-mv78-g7wq-mhp4

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29586.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29586.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 5f7975d09eac0f10ed8a17dbb6f5964977725adc
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29586
+- GHSA-26j7-6w8w-7922
+details: TensorFlow is an end-to-end open source platform for machine learning. Optimized
+  pooling implementations in TFLite fail to check that the stride arguments are not
+  0 before calling `ComputePaddingHeightWidth`(https://github.com/tensorflow/tensorflow/blob/3f24ccd932546416ec906a02ddd183b48a1d2c83/tensorflow/lite/kernels/pooling.cc#L90).
+  Since users can craft special models which will have `params->stride_{height,width}`
+  be zero, this will result in a division by zero. The fix will be included in TensorFlow
+  2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3,
+  TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported
+  range.
+id: PYSEC-0000-CVE-2021-29586
+modified: '2021-08-27T03:22:36.699869Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/5f7975d09eac0f10ed8a17dbb6f5964977725adc
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-26j7-6w8w-7922

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29587.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29587.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 0d45ea1ca641b21b73bcf9c00e0179cda284e7e7
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29587
+- GHSA-j7rm-8ww4-xx2g
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  `Prepare` step of the `SpaceToDepth` TFLite operator does not check for 0 before
+  division(https://github.com/tensorflow/tensorflow/blob/5f7975d09eac0f10ed8a17dbb6f5964977725adc/tensorflow/lite/kernels/space_to_depth.cc#L63-L67).
+  An attacker can craft a model such that `params->block_size` would be zero. The
+  fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit on
+  TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29587
+modified: '2021-08-27T03:22:36.876924Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-j7rm-8ww4-xx2g
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/0d45ea1ca641b21b73bcf9c00e0179cda284e7e7

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29588.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29588.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 801c1c6be5324219689c98e1bd3e0ca365ee834d
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29588
+- GHSA-vfr4-x8j2-3rf9
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  optimized implementation of the `TransposeConv` TFLite operator is [vulnerable to
+  a division by zero error](https://github.com/tensorflow/tensorflow/blob/0d45ea1ca641b21b73bcf9c00e0179cda284e7e7/tensorflow/lite/kernels/internal/optimized/optimized_ops.h#L5221-L5222).
+  An attacker can craft a model such that `stride_{h,w}` values are 0. Code calling
+  this function must validate these arguments. The fix will be included in TensorFlow
+  2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3,
+  TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported
+  range.
+id: PYSEC-0000-CVE-2021-29588
+modified: '2021-08-27T03:22:37.053061Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/801c1c6be5324219689c98e1bd3e0ca365ee834d
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-vfr4-x8j2-3rf9

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29589.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29589.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 8e45822aa0b9f5df4b4c64f221e64dc930a70a9d
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29589
+- GHSA-3w67-q784-6w7c
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  reference implementation of the `GatherNd` TFLite operator is vulnerable to a division
+  by zero error(https://github.com/tensorflow/tensorflow/blob/0d45ea1ca641b21b73bcf9c00e0179cda284e7e7/tensorflow/lite/kernels/internal/reference/reference_ops.h#L966).
+  An attacker can craft a model such that `params` input would be an empty tensor.
+  In turn, `params_shape.Dims(.)` would be zero, in at least one dimension. The fix
+  will be included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29589
+modified: '2021-08-27T03:22:37.235055Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/8e45822aa0b9f5df4b4c64f221e64dc930a70a9d
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-3w67-q784-6w7c

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29590.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29590.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 953f28dca13c92839ba389c055587cfe6c723578
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29590
+- GHSA-24x6-8c7m-hv3f
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementations of the `Minimum` and `Maximum` TFLite operators can be used to read
+  data outside of bounds of heap allocated objects, if any of the two input tensor
+  arguments are empty. This is because the broadcasting implementation(https://github.com/tensorflow/tensorflow/blob/0d45ea1ca641b21b73bcf9c00e0179cda284e7e7/tensorflow/lite/kernels/internal/reference/maximum_minimum.h#L52-L56)
+  indexes in both tensors with the same index but does not validate that the index
+  is within bounds. The fix will be included in TensorFlow 2.5.0. We will also cherrypick
+  this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow
+  2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29590
+modified: '2021-08-27T03:22:37.400702Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/953f28dca13c92839ba389c055587cfe6c723578
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-24x6-8c7m-hv3f

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29591.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29591.yaml
@@ -1,0 +1,48 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 9c1dc920d8ffb4893d6c9d27d1f039607b326743
+    - fixed: c6173f5fe66cdbab74f4f869311fe6aae2ba35f4
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29591
+- GHSA-cwv3-863g-39vx
+details: TensorFlow is an end-to-end open source platform for machine learning. TFlite
+  graphs must not have loops between nodes. However, this condition was not checked
+  and an attacker could craft models that would result in infinite loop during evaluation.
+  In certain cases, the infinite loop would be replaced by stack overflow due to too
+  many recursive calls. For example, the `While` implementation(https://github.com/tensorflow/tensorflow/blob/106d8f4fb89335a2c52d7c895b7a7485465ca8d9/tensorflow/lite/kernels/while.cc)
+  could be tricked into a scneario where both the body and the loop subgraphs are
+  the same. Evaluating one of the subgraphs means calling the `Eval` function for
+  the other and this quickly exhaust all stack space. The fix will be included in
+  TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow
+  2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still
+  in supported range. Please consult our security guide(https://github.com/tensorflow/tensorflow/blob/master/SECURITY.md)
+  for more information regarding the security model and how to contact us with issues
+  and questions.
+id: PYSEC-0000-CVE-2021-29591
+modified: '2021-08-27T03:22:37.582991Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-cwv3-863g-39vx
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/9c1dc920d8ffb4893d6c9d27d1f039607b326743
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/c6173f5fe66cdbab74f4f869311fe6aae2ba35f4

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29592.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29592.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: f8378920345f4f4604202d4ab15ef64b2aceaa16
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29592
+- GHSA-jjr8-m8g8-p6wv
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  fix for CVE-2020-15209(https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15209)
+  missed the case when the target shape of `Reshape` operator is given by the elements
+  of a 1-D tensor. As such, the fix for the vulnerability(https://github.com/tensorflow/tensorflow/blob/9c1dc920d8ffb4893d6c9d27d1f039607b326743/tensorflow/lite/core/subgraph.cc#L1062-L1074)
+  allowed passing a null-buffer-backed tensor with a 1D shape. The fix will be included
+  in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow
+  2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-29592
+modified: '2021-08-27T03:22:37.768858Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/f8378920345f4f4604202d4ab15ef64b2aceaa16
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-jjr8-m8g8-p6wv

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29593.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29593.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 2c74674348a4708ced58ad6eb1b23354df8ee044
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29593
+- GHSA-cfx7-2xpc-8w4h
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of the `BatchToSpaceNd` TFLite operator is vulnerable to a division
+  by zero error(https://github.com/tensorflow/tensorflow/blob/b5ed552fe55895aee8bd8b191f744a069957d18d/tensorflow/lite/kernels/batch_to_space_nd.cc#L81-L82).
+  An attacker can craft a model such that one dimension of the `block` input is 0.
+  Hence, the corresponding value in `block_shape` is 0. The fix will be included in
+  TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow
+  2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-29593
+modified: '2021-08-27T03:22:37.941172Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/2c74674348a4708ced58ad6eb1b23354df8ee044
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-cfx7-2xpc-8w4h

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29594.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29594.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: ff489d95a9006be080ad14feb378f2b4dac35552
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29594
+- GHSA-3qgw-p4fm-x7gf
+details: TensorFlow is an end-to-end open source platform for machine learning. TFLite's
+  convolution code(https://github.com/tensorflow/tensorflow/blob/09c73bca7d648e961dd05898292d91a8322a9d45/tensorflow/lite/kernels/conv.cc)
+  has multiple division where the divisor is controlled by the user and not checked
+  to be non-zero. The fix will be included in TensorFlow 2.5.0. We will also cherrypick
+  this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow
+  2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29594
+modified: '2021-08-27T03:22:38.125295Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/ff489d95a9006be080ad14feb378f2b4dac35552
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-3qgw-p4fm-x7gf

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29595.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29595.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 106d8f4fb89335a2c52d7c895b7a7485465ca8d9
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29595
+- GHSA-vf94-36g5-69v8
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of the `DepthToSpace` TFLite operator is vulnerable to a division
+  by zero error(https://github.com/tensorflow/tensorflow/blob/0d45ea1ca641b21b73bcf9c00e0179cda284e7e7/tensorflow/lite/kernels/depth_to_space.cc#L63-L69).
+  An attacker can craft a model such that `params->block_size` is 0. The fix will
+  be included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29595
+modified: '2021-08-27T03:22:38.313497Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-vf94-36g5-69v8
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/106d8f4fb89335a2c52d7c895b7a7485465ca8d9

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29596.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29596.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: f61c57bd425878be108ec787f4d96390579fb83e
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29596
+- GHSA-4vrf-ff7v-hpgr
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of the `EmbeddingLookup` TFLite operator is vulnerable to a division
+  by zero error(https://github.com/tensorflow/tensorflow/blob/e4b29809543b250bc9b19678ec4776299dd569ba/tensorflow/lite/kernels/embedding_lookup.cc#L73-L74).
+  An attacker can craft a model such that the first dimension of the `value` input
+  is 0. The fix will be included in TensorFlow 2.5.0. We will also cherrypick this
+  commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4,
+  as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29596
+modified: '2021-08-27T03:22:38.479573Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-4vrf-ff7v-hpgr
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/f61c57bd425878be108ec787f4d96390579fb83e

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29597.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29597.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 6d36ba65577006affb272335b7c1abd829010708
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29597
+- GHSA-v52p-hfjf-wg88
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of the `SpaceToBatchNd` TFLite operator is [vulnerable to a division
+  by zero error](https://github.com/tensorflow/tensorflow/blob/412c7d9bb8f8a762c5b266c9e73bfa165f29aac8/tensorflow/lite/kernels/space_to_batch_nd.cc#L82-L83).
+  An attacker can craft a model such that one dimension of the `block` input is 0.
+  Hence, the corresponding value in `block_shape` is 0. The fix will be included in
+  TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow
+  2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-29597
+modified: '2021-08-27T03:22:38.644851Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/6d36ba65577006affb272335b7c1abd829010708
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-v52p-hfjf-wg88

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29598.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29598.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 6841e522a3e7d48706a02e8819836e809f738682
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29598
+- GHSA-pmpr-55fj-r229
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of the `SVDF` TFLite operator is vulnerable to a division by zero
+  error(https://github.com/tensorflow/tensorflow/blob/7f283ff806b2031f407db64c4d3edcda8fb9f9f5/tensorflow/lite/kernels/svdf.cc#L99-L102).
+  An attacker can craft a model such that `params->rank` would be 0. The fix will
+  be included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29598
+modified: '2021-08-27T03:22:38.832523Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-pmpr-55fj-r229
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/6841e522a3e7d48706a02e8819836e809f738682

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29599.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29599.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: b22786e7e9b7bdb6a56936ff29cc7e9968d7bc1d
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29599
+- GHSA-97wf-p777-86jq
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of the `Split` TFLite operator is vulnerable to a division by zero
+  error(https://github.com/tensorflow/tensorflow/blob/e2752089ef7ce9bcf3db0ec618ebd23ea119d0c7/tensorflow/lite/kernels/split.cc#L63-L65).
+  An attacker can craft a model such that `num_splits` would be 0. The fix will be
+  included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29599
+modified: '2021-08-27T03:22:39.020093Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/b22786e7e9b7bdb6a56936ff29cc7e9968d7bc1d
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-97wf-p777-86jq

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29600.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29600.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 3ebedd7e345453d68e279cfc3e4072648e5e12e5
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29600
+- GHSA-j8qh-3xrq-c825
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of the `OneHot` TFLite operator is vulnerable to a division by zero
+  error(https://github.com/tensorflow/tensorflow/blob/f61c57bd425878be108ec787f4d96390579fb83e/tensorflow/lite/kernels/one_hot.cc#L68-L72).
+  An attacker can craft a model such that at least one of the dimensions of `indices`
+  would be 0. In turn, the `prefix_dim_size` value would become 0. The fix will be
+  included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29600
+modified: '2021-08-27T03:22:39.194303Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-j8qh-3xrq-c825
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/3ebedd7e345453d68e279cfc3e4072648e5e12e5

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29601.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29601.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 4253f96a58486ffe84b61c0415bb234a4632ee73
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29601
+- GHSA-9c84-4hx6-xmm4
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  TFLite implementation of concatenation is vulnerable to an integer overflow issue(https://github.com/tensorflow/tensorflow/blob/7b7352a724b690b11bfaae2cd54bc3907daf6285/tensorflow/lite/kernels/concatenation.cc#L70-L76).
+  An attacker can craft a model such that the dimensions of one of the concatenation
+  input overflow the values of `int`. TFLite uses `int` to represent tensor dimensions,
+  whereas TF uses `int64`. Hence, valid TF models can trigger an integer overflow
+  when converted to TFLite format. The fix will be included in TensorFlow 2.5.0. We
+  will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow
+  2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29601
+modified: '2021-08-27T03:22:39.383979Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-9c84-4hx6-xmm4
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/4253f96a58486ffe84b61c0415bb234a4632ee73

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29602.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29602.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: cbda3c6b2dbbd3fbdc482ff8c0170a78ec2e97d0
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29602
+- GHSA-rf3h-xgv5-2q39
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of the `DepthwiseConv` TFLite operator is vulnerable to a division
+  by zero error(https://github.com/tensorflow/tensorflow/blob/1a8e885b864c818198a5b2c0cbbeca5a1e833bc8/tensorflow/lite/kernels/depthwise_conv.cc#L287-L288).
+  An attacker can craft a model such that `input`'s fourth dimension would be 0. The
+  fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit on
+  TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29602
+modified: '2021-08-27T03:22:39.570829Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/cbda3c6b2dbbd3fbdc482ff8c0170a78ec2e97d0
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-rf3h-xgv5-2q39

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29603.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29603.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: c59c37e7b2d563967da813fa50fe20b21f4da683
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29603
+- GHSA-crch-j389-5f84
+details: TensorFlow is an end-to-end open source platform for machine learning. A
+  specially crafted TFLite model could trigger an OOB write on heap in the TFLite
+  implementation of `ArgMin`/`ArgMax`(https://github.com/tensorflow/tensorflow/blob/102b211d892f3abc14f845a72047809b39cc65ab/tensorflow/lite/kernels/arg_min_max.cc#L52-L59).
+  If `axis_value` is not a value between 0 and `NumDimensions(input)`, then the condition
+  in the `if` is never true, so code writes past the last valid element of `output_dims->data`.
+  The fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit
+  on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as
+  these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29603
+modified: '2021-08-27T03:22:39.733041Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-crch-j389-5f84
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/c59c37e7b2d563967da813fa50fe20b21f4da683

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29604.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29604.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 5117e0851348065ed59c991562c0ec80d9193db2
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29604
+- GHSA-8rm6-75mf-7r7r
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  TFLite implementation of hashtable lookup is vulnerable to a division by zero error(https://github.com/tensorflow/tensorflow/blob/1a8e885b864c818198a5b2c0cbbeca5a1e833bc8/tensorflow/lite/kernels/hashtable_lookup.cc#L114-L115)
+  An attacker can craft a model such that `values`'s first dimension would be 0. The
+  fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit on
+  TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29604
+modified: '2021-08-27T03:22:39.893665Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-8rm6-75mf-7r7r
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/5117e0851348065ed59c991562c0ec80d9193db2

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29605.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29605.yaml
@@ -1,0 +1,42 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 7c8cc4ec69cd348e44ad6a2699057ca88faad3e5
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29605
+- GHSA-jf7h-7m85-w2v2
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  TFLite code for allocating `TFLiteIntArray`s is vulnerable to an integer overflow
+  issue(https://github.com/tensorflow/tensorflow/blob/4ceffae632721e52bf3501b736e4fe9d1221cdfa/tensorflow/lite/c/common.c#L24-L27).
+  An attacker can craft a model such that the `size` multiplier is so large that the
+  return value overflows the `int` datatype and becomes negative. In turn, this results
+  in invalid value being given to `malloc`(https://github.com/tensorflow/tensorflow/blob/4ceffae632721e52bf3501b736e4fe9d1221cdfa/tensorflow/lite/c/common.c#L47-L52).
+  In this case, `ret->size` would dereference an invalid pointer. The fix will be
+  included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29605
+modified: '2021-08-27T03:22:40.058012Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-jf7h-7m85-w2v2
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/7c8cc4ec69cd348e44ad6a2699057ca88faad3e5

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29606.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29606.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: ae2daeb45abfe2c6dda539cf8d0d6f653d3ef412
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29606
+- GHSA-h4pc-gx2w-f2xv
+details: TensorFlow is an end-to-end open source platform for machine learning. A
+  specially crafted TFLite model could trigger an OOB read on heap in the TFLite implementation
+  of `Split_V`(https://github.com/tensorflow/tensorflow/blob/c59c37e7b2d563967da813fa50fe20b21f4da683/tensorflow/lite/kernels/split_v.cc#L99).
+  If `axis_value` is not a value between 0 and `NumDimensions(input)`, then the `SizeOfDimension`
+  function(https://github.com/tensorflow/tensorflow/blob/102b211d892f3abc14f845a72047809b39cc65ab/tensorflow/lite/kernels/kernel_util.h#L148-L150)
+  will access data outside the bounds of the tensor shape array. The fix will be included
+  in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow
+  2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-29606
+modified: '2021-08-27T03:22:40.241160Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-h4pc-gx2w-f2xv
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/ae2daeb45abfe2c6dda539cf8d0d6f653d3ef412

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29607.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29607.yaml
@@ -1,0 +1,46 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: ba6822bd7b7324ba201a28b2f278c29a98edbef2
+    - fixed: f6fde895ef9c77d848061c0517f19d0ec2682f3a
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29607
+- GHSA-gv26-jpj9-c8gq
+details: TensorFlow is an end-to-end open source platform for machine learning. Incomplete
+  validation in `SparseAdd` results in allowing attackers to exploit undefined behavior
+  (dereferencing null pointers) as well as write outside of bounds of heap allocated
+  data. The implementation(https://github.com/tensorflow/tensorflow/blob/656e7673b14acd7835dc778867f84916c6d1cac2/tensorflow/core/kernels/sparse_sparse_binary_op_shared.cc)
+  has a large set of validation for the two sparse tensor inputs (6 tensors in total),
+  but does not validate that the tensors are not empty or that the second dimension
+  of `*_indices` matches the size of corresponding `*_shape`. This allows attackers
+  to send tensor triples that represent invalid sparse tensors to abuse code assumptions
+  that are not protected by validation. The fix will be included in TensorFlow 2.5.0.
+  We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow
+  2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29607
+modified: '2021-08-27T03:22:40.417025Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/ba6822bd7b7324ba201a28b2f278c29a98edbef2
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/f6fde895ef9c77d848061c0517f19d0ec2682f3a
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-gv26-jpj9-c8gq

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29608.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29608.yaml
@@ -1,0 +1,47 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: c4d7afb6a5986b04505aca4466ae1951686c80f6
+    - fixed: f94ef358bb3e91d517446454edff6535bcfe8e4a
+    - fixed: b761c9b652af2107cfbc33efd19be0ce41daa33e
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29608
+- GHSA-rgvq-pcvf-hx75
+details: TensorFlow is an end-to-end open source platform for machine learning. Due
+  to lack of validation in `tf.raw_ops.RaggedTensorToTensor`, an attacker can exploit
+  an undefined behavior if input arguments are empty. The implementation(https://github.com/tensorflow/tensorflow/blob/656e7673b14acd7835dc778867f84916c6d1cac2/tensorflow/core/kernels/ragged_tensor_to_tensor_op.cc#L356-L360)
+  only checks that one of the tensors is not empty, but does not check for the other
+  ones. There are multiple `DCHECK` validations to prevent heap OOB, but these are
+  no-op in release builds, hence they don't prevent anything. The fix will be included
+  in TensorFlow 2.5.0. We will also cherrypick these commits on TensorFlow 2.4.2,
+  TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-29608
+modified: '2021-08-27T03:22:40.610515Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/c4d7afb6a5986b04505aca4466ae1951686c80f6
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/f94ef358bb3e91d517446454edff6535bcfe8e4a
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-rgvq-pcvf-hx75
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/b761c9b652af2107cfbc33efd19be0ce41daa33e

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29609.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29609.yaml
@@ -1,0 +1,46 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 41727ff06111117bdf86b37db198217fd7a143cc
+    - fixed: 6fd02f44810754ae7481838b6a67c5df7f909ca3
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29609
+- GHSA-cjc7-49v2-jp64
+details: TensorFlow is an end-to-end open source platform for machine learning. Incomplete
+  validation in `SparseAdd` results in allowing attackers to exploit undefined behavior
+  (dereferencing null pointers) as well as write outside of bounds of heap allocated
+  data. The implementation(https://github.com/tensorflow/tensorflow/blob/656e7673b14acd7835dc778867f84916c6d1cac2/tensorflow/core/kernels/sparse_add_op.cc)
+  has a large set of validation for the two sparse tensor inputs (6 tensors in total),
+  but does not validate that the tensors are not empty or that the second dimension
+  of `*_indices` matches the size of corresponding `*_shape`. This allows attackers
+  to send tensor triples that represent invalid sparse tensors to abuse code assumptions
+  that are not protected by validation. The fix will be included in TensorFlow 2.5.0.
+  We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow
+  2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29609
+modified: '2021-08-27T03:22:40.807777Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/41727ff06111117bdf86b37db198217fd7a143cc
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-cjc7-49v2-jp64
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/6fd02f44810754ae7481838b6a67c5df7f909ca3

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29610.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29610.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: c5b0d5f8ac19888e46ca14b0e27562e7fbbee9a9
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29610
+- GHSA-mq5c-prh3-3f3h
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  validation in `tf.raw_ops.QuantizeAndDequantizeV2` allows invalid values for `axis`
+  argument:. The validation(https://github.com/tensorflow/tensorflow/blob/eccb7ec454e6617738554a255d77f08e60ee0808/tensorflow/core/kernels/quantize_and_dequantize_op.cc#L74-L77)
+  uses `||` to mix two different conditions. If `axis_ < -1` the condition in `OP_REQUIRES`
+  will still be true, but this value of `axis_` results in heap underflow. This allows
+  attackers to read/write to other data on the heap. The fix will be included in TensorFlow
+  2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3,
+  TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported
+  range.
+id: PYSEC-0000-CVE-2021-29610
+modified: '2021-08-27T03:22:41.001819Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-mq5c-prh3-3f3h
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/c5b0d5f8ac19888e46ca14b0e27562e7fbbee9a9

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29611.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29611.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 1d04d7d93f4ed3854abf75d6b712d72c3f70d6b6
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29611
+- GHSA-9rpc-5v9q-5r7f
+details: TensorFlow is an end-to-end open source platform for machine learning. Incomplete
+  validation in `SparseReshape` results in a denial of service based on a `CHECK`-failure.
+  The implementation(https://github.com/tensorflow/tensorflow/blob/e87b51ce05c3eb172065a6ea5f48415854223285/tensorflow/core/kernels/sparse_reshape_op.cc#L40)
+  has no validation that the input arguments specify a valid sparse tensor. The fix
+  will be included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2 and TensorFlow 2.3.3, as these are the only affected versions.
+id: PYSEC-0000-CVE-2021-29611
+modified: '2021-08-27T03:22:41.176381Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-9rpc-5v9q-5r7f
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/1d04d7d93f4ed3854abf75d6b712d72c3f70d6b6

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29612.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29612.yaml
@@ -1,0 +1,47 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: ba6822bd7b7324ba201a28b2f278c29a98edbef2
+    - fixed: 0ab290774f91a23bebe30a358fde4e53ab4876a0
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29612
+- GHSA-2xgj-xhgf-ggjv
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a heap buffer overflow in Eigen implementation of `tf.raw_ops.BandedTriangularSolve`.
+  The implementation(https://github.com/tensorflow/tensorflow/blob/eccb7ec454e6617738554a255d77f08e60ee0808/tensorflow/core/kernels/linalg/banded_triangular_solve_op.cc#L269-L278)
+  calls `ValidateInputTensors` for input validation but fails to validate that the
+  two tensors are not empty. Furthermore, since `OP_REQUIRES` macro only stops execution
+  of current function after setting `ctx->status()` to a non-OK value, callers of
+  helper functions that use `OP_REQUIRES` must check value of `ctx->status()` before
+  continuing. This doesn't happen in this op's implementation(https://github.com/tensorflow/tensorflow/blob/eccb7ec454e6617738554a255d77f08e60ee0808/tensorflow/core/kernels/linalg/banded_triangular_solve_op.cc#L219),
+  hence the validation that is present is also not effective. The fix will be included
+  in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow
+  2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-29612
+modified: '2021-08-27T03:22:41.356902Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-2xgj-xhgf-ggjv
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/ba6822bd7b7324ba201a28b2f278c29a98edbef2
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/0ab290774f91a23bebe30a358fde4e53ab4876a0

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29613.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29613.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 14607c0707040d775e06b6817325640cb4b5864c
+    - fixed: 4504a081af71514bb1828048363e6540f797005b
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29613
+- GHSA-vvg4-vgrv-xfr7
+details: TensorFlow is an end-to-end open source platform for machine learning. Incomplete
+  validation in `tf.raw_ops.CTCLoss` allows an attacker to trigger an OOB read from
+  heap. The fix will be included in TensorFlow 2.5.0. We will also cherrypick these
+  commits on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4,
+  as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29613
+modified: '2021-08-27T03:22:41.522961Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-vvg4-vgrv-xfr7
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/14607c0707040d775e06b6817325640cb4b5864c
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/4504a081af71514bb1828048363e6540f797005b

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29614.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29614.yaml
@@ -1,0 +1,51 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 698e01511f62a3c185754db78ebce0eee1f0184d
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29614
+- GHSA-8pmx-p244-g88h
+details: 'TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of `tf.io.decode_raw` produces incorrect results and crashes the
+  Python interpreter when combining `fixed_length` and wider datatypes. The implementation
+  of the padded version(https://github.com/tensorflow/tensorflow/blob/1d8903e5b167ed0432077a3db6e462daf781d1fe/tensorflow/core/kernels/decode_padded_raw_op.cc)
+  is buggy due to a confusion about pointer arithmetic rules. First, the code computes(https://github.com/tensorflow/tensorflow/blob/1d8903e5b167ed0432077a3db6e462daf781d1fe/tensorflow/core/kernels/decode_padded_raw_op.cc#L61)
+  the width of each output element by dividing the `fixed_length` value to the size
+  of the type argument. The `fixed_length` argument is also used to determine the
+  size needed for the output tensor(https://github.com/tensorflow/tensorflow/blob/1d8903e5b167ed0432077a3db6e462daf781d1fe/tensorflow/core/kernels/decode_padded_raw_op.cc#L63-L79).
+  This is followed by reencoding code(https://github.com/tensorflow/tensorflow/blob/1d8903e5b167ed0432077a3db6e462daf781d1fe/tensorflow/core/kernels/decode_padded_raw_op.cc#L85-L94).
+  The erroneous code is the last line above: it is moving the `out_data` pointer by
+  `fixed_length * sizeof(T)` bytes whereas it only copied at most `fixed_length` bytes
+  from the input. This results in parts of the input not being decoded into the output.
+  Furthermore, because the pointer advance is far wider than desired, this quickly
+  leads to writing to outside the bounds of the backing data. This OOB write leads
+  to interpreter crash in the reproducer mentioned here, but more severe attacks can
+  be mounted too, given that this gadget allows writing to periodically placed locations
+  in memory. The fix will be included in TensorFlow 2.5.0. We will also cherrypick
+  this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow
+  2.1.4, as these are also affected and still in supported range.'
+id: PYSEC-0000-CVE-2021-29614
+modified: '2021-08-27T03:22:41.712204Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/698e01511f62a3c185754db78ebce0eee1f0184d
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-8pmx-p244-g88h

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29615.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29615.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: e07e1c3d26492c06f078c7e5bf2d138043e199c1
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29615
+- GHSA-qw5h-7f53-xrp6
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of `ParseAttrValue`(https://github.com/tensorflow/tensorflow/blob/c22d88d6ff33031aa113e48aa3fc9aa74ed79595/tensorflow/core/framework/attr_value_util.cc#L397-L453)
+  can be tricked into stack overflow due to recursion by giving in a specially crafted
+  input. The fix will be included in TensorFlow 2.5.0. We will also cherrypick this
+  commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4,
+  as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29615
+modified: '2021-08-27T03:22:41.882183Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/e07e1c3d26492c06f078c7e5bf2d138043e199c1
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-qw5h-7f53-xrp6

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29616.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29616.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: e6340f0665d53716ef3197ada88936c2a5f7a2d3
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29616
+- GHSA-4hvv-7x94-7vq8
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of TrySimplify(https://github.com/tensorflow/tensorflow/blob/c22d88d6ff33031aa113e48aa3fc9aa74ed79595/tensorflow/core/grappler/optimizers/arithmetic_optimizer.cc#L390-L401)
+  has undefined behavior due to dereferencing a null pointer in corner cases that
+  result in optimizing a node with no inputs. The fix will be included in TensorFlow
+  2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3,
+  TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported
+  range.
+id: PYSEC-0000-CVE-2021-29616
+modified: '2021-08-27T03:22:42.041590Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-4hvv-7x94-7vq8
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/e6340f0665d53716ef3197ada88936c2a5f7a2d3

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29617.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29617.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 890f7164b70354c57d40eda52dcdd7658677c09f
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29617
+- GHSA-mmq6-q8r3-48fm
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a denial of service via `CHECK`-fail in `tf.strings.substr` with
+  invalid arguments. The fix will be included in TensorFlow 2.5.0. We will also cherrypick
+  this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow
+  2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29617
+modified: '2021-08-27T03:22:42.200654Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/890f7164b70354c57d40eda52dcdd7658677c09f
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-mmq6-q8r3-48fm
+- type: REPORT
+  url: https://github.com/tensorflow/issues/46974
+- type: REPORT
+  url: https://github.com/tensorflow/issues/46900

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29618.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29618.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 1dc6a7ce6e0b3e27a7ae650bfc05b195ca793f88
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29618
+- GHSA-xqfj-cr6q-pc8w
+details: TensorFlow is an end-to-end open source platform for machine learning. Passing
+  a complex argument to `tf.transpose` at the same time as passing `conjugate=True`
+  argument results in a crash. The fix will be included in TensorFlow 2.5.0. We will
+  also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3
+  and TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29618
+modified: '2021-08-27T03:22:42.358462Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/1dc6a7ce6e0b3e27a7ae650bfc05b195ca793f88
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-xqfj-cr6q-pc8w
+- type: REPORT
+  url: https://github.com/tensorflow/issues/46973
+- type: REPORT
+  url: https://github.com/tensorflow/issues/42105

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29619.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-29619.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 82e6203221865de4008445b13c69b6826d2b28d9
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29619
+- GHSA-wvjw-p9f5-vq28
+details: TensorFlow is an end-to-end open source platform for machine learning. Passing
+  invalid arguments (e.g., discovered via fuzzing) to `tf.raw_ops.SparseCountSparseOutput`
+  results in segfault. The fix will be included in TensorFlow 2.5.0. We will also
+  cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and
+  TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29619
+modified: '2021-08-27T03:22:42.523296Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/82e6203221865de4008445b13c69b6826d2b28d9
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-wvjw-p9f5-vq28

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37635.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37635.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 87158f43f05f2720a374f3e6d22a7aaa3a33f750
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37635
+- GHSA-cgfm-62j4-v4rf
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions the implementation of sparse reduction operations in TensorFlow
+  can trigger accesses outside of bounds of heap allocated data. The [implementation](https://github.com/tensorflow/tensorflow/blob/a1bc56203f21a5a4995311825ffaba7a670d7747/tensorflow/core/kernels/sparse_reduce_op.cc#L217-L228)
+  fails to validate that each reduction group does not overflow and that each corresponding
+  index does not point to outside the bounds of the input tensor. We have patched
+  the issue in GitHub commit 87158f43f05f2720a374f3e6d22a7aaa3a33f750. The fix will
+  be included in TensorFlow 2.6.0. We will also cherrypick this commit on TensorFlow
+  2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-37635
+modified: '2021-08-27T03:22:42.637508Z'
+published: '2021-08-12T21:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/87158f43f05f2720a374f3e6d22a7aaa3a33f750
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-cgfm-62j4-v4rf

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37636.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37636.yaml
@@ -1,0 +1,36 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: d9204be9f49520cdaaeb2541d1dc5187b23f31d9
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37636
+- GHSA-hp4c-x6r7-6555
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions the implementation of `tf.raw_ops.SparseDenseCwiseDiv` is vulnerable
+  to a division by 0 error. The [implementation](https://github.com/tensorflow/tensorflow/blob/a1bc56203f21a5a4995311825ffaba7a670d7747/tensorflow/core/kernels/sparse_dense_binary_op_shared.cc#L56)
+  uses a common class for all binary operations but fails to treat the division by
+  0 case separately. We have patched the issue in GitHub commit d9204be9f49520cdaaeb2541d1dc5187b23f31d9.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37636
+modified: '2021-08-27T03:22:42.737707Z'
+published: '2021-08-12T18:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-hp4c-x6r7-6555
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/d9204be9f49520cdaaeb2541d1dc5187b23f31d9

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37637.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37637.yaml
@@ -1,0 +1,36 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 5dc7f6981fdaf74c8c5be41f393df705841fb7c5
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37637
+- GHSA-c9qf-r67m-p7cg
+details: TensorFlow is an end-to-end open source platform for machine learning. It
+  is possible to trigger a null pointer dereference in TensorFlow by passing an invalid
+  input to `tf.raw_ops.CompressElement`. The [implementation](https://github.com/tensorflow/tensorflow/blob/47a06f40411a69c99f381495f490536972152ac0/tensorflow/core/data/compression_utils.cc#L34)
+  was accessing the size of a buffer obtained from the return of a separate function
+  call before validating that said buffer is valid. We have patched the issue in GitHub
+  commit 5dc7f6981fdaf74c8c5be41f393df705841fb7c5. The fix will be included in TensorFlow
+  2.6.0. We will also cherrypick this commit on TensorFlow 2.5.1, TensorFlow 2.4.3,
+  and TensorFlow 2.3.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-37637
+modified: '2021-08-27T03:22:42.844418Z'
+published: '2021-08-12T19:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/5dc7f6981fdaf74c8c5be41f393df705841fb7c5
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-c9qf-r67m-p7cg

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37638.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37638.yaml
@@ -1,0 +1,36 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 301ae88b331d37a2a16159b65b255f4f9eb39314
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37638
+- GHSA-hwr7-8gxx-fj5p
+details: TensorFlow is an end-to-end open source platform for machine learning. Sending
+  invalid argument for `row_partition_types` of `tf.raw_ops.RaggedTensorToTensor`
+  API results in a null pointer dereference and undefined behavior. The [implementation](https://github.com/tensorflow/tensorflow/blob/47a06f40411a69c99f381495f490536972152ac0/tensorflow/core/kernels/ragged_tensor_to_tensor_op.cc#L328)
+  accesses the first element of a user supplied list of values without validating
+  that the provided list is not empty. We have patched the issue in GitHub commit
+  301ae88b331d37a2a16159b65b255f4f9eb39314. The fix will be included in TensorFlow
+  2.6.0. We will also cherrypick this commit on TensorFlow 2.5.1, TensorFlow 2.4.3,
+  and TensorFlow 2.3.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-37638
+modified: '2021-08-27T03:22:42.935785Z'
+published: '2021-08-12T19:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-hwr7-8gxx-fj5p
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/301ae88b331d37a2a16159b65b255f4f9eb39314

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37639.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37639.yaml
@@ -1,0 +1,42 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 9e82dce6e6bd1f36a57e08fa85af213e2b2f2622
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37639
+- GHSA-gh6x-4whr-2qv4
+details: TensorFlow is an end-to-end open source platform for machine learning. When
+  restoring tensors via raw APIs, if the tensor name is not provided, TensorFlow can
+  be tricked into dereferencing a null pointer. Alternatively, attackers can read
+  memory outside the bounds of heap allocated data by providing some tensor names
+  but not enough for a successful restoration. The [implementation](https://github.com/tensorflow/tensorflow/blob/47a06f40411a69c99f381495f490536972152ac0/tensorflow/core/kernels/save_restore_tensor.cc#L158-L159)
+  retrieves the tensor list corresponding to the `tensor_name` user controlled input
+  and immediately retrieves the tensor at the restoration index (controlled via `preferred_shard`
+  argument). This occurs without validating that the provided list has enough values.
+  If the list is empty this results in dereferencing a null pointer (undefined behavior).
+  If, however, the list has some elements, if the restoration index is outside the
+  bounds this results in heap OOB read. We have patched the issue in GitHub commit
+  9e82dce6e6bd1f36a57e08fa85af213e2b2f2622. The fix will be included in TensorFlow
+  2.6.0. We will also cherrypick this commit on TensorFlow 2.5.1, TensorFlow 2.4.3,
+  and TensorFlow 2.3.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-37639
+modified: '2021-08-27T03:22:43.020795Z'
+published: '2021-08-12T19:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-gh6x-4whr-2qv4
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/9e82dce6e6bd1f36a57e08fa85af213e2b2f2622

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37640.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37640.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 4923de56ec94fff7770df259ab7f2288a74feb41
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37640
+- GHSA-95xm-g58g-3p88
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions the implementation of `tf.raw_ops.SparseReshape` can be made to
+  trigger an integral division by 0 exception. The [implementation](https://github.com/tensorflow/tensorflow/blob/8d72537c6abf5a44103b57b9c2e22c14f5f49698/tensorflow/core/kernels/reshape_util.cc#L176-L181)
+  calls the reshaping functor whenever there is at least an index in the input but
+  does not check that shape of the input or the target shape have both a non-zero
+  number of elements. The [reshape functor](https://github.com/tensorflow/tensorflow/blob/8d72537c6abf5a44103b57b9c2e22c14f5f49698/tensorflow/core/kernels/reshape_util.cc#L40-L78)
+  blindly divides by the dimensions of the target shape. Hence, if this is not checked,
+  code will result in a division by 0. We have patched the issue in GitHub commit
+  4923de56ec94fff7770df259ab7f2288a74feb41. The fix will be included in TensorFlow
+  2.6.0. We will also cherrypick this commit on TensorFlow 2.5.1 as this is the other
+  affected version.
+id: PYSEC-0000-CVE-2021-37640
+modified: '2021-08-27T03:22:43.107664Z'
+published: '2021-08-12T18:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-95xm-g58g-3p88
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/4923de56ec94fff7770df259ab7f2288a74feb41

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37641.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37641.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: a2b743f6017d7b97af1fe49087ae15f0ac634373
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37641
+- GHSA-9c8h-vvrj-w2p8
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions if the arguments to `tf.raw_ops.RaggedGather` don't determine
+  a valid ragged tensor code can trigger a read from outside of bounds of heap allocated
+  buffers. The [implementation](https://github.com/tensorflow/tensorflow/blob/8d72537c6abf5a44103b57b9c2e22c14f5f49698/tensorflow/core/kernels/ragged_gather_op.cc#L70)
+  directly reads the first dimension of a tensor shape before checking that said tensor
+  has rank of at least 1 (i.e., it is not a scalar). Furthermore, the implementation
+  does not check that the list given by `params_nested_splits` is not an empty list
+  of tensors. We have patched the issue in GitHub commit a2b743f6017d7b97af1fe49087ae15f0ac634373.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37641
+modified: '2021-08-27T03:22:43.190554Z'
+published: '2021-08-12T21:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/a2b743f6017d7b97af1fe49087ae15f0ac634373
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-9c8h-vvrj-w2p8

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37642.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37642.yaml
@@ -1,0 +1,36 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 4aacb30888638da75023e6601149415b39763d76
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37642
+- GHSA-ch4f-829c-v5pw
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions the implementation of `tf.raw_ops.ResourceScatterDiv` is vulnerable
+  to a division by 0 error. The [implementation](https://github.com/tensorflow/tensorflow/blob/8d72537c6abf5a44103b57b9c2e22c14f5f49698/tensorflow/core/kernels/resource_variable_ops.cc#L865)
+  uses a common class for all binary operations but fails to treat the division by
+  0 case separately. We have patched the issue in GitHub commit 4aacb30888638da75023e6601149415b39763d76.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37642
+modified: '2021-08-27T03:22:43.277267Z'
+published: '2021-08-12T18:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/4aacb30888638da75023e6601149415b39763d76
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-ch4f-829c-v5pw

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37643.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37643.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 482da92095c4d48f8784b1f00dda4f81c28d2988
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37643
+- GHSA-fcwc-p4fc-c5cc
+details: TensorFlow is an end-to-end open source platform for machine learning. If
+  a user does not provide a valid padding value to `tf.raw_ops.MatrixDiagPartOp`,
+  then the code triggers a null pointer dereference (if input is empty) or produces
+  invalid behavior, ignoring all values after the first. The [implementation](https://github.com/tensorflow/tensorflow/blob/8d72537c6abf5a44103b57b9c2e22c14f5f49698/tensorflow/core/kernels/linalg/matrix_diag_op.cc#L89)
+  reads the first value from a tensor buffer without first checking that the tensor
+  has values to read from. We have patched the issue in GitHub commit 482da92095c4d48f8784b1f00dda4f81c28d2988.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37643
+modified: '2021-08-27T03:22:43.365129Z'
+published: '2021-08-12T19:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/482da92095c4d48f8784b1f00dda4f81c28d2988
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-fcwc-p4fc-c5cc

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37644.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37644.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 8a6e874437670045e6c7dc6154c7412b4a2135e2
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37644
+- GHSA-27j5-4p9v-pp67
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions providing a negative element to `num_elements` list argument of
+  `tf.raw_ops.TensorListReserve` causes the runtime to abort the process due to reallocating
+  a `std::vector` to have a negative number of elements. The [implementation](https://github.com/tensorflow/tensorflow/blob/8d72537c6abf5a44103b57b9c2e22c14f5f49698/tensorflow/core/kernels/list_kernels.cc#L312)
+  calls `std::vector.resize()` with the new size controlled by input given by the
+  user, without checking that this input is valid. We have patched the issue in GitHub
+  commit 8a6e874437670045e6c7dc6154c7412b4a2135e2. The fix will be included in TensorFlow
+  2.6.0. We will also cherrypick this commit on TensorFlow 2.5.1, TensorFlow 2.4.3,
+  and TensorFlow 2.3.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-37644
+modified: '2021-08-27T03:22:43.455188Z'
+published: '2021-08-12T21:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-27j5-4p9v-pp67
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/8a6e874437670045e6c7dc6154c7412b4a2135e2

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37645.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37645.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 96f364a1ca3009f98980021c4b32be5fdcca33a1
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37645
+- GHSA-9w2p-5mgw-p94c
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions the implementation of `tf.raw_ops.QuantizeAndDequantizeV4Grad`
+  is vulnerable to an integer overflow issue caused by converting a signed integer
+  value to an unsigned one and then allocating memory based on this value. The [implementation](https://github.com/tensorflow/tensorflow/blob/8d72537c6abf5a44103b57b9c2e22c14f5f49698/tensorflow/core/kernels/quantize_and_dequantize_op.cc#L126)
+  uses the `axis` value as the size argument to `absl::InlinedVector` constructor.
+  But, the constructor uses an unsigned type for the argument, so the implicit conversion
+  transforms the negative value to a large integer. We have patched the issue in GitHub
+  commit 96f364a1ca3009f98980021c4b32be5fdcca33a1. The fix will be included in TensorFlow
+  2.6.0. We will also cherrypick this commit on TensorFlow 2.5.1, and TensorFlow 2.4.3,
+  as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-37645
+modified: '2021-08-27T03:22:43.539250Z'
+published: '2021-08-12T21:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-9w2p-5mgw-p94c
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/96f364a1ca3009f98980021c4b32be5fdcca33a1

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37646.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37646.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: c283e542a3f422420cfdb332414543b62fc4e4a5
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37646
+- GHSA-h6jh-7gv5-28vg
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions the implementation of `tf.raw_ops.StringNGrams` is vulnerable
+  to an integer overflow issue caused by converting a signed integer value to an unsigned
+  one and then allocating memory based on this value. The [implementation](https://github.com/tensorflow/tensorflow/blob/8d72537c6abf5a44103b57b9c2e22c14f5f49698/tensorflow/core/kernels/string_ngrams_op.cc#L184)
+  calls `reserve` on a `tstring` with a value that sometimes can be negative if user
+  supplies negative `ngram_widths`. The `reserve` method calls `TF_TString_Reserve`
+  which has an `unsigned long` argument for the size of the buffer. Hence, the implicit
+  conversion transforms the negative value to a large integer. We have patched the
+  issue in GitHub commit c283e542a3f422420cfdb332414543b62fc4e4a5. The fix will be
+  included in TensorFlow 2.6.0. We will also cherrypick this commit on TensorFlow
+  2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-37646
+modified: '2021-08-27T03:22:43.623027Z'
+published: '2021-08-12T21:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/c283e542a3f422420cfdb332414543b62fc4e4a5
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-h6jh-7gv5-28vg

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37647.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37647.yaml
@@ -1,0 +1,42 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 02cc160e29d20631de3859c6653184e3f876b9d7
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37647
+- GHSA-c5x2-p679-95wc
+details: TensorFlow is an end-to-end open source platform for machine learning. When
+  a user does not supply arguments that determine a valid sparse tensor, `tf.raw_ops.SparseTensorSliceDataset`
+  implementation can be made to dereference a null pointer. The [implementation](https://github.com/tensorflow/tensorflow/blob/8d72537c6abf5a44103b57b9c2e22c14f5f49698/tensorflow/core/kernels/data/sparse_tensor_slice_dataset_op.cc#L240-L251)
+  has some argument validation but fails to consider the case when either `indices`
+  or `values` are provided for an empty sparse tensor when the other is not. If `indices`
+  is empty, then [code that performs validation](https://github.com/tensorflow/tensorflow/blob/8d72537c6abf5a44103b57b9c2e22c14f5f49698/tensorflow/core/kernels/data/sparse_tensor_slice_dataset_op.cc#L260-L261)
+  (i.e., checking that the indices are monotonically increasing) results in a null
+  pointer dereference. If `indices` as provided by the user is empty, then `indices`
+  in the C++ code above is backed by an empty `std::vector`, hence calling `indices->dim_size(0)`
+  results in null pointer dereferencing (same as calling `std::vector::at()` on an
+  empty vector). We have patched the issue in GitHub commit 02cc160e29d20631de3859c6653184e3f876b9d7.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37647
+modified: '2021-08-27T03:22:43.708163Z'
+published: '2021-08-12T19:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-c5x2-p679-95wc
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/02cc160e29d20631de3859c6653184e3f876b9d7

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37648.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37648.yaml
@@ -1,0 +1,42 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 9728c60e136912a12d99ca56e106b7cce7af5986
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37648
+- GHSA-wp77-4gmm-7cq8
+details: 'TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions the code for `tf.raw_ops.SaveV2` does not properly validate the
+  inputs and an attacker can trigger a null pointer dereference. The [implementation](https://github.com/tensorflow/tensorflow/blob/8d72537c6abf5a44103b57b9c2e22c14f5f49698/tensorflow/core/kernels/save_restore_v2_ops.cc)
+  uses `ValidateInputs` to check that the input arguments are valid. This validation
+  would have caught the illegal state represented by the reproducer above. However,
+  the validation uses `OP_REQUIRES` which translates to setting the `Status` object
+  of the current `OpKernelContext` to an error status, followed by an empty `return`
+  statement which just terminates the execution of the function it is present in.
+  However, this does not mean that the kernel execution is finalized: instead, execution
+  continues from the next line in `Compute` that follows the call to `ValidateInputs`.
+  This is equivalent to lacking the validation. We have patched the issue in GitHub
+  commit 9728c60e136912a12d99ca56e106b7cce7af5986. The fix will be included in TensorFlow
+  2.6.0. We will also cherrypick this commit on TensorFlow 2.5.1, TensorFlow 2.4.3,
+  and TensorFlow 2.3.4, as these are also affected and still in supported range.'
+id: PYSEC-0000-CVE-2021-37648
+modified: '2021-08-27T03:22:43.792593Z'
+published: '2021-08-12T22:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/9728c60e136912a12d99ca56e106b7cce7af5986
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-wp77-4gmm-7cq8

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37649.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37649.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 7bdf50bb4f5c54a4997c379092888546c97c3ebd
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37649
+- GHSA-6gv8-p3vj-pxvr
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  code for `tf.raw_ops.UncompressElement` can be made to trigger a null pointer dereference.
+  The [implementation](https://github.com/tensorflow/tensorflow/blob/f24faa153ad31a4b51578f8181d3aaab77a1ddeb/tensorflow/core/kernels/data/experimental/compression_ops.cc#L50-L53)
+  obtains a pointer to a `CompressedElement` from a `Variant` tensor and then proceeds
+  to dereference it for decompressing. There is no check that the `Variant` tensor
+  contained a `CompressedElement`, so the pointer is actually `nullptr`. We have patched
+  the issue in GitHub commit 7bdf50bb4f5c54a4997c379092888546c97c3ebd. The fix will
+  be included in TensorFlow 2.6.0. We will also cherrypick this commit on TensorFlow
+  2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-37649
+modified: '2021-08-27T03:22:43.879548Z'
+published: '2021-08-12T19:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/7bdf50bb4f5c54a4997c379092888546c97c3ebd
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-6gv8-p3vj-pxvr

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37650.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37650.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: e0b6e58c328059829c3eb968136f17aa72b6c876
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37650
+- GHSA-f8h4-7rgh-q2gm
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions the implementation for `tf.raw_ops.ExperimentalDatasetToTFRecord`
+  and `tf.raw_ops.DatasetToTFRecord` can trigger heap buffer overflow and segmentation
+  fault. The [implementation](https://github.com/tensorflow/tensorflow/blob/f24faa153ad31a4b51578f8181d3aaab77a1ddeb/tensorflow/core/kernels/data/experimental/to_tf_record_op.cc#L93-L102)
+  assumes that all records in the dataset are of string type. However, there is no
+  check for that, and the example given above uses numeric types. We have patched
+  the issue in GitHub commit e0b6e58c328059829c3eb968136f17aa72b6c876. The fix will
+  be included in TensorFlow 2.6.0. We will also cherrypick this commit on TensorFlow
+  2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-37650
+modified: '2021-08-27T03:22:43.967494Z'
+published: '2021-08-12T21:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/e0b6e58c328059829c3eb968136f17aa72b6c876
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-f8h4-7rgh-q2gm

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37651.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37651.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 0f931751fb20f565c4e94aa6df58d54a003cdb30
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37651
+- GHSA-hpv4-7p9c-mvfr
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions the implementation for `tf.raw_ops.FractionalAvgPoolGrad` can
+  be tricked into accessing data outside of bounds of heap allocated buffers. The
+  [implementation](https://github.com/tensorflow/tensorflow/blob/f24faa153ad31a4b51578f8181d3aaab77a1ddeb/tensorflow/core/kernels/fractional_avg_pool_op.cc#L205)
+  does not validate that the input tensor is non-empty. Thus, code constructs an empty
+  `EigenDoubleMatrixMap` and then accesses this buffer with indices that are outside
+  of the empty area. We have patched the issue in GitHub commit 0f931751fb20f565c4e94aa6df58d54a003cdb30.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37651
+modified: '2021-08-27T03:22:44.051773Z'
+published: '2021-08-12T21:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-hpv4-7p9c-mvfr
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/0f931751fb20f565c4e94aa6df58d54a003cdb30

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37652.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37652.yaml
@@ -1,0 +1,43 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 5ecec9c6fbdbc6be03295685190a45e7eee726ab
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37652
+- GHSA-m7fm-4jfh-jrg6
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions the implementation for `tf.raw_ops.BoostedTreesCreateEnsemble`
+  can result in a use after free error if an attacker supplies specially crafted arguments.
+  The [implementation](https://github.com/tensorflow/tensorflow/blob/f24faa153ad31a4b51578f8181d3aaab77a1ddeb/tensorflow/core/kernels/boosted_trees/resource_ops.cc#L55)
+  uses a reference counted resource and decrements the refcount if the initialization
+  fails, as it should. However, when the code was written, the resource was represented
+  as a naked pointer but later refactoring has changed it to be a smart pointer. Thus,
+  when the pointer leaves the scope, a subsequent `free`-ing of the resource occurs,
+  but this fails to take into account that the refcount has already reached 0, thus
+  the resource has been already freed. During this double-free process, members of
+  the resource object are accessed for cleanup but they are invalid as the entire
+  resource has been freed. We have patched the issue in GitHub commit 5ecec9c6fbdbc6be03295685190a45e7eee726ab.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37652
+modified: '2021-08-27T03:22:44.162996Z'
+published: '2021-08-12T22:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/5ecec9c6fbdbc6be03295685190a45e7eee726ab
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-m7fm-4jfh-jrg6

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37653.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37653.yaml
@@ -1,0 +1,36 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: ac117ee8a8ea57b73d34665cdf00ef3303bc0b11
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37653
+- GHSA-qjj8-32p7-h289
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can trigger a crash via a floating point exception
+  in `tf.raw_ops.ResourceGather`. The [implementation](https://github.com/tensorflow/tensorflow/blob/f24faa153ad31a4b51578f8181d3aaab77a1ddeb/tensorflow/core/kernels/resource_variable_ops.cc#L725-L731)
+  computes the value of a value, `batch_size`, and then divides by it without checking
+  that this value is not 0. We have patched the issue in GitHub commit ac117ee8a8ea57b73d34665cdf00ef3303bc0b11.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37653
+modified: '2021-08-27T03:22:44.260808Z'
+published: '2021-08-12T18:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-qjj8-32p7-h289
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/ac117ee8a8ea57b73d34665cdf00ef3303bc0b11

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37654.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37654.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: bc9c546ce7015c57c2f15c168b3d9201de679a1d
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37654
+- GHSA-2r8p-fg3c-wcj4
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can trigger a crash via a `CHECK`-fail in debug builds
+  of TensorFlow using `tf.raw_ops.ResourceGather` or a read from outside the bounds
+  of heap allocated data in the same API in a release build. The [implementation](https://github.com/tensorflow/tensorflow/blob/f24faa153ad31a4b51578f8181d3aaab77a1ddeb/tensorflow/core/kernels/resource_variable_ops.cc#L660-L668)
+  does not check that the `batch_dims` value that the user supplies is less than the
+  rank of the input tensor. Since the implementation uses several for loops over the
+  dimensions of `tensor`, this results in reading data from outside the bounds of
+  heap allocated buffer backing the tensor. We have patched the issue in GitHub commit
+  bc9c546ce7015c57c2f15c168b3d9201de679a1d. The fix will be included in TensorFlow
+  2.6.0. We will also cherrypick this commit on TensorFlow 2.5.1, TensorFlow 2.4.3,
+  and TensorFlow 2.3.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-37654
+modified: '2021-08-27T03:22:44.348474Z'
+published: '2021-08-12T21:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-2r8p-fg3c-wcj4
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/bc9c546ce7015c57c2f15c168b3d9201de679a1d

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37655.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37655.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 01cff3f986259d661103412a20745928c727326f
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37655
+- GHSA-7fvx-3jfc-2cpc
+details: 'TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can trigger a read from outside of bounds of heap
+  allocated data by sending invalid arguments to `tf.raw_ops.ResourceScatterUpdate`.
+  The [implementation](https://github.com/tensorflow/tensorflow/blob/f24faa153ad31a4b51578f8181d3aaab77a1ddeb/tensorflow/core/kernels/resource_variable_ops.cc#L919-L923)
+  has an incomplete validation of the relationship between the shapes of `indices`
+  and `updates`: instead of checking that the shape of `indices` is a prefix of the
+  shape of `updates` (so that broadcasting can happen), code only checks that the
+  number of elements in these two tensors are in a divisibility relationship. We have
+  patched the issue in GitHub commit 01cff3f986259d661103412a20745928c727326f. The
+  fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit on
+  TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.'
+id: PYSEC-0000-CVE-2021-37655
+modified: '2021-08-27T03:22:44.439225Z'
+published: '2021-08-12T21:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-7fvx-3jfc-2cpc
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/01cff3f986259d661103412a20745928c727326f

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37656.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37656.yaml
@@ -1,0 +1,36 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 1071f554dbd09f7e101324d366eec5f4fe5a3ece
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37656
+- GHSA-4xfp-4pfp-89wg
+details: 'TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can cause undefined behavior via binding a reference
+  to null pointer in `tf.raw_ops.RaggedTensorToSparse`. The [implementation](https://github.com/tensorflow/tensorflow/blob/f24faa153ad31a4b51578f8181d3aaab77a1ddeb/tensorflow/core/kernels/ragged_tensor_to_sparse_kernel.cc#L30)
+  has an incomplete validation of the splits values: it does not check that they are
+  in increasing order. We have patched the issue in GitHub commit 1071f554dbd09f7e101324d366eec5f4fe5a3ece.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.'
+id: PYSEC-0000-CVE-2021-37656
+modified: '2021-08-27T03:22:44.528249Z'
+published: '2021-08-12T21:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/1071f554dbd09f7e101324d366eec5f4fe5a3ece
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-4xfp-4pfp-89wg

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37657.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37657.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: f2a673bd34f0d64b8e40a551ac78989d16daad09
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37657
+- GHSA-5xwc-mrhx-5g3m
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can cause undefined behavior via binding a reference
+  to null pointer in all operations of type `tf.raw_ops.MatrixDiagV*`. The [implementation](https://github.com/tensorflow/tensorflow/blob/84d053187cb80d975ef2b9684d4b61981bca0c41/tensorflow/core/kernels/linalg/matrix_diag_op.cc)
+  has incomplete validation that the value of `k` is a valid tensor. We have check
+  that this value is either a scalar or a vector, but there is no check for the number
+  of elements. If this is an empty tensor, then code that accesses the first element
+  of the tensor is wrong. We have patched the issue in GitHub commit f2a673bd34f0d64b8e40a551ac78989d16daad09.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37657
+modified: '2021-08-27T03:22:44.622008Z'
+published: '2021-08-12T21:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/f2a673bd34f0d64b8e40a551ac78989d16daad09
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-5xwc-mrhx-5g3m

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37658.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37658.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: ff8894044dfae5568ecbf2ed514c1a37dc394f1b
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37658
+- GHSA-6p5r-g9mq-ggh2
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can cause undefined behavior via binding a reference
+  to null pointer in all operations of type `tf.raw_ops.MatrixSetDiagV*`. The [implementation](https://github.com/tensorflow/tensorflow/blob/84d053187cb80d975ef2b9684d4b61981bca0c41/tensorflow/core/kernels/linalg/matrix_diag_op.cc)
+  has incomplete validation that the value of `k` is a valid tensor. We have check
+  that this value is either a scalar or a vector, but there is no check for the number
+  of elements. If this is an empty tensor, then code that accesses the first element
+  of the tensor is wrong. We have patched the issue in GitHub commit ff8894044dfae5568ecbf2ed514c1a37dc394f1b.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37658
+modified: '2021-08-27T03:22:44.725554Z'
+published: '2021-08-12T21:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/ff8894044dfae5568ecbf2ed514c1a37dc394f1b
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-6p5r-g9mq-ggh2

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37659.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37659.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 93f428fd1768df147171ed674fee1fc5ab8309ec
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37659
+- GHSA-q3g3-h9r4-prrc
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can cause undefined behavior via binding a reference
+  to null pointer in all binary cwise operations that don't require broadcasting (e.g.,
+  gradients of binary cwise operations). The [implementation](https://github.com/tensorflow/tensorflow/blob/84d053187cb80d975ef2b9684d4b61981bca0c41/tensorflow/core/kernels/cwise_ops_common.h#L264)
+  assumes that the two inputs have exactly the same number of elements but does not
+  check that. Hence, when the eigen functor executes it triggers heap OOB reads and
+  undefined behavior due to binding to nullptr. We have patched the issue in GitHub
+  commit 93f428fd1768df147171ed674fee1fc5ab8309ec. The fix will be included in TensorFlow
+  2.6.0. We will also cherrypick this commit on TensorFlow 2.5.1, TensorFlow 2.4.3,
+  and TensorFlow 2.3.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-37659
+modified: '2021-08-27T03:22:44.808272Z'
+published: '2021-08-12T21:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/93f428fd1768df147171ed674fee1fc5ab8309ec
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-q3g3-h9r4-prrc

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37660.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37660.yaml
@@ -1,0 +1,36 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: e86605c0a336c088b638da02135ea6f9f6753618
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37660
+- GHSA-cm5x-837x-jf3c
+details: 'TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can cause a floating point exception by calling inplace
+  operations with crafted arguments that would result in a division by 0. The [implementation](https://github.com/tensorflow/tensorflow/blob/84d053187cb80d975ef2b9684d4b61981bca0c41/tensorflow/core/kernels/inplace_ops.cc#L283)
+  has a logic error: it should skip processing if `x` and `v` are empty but the code
+  uses `||` instead of `&&`. We have patched the issue in GitHub commit e86605c0a336c088b638da02135ea6f9f6753618.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.'
+id: PYSEC-0000-CVE-2021-37660
+modified: '2021-08-27T03:22:44.908068Z'
+published: '2021-08-12T18:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-cm5x-837x-jf3c
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/e86605c0a336c088b638da02135ea6f9f6753618

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37661.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37661.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 8a84f7a2b5a2b27ecf88d25bad9ac777cd2f7992
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37661
+- GHSA-gf88-j2mg-cc82
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can cause a denial of service in `boosted_trees_create_quantile_stream_resource`
+  by using negative arguments. The [implementation](https://github.com/tensorflow/tensorflow/blob/84d053187cb80d975ef2b9684d4b61981bca0c41/tensorflow/core/kernels/boosted_trees/quantile_ops.cc#L96)
+  does not validate that `num_streams` only contains non-negative numbers. In turn,
+  [this results in using this value to allocate memory](https://github.com/tensorflow/tensorflow/blob/84d053187cb80d975ef2b9684d4b61981bca0c41/tensorflow/core/kernels/boosted_trees/quantiles/quantile_stream_resource.h#L31-L40).
+  However, `reserve` receives an unsigned integer so there is an implicit conversion
+  from a negative value to a large positive unsigned. This results in a crash from
+  the standard library. We have patched the issue in GitHub commit 8a84f7a2b5a2b27ecf88d25bad9ac777cd2f7992.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37661
+modified: '2021-08-27T03:22:45.010979Z'
+published: '2021-08-12T21:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/8a84f7a2b5a2b27ecf88d25bad9ac777cd2f7992
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-gf88-j2mg-cc82

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37662.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37662.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 9c87c32c710d0b5b53dc6fd3bfde4046e1f7a5ad
+    - fixed: 429f009d2b2c09028647dd4bb7b3f6f414bbaad7
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37662
+- GHSA-f5cx-5wr3-5qrc
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can generate undefined behavior via a reference binding
+  to nullptr in `BoostedTreesCalculateBestGainsPerFeature` and similar attack can
+  occur in `BoostedTreesCalculateBestFeatureSplitV2`. The [implementation](https://github.com/tensorflow/tensorflow/blob/84d053187cb80d975ef2b9684d4b61981bca0c41/tensorflow/core/kernels/boosted_trees/stats_ops.cc)
+  does not validate the input values. We have patched the issue in GitHub commit 9c87c32c710d0b5b53dc6fd3bfde4046e1f7a5ad
+  and in commit 429f009d2b2c09028647dd4bb7b3f6f414bbaad7. The fix will be included
+  in TensorFlow 2.6.0. We will also cherrypick this commit on TensorFlow 2.5.1, TensorFlow
+  2.4.3, and TensorFlow 2.3.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-37662
+modified: '2021-08-27T03:22:45.118929Z'
+published: '2021-08-12T21:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/9c87c32c710d0b5b53dc6fd3bfde4046e1f7a5ad
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-f5cx-5wr3-5qrc
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/429f009d2b2c09028647dd4bb7b3f6f414bbaad7

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37663.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37663.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 6da6620efad397c85493b8f8667b821403516708
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37663
+- GHSA-g25h-jr74-qp5j
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions due to incomplete validation in `tf.raw_ops.QuantizeV2`, an attacker
+  can trigger undefined behavior via binding a reference to a null pointer or can
+  access data outside the bounds of heap allocated arrays. The [implementation](https://github.com/tensorflow/tensorflow/blob/84d053187cb80d975ef2b9684d4b61981bca0c41/tensorflow/core/kernels/quantize_op.cc#L59)
+  has some validation but does not check that `min_range` and `max_range` both have
+  the same non-zero number of elements. If `axis` is provided (i.e., not `-1`), then
+  validation should check that it is a value in range for the rank of `input` tensor
+  and then the lengths of `min_range` and `max_range` inputs match the `axis` dimension
+  of the `input` tensor. We have patched the issue in GitHub commit 6da6620efad397c85493b8f8667b821403516708.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37663
+modified: '2021-08-27T03:22:45.209094Z'
+published: '2021-08-12T23:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/6da6620efad397c85493b8f8667b821403516708
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-g25h-jr74-qp5j

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37664.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37664.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: e84c975313e8e8e38bb2ea118196369c45c51378
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37664
+- GHSA-r4c4-5fpq-56wg
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can read from outside of bounds of heap allocated
+  data by sending specially crafted illegal arguments to `BoostedTreesSparseCalculateBestFeatureSplit`.
+  The [implementation](https://github.com/tensorflow/tensorflow/blob/84d053187cb80d975ef2b9684d4b61981bca0c41/tensorflow/core/kernels/boosted_trees/stats_ops.cc)
+  needs to validate that each value in `stats_summary_indices` is in range. We have
+  patched the issue in GitHub commit e84c975313e8e8e38bb2ea118196369c45c51378. The
+  fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit on
+  TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37664
+modified: '2021-08-27T03:22:45.297527Z'
+published: '2021-08-12T21:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-r4c4-5fpq-56wg
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/e84c975313e8e8e38bb2ea118196369c45c51378

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37665.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37665.yaml
@@ -1,0 +1,42 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 9e62869465573cb2d9b5053f1fa02a81fce21d69
+    - fixed: 203214568f5bc237603dbab6e1fd389f1572f5c9
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37665
+- GHSA-v82p-hv3v-p6qp
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions due to incomplete validation in MKL implementation of requantization,
+  an attacker can trigger undefined behavior via binding a reference to a null pointer
+  or can access data outside the bounds of heap allocated arrays. The [implementation](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/core/kernels/mkl/mkl_requantization_range_per_channel_op.cc)
+  does not validate the dimensions of the `input` tensor. A similar issue occurs in
+  `MklRequantizePerChannelOp`. The [implementation](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/core/kernels/mkl/mkl_requantize_per_channel_op.cc)
+  does not perform full validation for all the input arguments. We have patched the
+  issue in GitHub commit 9e62869465573cb2d9b5053f1fa02a81fce21d69 and in the Github
+  commit 203214568f5bc237603dbab6e1fd389f1572f5c9. The fix will be included in TensorFlow
+  2.6.0. We will also cherrypick this commit on TensorFlow 2.5.1, TensorFlow 2.4.3,
+  and TensorFlow 2.3.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-37665
+modified: '2021-08-27T03:22:45.390087Z'
+published: '2021-08-12T23:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/9e62869465573cb2d9b5053f1fa02a81fce21d69
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-v82p-hv3v-p6qp
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/203214568f5bc237603dbab6e1fd389f1572f5c9

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37666.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37666.yaml
@@ -1,0 +1,36 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: be7a4de6adfbd303ce08be4332554dff70362612
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37666
+- GHSA-w4xf-2pqw-5mq7
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can cause undefined behavior via binding a reference
+  to null pointer in `tf.raw_ops.RaggedTensorToVariant`. The [implementation](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/core/kernels/ragged_tensor_to_variant_op.cc#L129)
+  has an incomplete validation of the splits values, missing the case when the argument
+  would be empty. We have patched the issue in GitHub commit be7a4de6adfbd303ce08be4332554dff70362612.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37666
+modified: '2021-08-27T03:22:45.481654Z'
+published: '2021-08-12T22:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/be7a4de6adfbd303ce08be4332554dff70362612
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-w4xf-2pqw-5mq7

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37667.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37667.yaml
@@ -1,0 +1,36 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 2e0ee46f1a47675152d3d865797a18358881d7a6
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37667
+- GHSA-w74j-v8xh-3w5h
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can cause undefined behavior via binding a reference
+  to null pointer in `tf.raw_ops.UnicodeEncode`. The [implementation](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/core/kernels/unicode_ops.cc#L533-L539)
+  reads the first dimension of the `input_splits` tensor before validating that this
+  tensor is not empty. We have patched the issue in GitHub commit 2e0ee46f1a47675152d3d865797a18358881d7a6.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37667
+modified: '2021-08-27T03:22:45.582995Z'
+published: '2021-08-12T22:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/2e0ee46f1a47675152d3d865797a18358881d7a6
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-w74j-v8xh-3w5h

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37668.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37668.yaml
@@ -1,0 +1,36 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: a776040a5e7ebf76eeb7eb923bf1ae417dd4d233
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37668
+- GHSA-2wmv-37vq-52g5
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can cause denial of service in applications serving
+  models using `tf.raw_ops.UnravelIndex` by triggering a division by 0. The [implementation](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/core/kernels/unravel_index_op.cc#L36)
+  does not check that the tensor subsumed by `dims` is not empty. Hence, if one element
+  of `dims` is 0, the implementation does a division by 0. We have patched the issue
+  in GitHub commit a776040a5e7ebf76eeb7eb923bf1ae417dd4d233. The fix will be included
+  in TensorFlow 2.6.0. We will also cherrypick this commit on TensorFlow 2.5.1, TensorFlow
+  2.4.3, and TensorFlow 2.3.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-37668
+modified: '2021-08-27T03:22:45.672870Z'
+published: '2021-08-12T23:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/a776040a5e7ebf76eeb7eb923bf1ae417dd4d233
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-2wmv-37vq-52g5

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37669.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37669.yaml
@@ -1,0 +1,43 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 3a7362750d5c372420aa8f0caf7bf5b5c3d0f52d
+    - fixed: b5cdbf12ffcaaffecf98f22a6be5a64bb96e4f58
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37669
+- GHSA-vmjw-c2vp-p33c
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can cause denial of service in applications serving
+  models using `tf.raw_ops.NonMaxSuppressionV5` by triggering a division by 0. The
+  [implementation](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/core/kernels/image/non_max_suppression_op.cc#L170-L271)
+  uses a user controlled argument to resize a `std::vector`. However, as `std::vector::resize`
+  takes the size argument as a `size_t` and `output_size` is an `int`, there is an
+  implicit conversion to unsigned. If the attacker supplies a negative value, this
+  conversion results in a crash. A similar issue occurs in `CombinedNonMaxSuppression`.
+  We have patched the issue in GitHub commit 3a7362750d5c372420aa8f0caf7bf5b5c3d0f52d
+  and commit [b5cdbf12ffcaaffecf98f22a6be5a64bb96e4f58. The fix will be included in
+  TensorFlow 2.6.0. We will also cherrypick this commit on TensorFlow 2.5.1, TensorFlow
+  2.4.3, and TensorFlow 2.3.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-37669
+modified: '2021-08-27T03:22:45.759545Z'
+published: '2021-08-12T23:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-vmjw-c2vp-p33c
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/3a7362750d5c372420aa8f0caf7bf5b5c3d0f52d
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/b5cdbf12ffcaaffecf98f22a6be5a64bb96e4f58

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37670.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37670.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 42459e4273c2e47a3232cc16c4f4fff3b3a35c38
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37670
+- GHSA-9697-98pf-4rw7
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can read from outside of bounds of heap allocated
+  data by sending specially crafted illegal arguments to `tf.raw_ops.UpperBound`.
+  The [implementation](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/core/kernels/searchsorted_op.cc#L85-L104)
+  does not validate the rank of `sorted_input` argument. A similar issue occurs in
+  `tf.raw_ops.LowerBound`. We have patched the issue in GitHub commit 42459e4273c2e47a3232cc16c4f4fff3b3a35c38.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37670
+modified: '2021-08-27T03:22:45.845259Z'
+published: '2021-08-12T23:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/42459e4273c2e47a3232cc16c4f4fff3b3a35c38
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-9697-98pf-4rw7

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37671.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37671.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 532f5c5a547126c634fefd43bbad1dc6417678ac
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37671
+- GHSA-qr82-2c78-4m8h
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can cause undefined behavior via binding a reference
+  to null pointer in `tf.raw_ops.Map*` and `tf.raw_ops.OrderedMap*` operations. The
+  [implementation](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/core/kernels/map_stage_op.cc#L222-L248)
+  has a check in place to ensure that `indices` is in ascending order, but does not
+  check that `indices` is not empty. We have patched the issue in GitHub commit 532f5c5a547126c634fefd43bbad1dc6417678ac.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37671
+modified: '2021-08-27T03:22:45.925209Z'
+published: '2021-08-12T22:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/532f5c5a547126c634fefd43bbad1dc6417678ac
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-qr82-2c78-4m8h

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37672.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37672.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: a4e138660270e7599793fa438cd7b2fc2ce215a6
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37672
+- GHSA-5hj3-vjjf-f5m7
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can read from outside of bounds of heap allocated
+  data by sending specially crafted illegal arguments to `tf.raw_ops.SdcaOptimizerV2`.
+  The [implementation](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/core/kernels/sdca_internal.cc#L320-L353)
+  does not check that the length of `example_labels` is the same as the number of
+  examples. We have patched the issue in GitHub commit a4e138660270e7599793fa438cd7b2fc2ce215a6.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37672
+modified: '2021-08-27T03:22:46.024313Z'
+published: '2021-08-12T23:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/a4e138660270e7599793fa438cd7b2fc2ce215a6
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-5hj3-vjjf-f5m7

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37673.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37673.yaml
@@ -1,0 +1,36 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: d7de67733925de196ec8863a33445b73f9562d1d
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37673
+- GHSA-278g-rq84-9hmg
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can trigger a denial of service via a `CHECK`-fail
+  in `tf.raw_ops.MapStage`. The [implementation](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/core/kernels/map_stage_op.cc#L513)
+  does not check that the `key` input is a valid non-empty tensor. We have patched
+  the issue in GitHub commit d7de67733925de196ec8863a33445b73f9562d1d. The fix will
+  be included in TensorFlow 2.6.0. We will also cherrypick this commit on TensorFlow
+  2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-37673
+modified: '2021-08-27T03:22:46.123018Z'
+published: '2021-08-12T23:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/d7de67733925de196ec8863a33445b73f9562d1d
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-278g-rq84-9hmg

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37674.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37674.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 136b51f10903e044308cf77117c0ed9871350475
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37674
+- GHSA-7ghq-fvr3-pj2x
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can trigger a denial of service via a segmentation
+  fault in `tf.raw_ops.MaxPoolGrad` caused by missing validation. The [implementation](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/core/kernels/maxpooling_op.cc)
+  misses some validation for the `orig_input` and `orig_output` tensors. The fixes
+  for CVE-2021-29579 were incomplete. We have patched the issue in GitHub commit 136b51f10903e044308cf77117c0ed9871350475.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37674
+modified: '2021-08-27T03:22:46.211223Z'
+published: '2021-08-12T23:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/136b51f10903e044308cf77117c0ed9871350475
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-7ghq-fvr3-pj2x
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/security/advisory/tfsa-2021-068.md

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37675.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37675.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 8a793b5d7f59e37ac7f3cd0954a750a2fe76bad4
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37675
+- GHSA-9c8h-2mv3-49ww
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions most implementations of convolution operators in TensorFlow are
+  affected by a division by 0 vulnerability where an attacker can trigger a denial
+  of service via a crash. The shape inference [implementation](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/core/framework/common_shape_fns.cc#L577)
+  is missing several validations before doing divisions and modulo operations. We
+  have patched the issue in GitHub commit 8a793b5d7f59e37ac7f3cd0954a750a2fe76bad4.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37675
+modified: '2021-08-27T03:22:46.293986Z'
+published: '2021-08-12T22:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-9c8h-2mv3-49ww
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/8a793b5d7f59e37ac7f3cd0954a750a2fe76bad4

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37676.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37676.yaml
@@ -1,0 +1,36 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 578e634b4f1c1c684d4b4294f9e5281b2133b3ed
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37676
+- GHSA-v768-w7m9-2vmm
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can cause undefined behavior via binding a reference
+  to null pointer in `tf.raw_ops.SparseFillEmptyRows`. The shape inference [implementation](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/core/ops/sparse_ops.cc#L608-L634)
+  does not validate that the input arguments are not empty tensors. We have patched
+  the issue in GitHub commit 578e634b4f1c1c684d4b4294f9e5281b2133b3ed. The fix will
+  be included in TensorFlow 2.6.0. We will also cherrypick this commit on TensorFlow
+  2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-37676
+modified: '2021-08-27T03:22:46.384345Z'
+published: '2021-08-12T22:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/578e634b4f1c1c684d4b4294f9e5281b2133b3ed
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-v768-w7m9-2vmm

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37677.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37677.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: da857cfa0fde8f79ad0afdbc94e88b5d4bbec764
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37677
+- GHSA-qfpc-5pjr-mh26
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions the shape inference code for `tf.raw_ops.Dequantize` has a vulnerability
+  that could trigger a denial of service via a segfault if an attacker provides invalid
+  arguments. The shape inference [implementation](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/core/ops/array_ops.cc#L2999-L3014)
+  uses `axis` to select between two different values for `minmax_rank` which is then
+  used to retrieve tensor dimensions. However, code assumes that `axis` can be either
+  `-1` or a value greater than `-1`, with no validation for the other values. We have
+  patched the issue in GitHub commit da857cfa0fde8f79ad0afdbc94e88b5d4bbec764. The
+  fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit on
+  TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37677
+modified: '2021-08-27T03:22:46.477427Z'
+published: '2021-08-12T23:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-qfpc-5pjr-mh26
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/da857cfa0fde8f79ad0afdbc94e88b5d4bbec764

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37678.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37678.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 23d6383eb6c14084a8fc3bdf164043b974818012
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37678
+- GHSA-r6jx-9g48-2r5r
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions TensorFlow and Keras can be tricked to perform arbitrary code
+  execution when deserializing a Keras model from YAML format. The [implementation](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/python/keras/saving/model_config.py#L66-L104)
+  uses `yaml.unsafe_load` which can perform arbitrary code execution on the input.
+  Given that YAML format support requires a significant amount of work, we have removed
+  it for now. We have patched the issue in GitHub commit 23d6383eb6c14084a8fc3bdf164043b974818012.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37678
+modified: '2021-08-27T03:22:46.598549Z'
+published: '2021-08-12T23:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-r6jx-9g48-2r5r
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/23d6383eb6c14084a8fc3bdf164043b974818012

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37679.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37679.yaml
@@ -1,0 +1,42 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 4e2565483d0ffcadc719bd44893fb7f609bb5f12
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37679
+- GHSA-g8wg-cjwc-xhhp
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions it is possible to nest a `tf.map_fn` within another `tf.map_fn`
+  call. However, if the input tensor is a `RaggedTensor` and there is no function
+  signature provided, code assumes the output is a fully specified tensor and fills
+  output buffer with uninitialized contents from the heap. The `t` and `z` outputs
+  should be identical, however this is not the case. The last row of `t` contains
+  data from the heap which can be used to leak other memory information. The bug lies
+  in the conversion from a `Variant` tensor to a `RaggedTensor`. The [implementation](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/core/kernels/ragged_tensor_from_variant_op.cc#L177-L190)
+  does not check that all inner shapes match and this results in the additional dimensions.
+  The same implementation can result in data loss, if input tensor is tweaked. We
+  have patched the issue in GitHub commit 4e2565483d0ffcadc719bd44893fb7f609bb5f12.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37679
+modified: '2021-08-27T03:22:46.691143Z'
+published: '2021-08-12T23:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-g8wg-cjwc-xhhp
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/4e2565483d0ffcadc719bd44893fb7f609bb5f12

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37680.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37680.yaml
@@ -1,0 +1,35 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 718721986aa137691ee23f03638867151f74935f
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37680
+- GHSA-cfpj-3q4c-jhvr
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions the implementation of fully connected layers in TFLite is [vulnerable
+  to a division by zero error](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/lite/kernels/fully_connected.cc#L226).
+  We have patched the issue in GitHub commit 718721986aa137691ee23f03638867151f74935f.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37680
+modified: '2021-08-27T03:22:46.794136Z'
+published: '2021-08-12T22:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/718721986aa137691ee23f03638867151f74935f
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-cfpj-3q4c-jhvr

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37681.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37681.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 5b048e87e4e55990dae6b547add4dae59f4e1c76
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37681
+- GHSA-7xwj-5r4v-429p
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions the implementation of SVDF in TFLite is [vulnerable to a null
+  pointer error](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/lite/kernels/svdf.cc#L300-L313).
+  The [`GetVariableInput` function](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/lite/kernels/kernel_util.cc#L115-L119)
+  can return a null pointer but `GetTensorData` assumes that the argument is always
+  a valid tensor. Furthermore, because `GetVariableInput` calls [`GetMutableInput`](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/lite/kernels/kernel_util.cc#L82-L90)
+  which might return `nullptr`, the `tensor->is_variable` expression can also trigger
+  a null pointer exception. We have patched the issue in GitHub commit 5b048e87e4e55990dae6b547add4dae59f4e1c76.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37681
+modified: '2021-08-27T03:22:46.881278Z'
+published: '2021-08-12T22:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/5b048e87e4e55990dae6b547add4dae59f4e1c76
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-7xwj-5r4v-429p

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37682.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37682.yaml
@@ -1,0 +1,44 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 537bc7c723439b9194a358f64d871dd326c18887
+    - fixed: 4a91f2069f7145aab6ba2d8cfe41be8a110c18a5
+    - fixed: 8933b8a21280696ab119b63263babdb54c298538
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37682
+- GHSA-4c4g-crqm-xrxw
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions all TFLite operations that use quantization can be made to use
+  unitialized values. [For example](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/lite/kernels/depthwise_conv.cc#L198-L200).
+  The issue stems from the fact that `quantization.params` is only valid if `quantization.type`
+  is different that `kTfLiteNoQuantization`. However, these checks are missing in
+  large parts of the code. We have patched the issue in GitHub commits 537bc7c723439b9194a358f64d871dd326c18887,
+  4a91f2069f7145aab6ba2d8cfe41be8a110c18a5 and 8933b8a21280696ab119b63263babdb54c298538.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37682
+modified: '2021-08-27T03:22:46.967506Z'
+published: '2021-08-12T23:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/537bc7c723439b9194a358f64d871dd326c18887
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/4a91f2069f7145aab6ba2d8cfe41be8a110c18a5
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/8933b8a21280696ab119b63263babdb54c298538
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-4c4g-crqm-xrxw

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37683.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37683.yaml
@@ -1,0 +1,36 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 1e206baedf8bef0334cca3eb92bab134ef525a28
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37683
+- GHSA-rhrq-64mq-hf9h
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions the implementation of division in TFLite is [vulnerable to a division
+  by 0 error](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/lite/kernels/div.cc).
+  There is no check that the divisor tensor does not contain zero elements. We have
+  patched the issue in GitHub commit 1e206baedf8bef0334cca3eb92bab134ef525a28. The
+  fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit on
+  TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37683
+modified: '2021-08-27T03:22:47.052583Z'
+published: '2021-08-12T23:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/1e206baedf8bef0334cca3eb92bab134ef525a28
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-rhrq-64mq-hf9h

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37684.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37684.yaml
@@ -1,0 +1,28 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37684
+- GHSA-q7f7-544h-67h9
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions the implementations of pooling in TFLite are vulnerable to division
+  by 0 errors as there are no checks for divisors not being 0. We have patched the
+  issue in GitHub commit [dfa22b348b70bb89d6d6ec0ff53973bacb4f4695](https://github.com/tensorflow/tensorflow/commit/dfa22b348b70bb89d6d6ec0ff53973bacb4f4695).
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37684
+modified: '2021-08-27T03:22:47.149147Z'
+published: '2021-08-12T23:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-q7f7-544h-67h9

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37685.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37685.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: d94ffe08a65400f898241c0374e9edc6fa8ed257
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37685
+- GHSA-c545-c4f9-rf6v
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions TFLite's [`expand_dims.cc`](https://github.com/tensorflow/tensorflow/blob/149562d49faa709ea80df1d99fc41d005b81082a/tensorflow/lite/kernels/expand_dims.cc#L36-L50)
+  contains a vulnerability which allows reading one element outside of bounds of heap
+  allocated data. If `axis` is a large negative value (e.g., `-100000`), then after
+  the first `if` it would still be negative. The check following the `if` statement
+  will pass and the `for` loop would read one element before the start of `input_dims.data`
+  (when `i = 0`). We have patched the issue in GitHub commit d94ffe08a65400f898241c0374e9edc6fa8ed257.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37685
+modified: '2021-08-27T03:22:47.234797Z'
+published: '2021-08-12T23:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/d94ffe08a65400f898241c0374e9edc6fa8ed257
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-c545-c4f9-rf6v

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37686.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37686.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: dfa22b348b70bb89d6d6ec0ff53973bacb4f4695
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37686
+- GHSA-mhhc-q96p-mfm9
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions the strided slice implementation in TFLite has a logic bug which
+  can allow an attacker to trigger an infinite loop. This arises from newly introduced
+  support for [ellipsis in axis definition](https://github.com/tensorflow/tensorflow/blob/149562d49faa709ea80df1d99fc41d005b81082a/tensorflow/lite/kernels/strided_slice.cc#L103-L122).
+  An attacker can craft a model such that `ellipsis_end_idx` is smaller than `i` (e.g.,
+  always negative). In this case, the inner loop does not increase `i` and the `continue`
+  statement causes execution to skip over the preincrement at the end of the outer
+  loop. We have patched the issue in GitHub commit dfa22b348b70bb89d6d6ec0ff53973bacb4f4695.
+  TensorFlow 2.6.0 is the only affected version.
+id: PYSEC-0000-CVE-2021-37686
+modified: '2021-08-27T03:22:47.333103Z'
+published: '2021-08-12T22:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-mhhc-q96p-mfm9
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/dfa22b348b70bb89d6d6ec0ff53973bacb4f4695

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37687.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37687.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: eb921122119a6b6e470ee98b89e65d721663179d
+    - fixed: bb6a0383ed553c286f87ca88c207f6774d5c4a8f
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37687
+- GHSA-jwf9-w5xm-f437
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions TFLite's [`GatherNd` implementation](https://github.com/tensorflow/tensorflow/blob/149562d49faa709ea80df1d99fc41d005b81082a/tensorflow/lite/kernels/gather_nd.cc#L124)
+  does not support negative indices but there are no checks for this situation. Hence,
+  an attacker can read arbitrary data from the heap by carefully crafting a model
+  with negative values in `indices`. Similar issue exists in [`Gather` implementation](https://github.com/tensorflow/tensorflow/blob/149562d49faa709ea80df1d99fc41d005b81082a/tensorflow/lite/kernels/gather.cc).
+  We have patched the issue in GitHub commits bb6a0383ed553c286f87ca88c207f6774d5c4a8f
+  and eb921122119a6b6e470ee98b89e65d721663179d. The fix will be included in TensorFlow
+  2.6.0. We will also cherrypick this commit on TensorFlow 2.5.1, TensorFlow 2.4.3,
+  and TensorFlow 2.3.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-37687
+modified: '2021-08-27T03:22:47.431884Z'
+published: '2021-08-12T23:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/eb921122119a6b6e470ee98b89e65d721663179d
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/bb6a0383ed553c286f87ca88c207f6774d5c4a8f
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-jwf9-w5xm-f437

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37688.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37688.yaml
@@ -1,0 +1,35 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 15691e456c7dc9bd6be203b09765b063bf4a380c
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37688
+- GHSA-vcjj-9vg7-vf68
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can craft a TFLite model that would trigger a null
+  pointer dereference, which would result in a crash and denial of service. The [implementation](https://github.com/tensorflow/tensorflow/blob/149562d49faa709ea80df1d99fc41d005b81082a/tensorflow/lite/kernels/internal/optimized/optimized_ops.h#L268-L285)
+  unconditionally dereferences a pointer. We have patched the issue in GitHub commit
+  15691e456c7dc9bd6be203b09765b063bf4a380c. The fix will be included in TensorFlow
+  2.6.0. We will also cherrypick this commit on TensorFlow 2.5.1, TensorFlow 2.4.3,
+  and TensorFlow 2.3.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-37688
+modified: '2021-08-27T03:22:47.519318Z'
+published: '2021-08-12T22:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-vcjj-9vg7-vf68
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/15691e456c7dc9bd6be203b09765b063bf4a380c

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37689.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37689.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: d6b57f461b39fd1aa8c1b870f1b974aac3554955
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37689
+- GHSA-wf5p-c75w-w3wh
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can craft a TFLite model that would trigger a null
+  pointer dereference, which would result in a crash and denial of service. This is
+  caused by the MLIR optimization of `L2NormalizeReduceAxis` operator. The [implementation](https://github.com/tensorflow/tensorflow/blob/149562d49faa709ea80df1d99fc41d005b81082a/tensorflow/compiler/mlir/lite/transforms/optimize.cc#L67-L70)
+  unconditionally dereferences a pointer to an iterator to a vector without checking
+  that the vector has elements. We have patched the issue in GitHub commit d6b57f461b39fd1aa8c1b870f1b974aac3554955.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37689
+modified: '2021-08-27T03:22:47.601647Z'
+published: '2021-08-12T22:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/d6b57f461b39fd1aa8c1b870f1b974aac3554955
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-wf5p-c75w-w3wh

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37690.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37690.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: ee119d4a498979525046fba1c3dd3f13a039fbb1
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37690
+- GHSA-3hxh-8cp2-g4hg
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions when running shape functions, some functions (such as `MutableHashTableShape`)
+  produce extra output information in the form of a `ShapeAndType` struct. The shapes
+  embedded in this struct are owned by an inference context that is cleaned up almost
+  immediately; if the upstream code attempts to access this shape information, it
+  can trigger a segfault. `ShapeRefiner` is mitigating this for normal output shapes
+  by cloning them (and thus putting the newly created shape under ownership of an
+  inference context that will not die), but we were not doing the same for shapes
+  and types. This commit fixes that by doing similar logic on output shapes and types.
+  We have patched the issue in GitHub commit ee119d4a498979525046fba1c3dd3f13a039fbb1.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37690
+modified: '2021-08-27T03:22:47.685921Z'
+published: '2021-08-13T00:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-3hxh-8cp2-g4hg
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/ee119d4a498979525046fba1c3dd3f13a039fbb1

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37691.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37691.yaml
@@ -1,0 +1,35 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 0575b640091680cfb70f4dd93e70658de43b94f9
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37691
+- GHSA-27qf-jwm8-g7f3
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can craft a TFLite model that would trigger a division
+  by zero error in LSH [implementation](https://github.com/tensorflow/tensorflow/blob/149562d49faa709ea80df1d99fc41d005b81082a/tensorflow/lite/kernels/lsh_projection.cc#L118).
+  We have patched the issue in GitHub commit 0575b640091680cfb70f4dd93e70658de43b94f9.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick thiscommit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37691
+modified: '2021-08-27T03:22:47.774010Z'
+published: '2021-08-12T23:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/0575b640091680cfb70f4dd93e70658de43b94f9
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-27qf-jwm8-g7f3

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37692.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-37692.yaml
@@ -1,0 +1,42 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 8721ba96e5760c229217b594f6d2ba332beedf22
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37692
+- GHSA-cmgw-8vpc-rc59
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions under certain conditions, Go code can trigger a segfault in string
+  deallocation. For string tensors, `C.TF_TString_Dealloc` is called during garbage
+  collection within a finalizer function. However, tensor structure isn't checked
+  until encoding to avoid a performance penalty. The current method for dealloc assumes
+  that encoding succeeded, but segfaults when a string tensor is garbage collected
+  whose encoding failed (e.g., due to mismatched dimensions). To fix this, the call
+  to set the finalizer function is deferred until `NewTensor` returns and, if encoding
+  failed for a string tensor, deallocs are determined based on bytes written. We have
+  patched the issue in GitHub commit 8721ba96e5760c229217b594f6d2ba332beedf22. The
+  fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit on
+  TensorFlow 2.5.1, which is the other affected version.
+id: PYSEC-0000-CVE-2021-37692
+modified: '2021-08-27T03:22:47.865620Z'
+published: '2021-08-12T23:15:00Z'
+references:
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/pull/50508
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-cmgw-8vpc-rc59
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/8721ba96e5760c229217b594f6d2ba332beedf22

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41196.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41196.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 12b1ff82b3f26ff8de17e58703231d5a02ef1b8b
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41196
+- GHSA-m539-j985-hcr8
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the Keras pooling layers can trigger a segfault if the size of the pool is 0 or
+  if a dimension is negative. This is due to the TensorFlow's implementation of pooling
+  operations where the values in the sliding window are not checked to be strictly
+  positive. The fix will be included in TensorFlow 2.7.0. We will also cherrypick
+  this commit on TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow 2.4.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41196
+modified: '2021-11-13T06:52:41.665281Z'
+published: '2021-11-05T20:15:00Z'
+references:
+- type: REPORT
+  url: https://github.com/tensorflow/tensorflow/issues/51936
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-m539-j985-hcr8
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/12b1ff82b3f26ff8de17e58703231d5a02ef1b8b

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41197.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41197.yaml
@@ -1,0 +1,51 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: a871989d7b6c18cdebf2fb4f0e5c5b62fbc19edf
+    - fixed: d81b1351da3e8c884ff836b64458d94e4a157c15
+    - fixed: 7c1692bd417eb4f9b33ead749a41166d6080af85
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41197
+- GHSA-prcg-wp5q-rv7p
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  TensorFlow allows tensor to have a large number of dimensions and each dimension
+  can be as large as desired. However, the total number of elements in a tensor must
+  fit within an `int64_t`. If an overflow occurs, `MultiplyWithoutOverflow` would
+  return a negative result. In the majority of TensorFlow codebase this then results
+  in a `CHECK`-failure. Newer constructs exist which return a `Status` instead of
+  crashing the binary. This is similar to CVE-2021-29584. The fix will be included
+  in TensorFlow 2.7.0. We will also cherrypick this commit on TensorFlow 2.6.1, TensorFlow
+  2.5.2, and TensorFlow 2.4.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41197
+modified: '2021-11-13T06:52:41.833730Z'
+published: '2021-11-05T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-prcg-wp5q-rv7p
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/a871989d7b6c18cdebf2fb4f0e5c5b62fbc19edf
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/d81b1351da3e8c884ff836b64458d94e4a157c15
+- type: REPORT
+  url: https://github.com/tensorflow/tensorflow/issues/46890
+- type: REPORT
+  url: https://github.com/tensorflow/tensorflow/issues/51908
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/7c1692bd417eb4f9b33ead749a41166d6080af85

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41198.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41198.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 9294094df6fea79271778eb7e7ae1bad8b5ef98f
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41198
+- GHSA-2p25-55c9-h58q
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  if `tf.tile` is called with a large input argument then the TensorFlow process will
+  crash due to a `CHECK`-failure caused by an overflow. The number of elements in
+  the output tensor is too much for the `int64_t` type and the overflow is detected
+  via a `CHECK` statement. This aborts the process. The fix will be included in TensorFlow
+  2.7.0. We will also cherrypick this commit on TensorFlow 2.6.1, TensorFlow 2.5.2,
+  and TensorFlow 2.4.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41198
+modified: '2021-11-13T06:52:42.007550Z'
+published: '2021-11-05T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/9294094df6fea79271778eb7e7ae1bad8b5ef98f
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-2p25-55c9-h58q
+- type: REPORT
+  url: https://github.com/tensorflow/tensorflow/issues/46911

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41199.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41199.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: e5272d4204ff5b46136a1ef1204fc00597e21837
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41199
+- GHSA-5hx2-qx8j-qjqm
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  if `tf.image.resize` is called with a large input argument then the TensorFlow process
+  will crash due to a `CHECK`-failure caused by an overflow. The number of elements
+  in the output tensor is too much for the `int64_t` type and the overflow is detected
+  via a `CHECK` statement. This aborts the process. The fix will be included in TensorFlow
+  2.7.0. We will also cherrypick this commit on TensorFlow 2.6.1, TensorFlow 2.5.2,
+  and TensorFlow 2.4.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41199
+modified: '2021-11-13T06:52:42.174686Z'
+published: '2021-11-05T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-5hx2-qx8j-qjqm
+- type: REPORT
+  url: https://github.com/tensorflow/tensorflow/issues/46914
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/e5272d4204ff5b46136a1ef1204fc00597e21837

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41200.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41200.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 874bda09e6702cd50bac90b453b50bcc65b2769e
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41200
+- GHSA-gh8h-7j2j-qv4f
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  if `tf.summary.create_file_writer` is called with non-scalar arguments code crashes
+  due to a `CHECK`-fail. The fix will be included in TensorFlow 2.7.0. We will also
+  cherrypick this commit on TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow 2.4.4,
+  as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41200
+modified: '2021-11-13T06:52:42.348013Z'
+published: '2021-11-05T20:15:00Z'
+references:
+- type: REPORT
+  url: https://github.com/tensorflow/tensorflow/issues/46909
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-gh8h-7j2j-qv4f
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/874bda09e6702cd50bac90b453b50bcc65b2769e

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41201.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41201.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: f09caa532b6e1ac8d2aa61b7832c78c5b79300c6
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41201
+- GHSA-j86v-p27c-73fm
+details: TensorFlow is an open source platform for machine learning. In affeced versions
+  during execution, `EinsumHelper::ParseEquation()` is supposed to set the flags in
+  `input_has_ellipsis` vector and `*output_has_ellipsis` boolean to indicate whether
+  there is ellipsis in the corresponding inputs and output. However, the code only
+  changes these flags to `true` and never assigns `false`. This results in unitialized
+  variable access if callers assume that `EinsumHelper::ParseEquation()` always sets
+  these flags. The fix will be included in TensorFlow 2.7.0. We will also cherrypick
+  this commit on TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow 2.4.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41201
+modified: '2021-11-13T06:52:42.499515Z'
+published: '2021-11-05T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/f09caa532b6e1ac8d2aa61b7832c78c5b79300c6
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-j86v-p27c-73fm

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41202.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41202.yaml
@@ -1,0 +1,47 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 1b0e0ec27e7895b9985076eab32445026ae5ca94
+    - fixed: 6d94002a09711d297dbba90390d5482b76113899
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41202
+- GHSA-xrqm-fpgr-6hhx
+details: 'TensorFlow is an open source platform for machine learning. In affected
+  versions while calculating the size of the output within the `tf.range` kernel,
+  there is a conditional statement of type `int64 = condition ? int64 : double`. Due
+  to C++ implicit conversion rules, both branches of the condition will be cast to
+  `double` and the result would be truncated before the assignment. This result in
+  overflows. The fix will be included in TensorFlow 2.7.0. We will also cherrypick
+  this commit on TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow 2.4.4, as these
+  are also affected and still in supported range.'
+id: PYSEC-0000-CVE-2021-41202
+modified: '2021-11-13T06:52:42.645758Z'
+published: '2021-11-05T22:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-xrqm-fpgr-6hhx
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/1b0e0ec27e7895b9985076eab32445026ae5ca94
+- type: REPORT
+  url: https://github.com/tensorflow/tensorflow/issues/46912
+- type: REPORT
+  url: https://github.com/tensorflow/tensorflow/issues/46889
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/6d94002a09711d297dbba90390d5482b76113899

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41203.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41203.yaml
@@ -1,0 +1,48 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 368af875869a204b4ac552b9ddda59f6a46a56ec
+    - fixed: abcced051cb1bd8fb05046ac3b6023a7ebcc4578
+    - fixed: e8dc63704c88007ee4713076605c90188d66f3d2
+    - fixed: b619c6f865715ca3b15ef1842b5b95edbaa710ad
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41203
+- GHSA-7pxj-m4jf-r6h2
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  an attacker can trigger undefined behavior, integer overflows, segfaults and `CHECK`-fail
+  crashes if they can change saved checkpoints from outside of TensorFlow. This is
+  because the checkpoints loading infrastructure is missing validation for invalid
+  file formats. The fixes will be included in TensorFlow 2.7.0. We will also cherrypick
+  these commits on TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow 2.4.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41203
+modified: '2021-11-13T06:52:42.793363Z'
+published: '2021-11-05T21:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-7pxj-m4jf-r6h2
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/368af875869a204b4ac552b9ddda59f6a46a56ec
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/abcced051cb1bd8fb05046ac3b6023a7ebcc4578
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/e8dc63704c88007ee4713076605c90188d66f3d2
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/b619c6f865715ca3b15ef1842b5b95edbaa710ad

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41204.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41204.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 7731e8dfbe4a56773be5dc94d631611211156659
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41204
+- GHSA-786j-5qwq-r36x
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  during TensorFlow's Grappler optimizer phase, constant folding might attempt to
+  deep copy a resource tensor. This results in a segfault, as these tensors are supposed
+  to not change. The fix will be included in TensorFlow 2.7.0. We will also cherrypick
+  this commit on TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow 2.4.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41204
+modified: '2021-11-13T06:52:42.949977Z'
+published: '2021-11-05T21:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/7731e8dfbe4a56773be5dc94d631611211156659
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-786j-5qwq-r36x

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41205.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41205.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 7cf73a2274732c9d82af51c2bc2cf90d13cd7e6d
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41205
+- GHSA-49rx-x2rw-pc6f
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the shape inference functions for the `QuantizeAndDequantizeV*` operations can trigger
+  a read outside of bounds of heap allocated array. The fix will be included in TensorFlow
+  2.7.0. We will also cherrypick this commit on TensorFlow 2.6.1, TensorFlow 2.5.2,
+  and TensorFlow 2.4.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41205
+modified: '2021-11-13T06:52:43.104468Z'
+published: '2021-11-05T21:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-49rx-x2rw-pc6f
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/7cf73a2274732c9d82af51c2bc2cf90d13cd7e6d

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41207.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41207.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: f2c3931113eaafe9ef558faaddd48e00a6606235
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41207
+- GHSA-7v94-64hj-m82h
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the implementation of `ParallelConcat` misses some input validation and can produce
+  a division by 0. The fix will be included in TensorFlow 2.7.0. We will also cherrypick
+  this commit on TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow 2.4.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41207
+modified: '2021-11-13T06:52:43.264871Z'
+published: '2021-11-05T22:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-7v94-64hj-m82h
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/f2c3931113eaafe9ef558faaddd48e00a6606235

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41208.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41208.yaml
@@ -1,0 +1,43 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 5c8c9a8bfe750f9743d0c859bae112060b216f5c
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41208
+- GHSA-57wx-m983-2f88
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the code for boosted trees in TensorFlow is still missing validation. As a result,
+  attackers can trigger denial of service (via dereferencing `nullptr`s or via `CHECK`-failures)
+  as well as abuse undefined behavior (binding references to `nullptr`s). An attacker
+  can also read and write from heap buffers, depending on the API that gets used and
+  the arguments that are passed to the call. Given that the boosted trees implementation
+  in TensorFlow is unmaintained, it is recommend to no longer use these APIs. We will
+  deprecate TensorFlow's boosted trees APIs in subsequent releases. The fix will be
+  included in TensorFlow 2.7.0. We will also cherrypick this commit on TensorFlow
+  2.6.1, TensorFlow 2.5.2, and TensorFlow 2.4.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-41208
+modified: '2021-11-13T06:52:43.429056Z'
+published: '2021-11-05T22:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/5c8c9a8bfe750f9743d0c859bae112060b216f5c
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-57wx-m983-2f88

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41209.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41209.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: f2c3931113eaafe9ef558faaddd48e00a6606235
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41209
+- GHSA-6hpv-v2rx-c5g6
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the implementations for convolution operators trigger a division by 0 if passed
+  empty filter tensor arguments. The fix will be included in TensorFlow 2.7.0. We
+  will also cherrypick this commit on TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow
+  2.4.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41209
+modified: '2021-11-13T06:52:43.607331Z'
+published: '2021-11-05T22:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/f2c3931113eaafe9ef558faaddd48e00a6606235
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-6hpv-v2rx-c5g6

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41210.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41210.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 701cfaca222a82afbeeb17496bd718baa65a67d2
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41210
+- GHSA-m342-ff57-4jcc
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the shape inference functions for `SparseCountSparseOutput` can trigger a read outside
+  of bounds of heap allocated array. The fix will be included in TensorFlow 2.7.0.
+  We will also cherrypick this commit on TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow
+  2.4.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41210
+modified: '2021-11-13T06:52:43.758467Z'
+published: '2021-11-05T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/701cfaca222a82afbeeb17496bd718baa65a67d2
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-m342-ff57-4jcc

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41211.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41211.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: a0d64445116c43cf46a5666bd4eee28e7a82f244
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41211
+- GHSA-cvgx-3v3q-m36c
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the shape inference code for `QuantizeV2` can trigger a read outside of bounds of
+  heap allocated array. This occurs whenever `axis` is a negative value less than
+  `-1`. In this case, we are accessing data before the start of a heap buffer. The
+  code allows `axis` to be an optional argument (`s` would contain an `error::NOT_FOUND`
+  error code). Otherwise, it assumes that `axis` is a valid index into the dimensions
+  of the `input` tensor. If `axis` is less than `-1` then this results in a heap OOB
+  read. The fix will be included in TensorFlow 2.7.0. We will also cherrypick this
+  commit on TensorFlow 2.6.1, as this version is the only one that is also affected.
+id: PYSEC-0000-CVE-2021-41211
+modified: '2021-11-13T06:52:43.843277Z'
+published: '2021-11-05T21:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-cvgx-3v3q-m36c
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/a0d64445116c43cf46a5666bd4eee28e7a82f244

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41212.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41212.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: fa6b7782fbb14aa08d767bc799c531f5e1fb3bb8
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41212
+- GHSA-fr77-rrx3-cp7g
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the shape inference code for `tf.ragged.cross` can trigger a read outside of bounds
+  of heap allocated array. The fix will be included in TensorFlow 2.7.0. We will also
+  cherrypick this commit on TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow 2.4.4,
+  as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41212
+modified: '2021-11-13T06:52:43.991676Z'
+published: '2021-11-05T21:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-fr77-rrx3-cp7g
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/fa6b7782fbb14aa08d767bc799c531f5e1fb3bb8

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41213.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41213.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: afac8158d43691661ad083f6dd9e56f327c1dcb7
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41213
+- GHSA-h67m-xg8f-fxcf
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the code behind `tf.function` API can be made to deadlock when two `tf.function`
+  decorated Python functions are mutually recursive. This occurs due to using a non-reentrant
+  `Lock` Python object. Loading any model which contains mutually recursive functions
+  is vulnerable. An attacker can cause denial of service by causing users to load
+  such models and calling a recursive `tf.function`, although this is not a frequent
+  scenario. The fix will be included in TensorFlow 2.7.0. We will also cherrypick
+  this commit on TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow 2.4.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41213
+modified: '2021-11-13T06:52:44.160284Z'
+published: '2021-11-05T23:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/afac8158d43691661ad083f6dd9e56f327c1dcb7
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-h67m-xg8f-fxcf

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41214.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41214.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: fa6b7782fbb14aa08d767bc799c531f5e1fb3bb8
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41214
+- GHSA-vwhq-49r4-gj9v
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the shape inference code for `tf.ragged.cross` has an undefined behavior due to
+  binding a reference to `nullptr`. The fix will be included in TensorFlow 2.7.0.
+  We will also cherrypick this commit on TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow
+  2.4.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41214
+modified: '2021-11-13T06:52:44.328170Z'
+published: '2021-11-05T21:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-vwhq-49r4-gj9v
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/fa6b7782fbb14aa08d767bc799c531f5e1fb3bb8

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41215.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41215.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: d3738dd70f1c9ceb547258cbb82d853da8771850
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41215
+- GHSA-x3v8-c8qx-3j3r
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the shape inference code for `DeserializeSparse` can trigger a null pointer dereference.
+  This is because the shape inference function assumes that the `serialize_sparse`
+  tensor is a tensor with positive rank (and having `3` as the last dimension). The
+  fix will be included in TensorFlow 2.7.0. We will also cherrypick this commit on
+  TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow 2.4.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-41215
+modified: '2021-11-13T06:52:44.476075Z'
+published: '2021-11-05T21:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/d3738dd70f1c9ceb547258cbb82d853da8771850
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-x3v8-c8qx-3j3r

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41216.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41216.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: c79ba87153ee343401dbe9d1954d7f79e521eb14
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41216
+- GHSA-3ff2-r28g-w7h9
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the shape inference function for `Transpose` is vulnerable to a heap buffer overflow.
+  This occurs whenever `perm` contains negative elements. The shape inference function
+  does not validate that the indices in `perm` are all valid. The fix will be included
+  in TensorFlow 2.7.0. We will also cherrypick this commit on TensorFlow 2.6.1, TensorFlow
+  2.5.2, and TensorFlow 2.4.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41216
+modified: '2021-11-13T06:52:44.644675Z'
+published: '2021-11-05T23:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-3ff2-r28g-w7h9
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/c79ba87153ee343401dbe9d1954d7f79e521eb14

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41217.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41217.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 05cbebd3c6bb8f517a158b0155debb8df79017ff
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41217
+- GHSA-5crj-c72x-m7gq
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the process of building the control flow graph for a TensorFlow model is vulnerable
+  to a null pointer exception when nodes that should be paired are not. This occurs
+  because the code assumes that the first node in the pairing (e.g., an `Enter` node)
+  always exists when encountering the second node (e.g., an `Exit` node). When this
+  is not the case, `parent` is `nullptr` so dereferencing it causes a crash. The fix
+  will be included in TensorFlow 2.7.0. We will also cherrypick this commit on TensorFlow
+  2.6.1, TensorFlow 2.5.2, and TensorFlow 2.4.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-41217
+modified: '2021-11-13T06:52:44.799831Z'
+published: '2021-11-05T21:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/05cbebd3c6bb8f517a158b0155debb8df79017ff
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-5crj-c72x-m7gq

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41218.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41218.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: a8ad3e5e79c75f36edb81e0ba3f3c0c5442aeddc
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41218
+- GHSA-9crf-c6qr-r273
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the shape inference code for `AllToAll` can be made to execute a division by 0.
+  This occurs whenever the `split_count` argument is 0. The fix will be included in
+  TensorFlow 2.7.0. We will also cherrypick this commit on TensorFlow 2.6.1, TensorFlow
+  2.5.2, and TensorFlow 2.4.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41218
+modified: '2021-11-13T06:52:44.955817Z'
+published: '2021-11-05T22:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-9crf-c6qr-r273
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/a8ad3e5e79c75f36edb81e0ba3f3c0c5442aeddc

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41219.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41219.yaml
@@ -1,0 +1,42 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: e6cf28c72ba2eb949ca950d834dd6d66bb01cfae
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41219
+- GHSA-4f99-p9c2-3j8x
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the code for sparse matrix multiplication is vulnerable to undefined behavior via
+  binding a reference to `nullptr`. This occurs whenever the dimensions of `a` or
+  `b` are 0 or less. In the case on one of these is 0, an empty output tensor should
+  be allocated (to conserve the invariant that output tensors are always allocated
+  when the operation is successful) but nothing should be written to it (that is,
+  we should return early from the kernel implementation). Otherwise, attempts to write
+  to this empty tensor would result in heap OOB access. The fix will be included in
+  TensorFlow 2.7.0. We will also cherrypick this commit on TensorFlow 2.6.1, TensorFlow
+  2.5.2, and TensorFlow 2.4.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41219
+modified: '2021-11-13T06:52:45.099185Z'
+published: '2021-11-05T21:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-4f99-p9c2-3j8x
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/e6cf28c72ba2eb949ca950d834dd6d66bb01cfae

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41220.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41220.yaml
@@ -1,0 +1,34 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: ca38dab9d3ee66c5de06f11af9a4b1200da5ef75
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41220
+- GHSA-gpfh-jvf9-7wg5
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the async implementation of `CollectiveReduceV2` suffers from a memory leak and
+  a use after free. This occurs due to the asynchronous computation and the fact that
+  objects that have been `std::move()`d from are still accessed. The fix will be included
+  in TensorFlow 2.7.0. We will also cherrypick this commit on TensorFlow 2.6.1, as
+  this version is the only one that is also affected.
+id: PYSEC-0000-CVE-2021-41220
+modified: '2021-11-13T06:52:45.180075Z'
+published: '2021-11-05T23:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-gpfh-jvf9-7wg5
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/ca38dab9d3ee66c5de06f11af9a4b1200da5ef75

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41221.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41221.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: af5fcebb37c8b5d71c237f4e59c6477015c78ce6
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41221
+- GHSA-cqv6-3phm-hcwx
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the shape inference code for the `Cudnn*` operations in TensorFlow can be tricked
+  into accessing invalid memory, via a heap buffer overflow. This occurs because the
+  ranks of the `input`, `input_h` and `input_c` parameters are not validated, but
+  code assumes they have certain values. The fix will be included in TensorFlow 2.7.0.
+  We will also cherrypick this commit on TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow
+  2.4.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41221
+modified: '2021-11-13T06:52:45.325083Z'
+published: '2021-11-05T23:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-cqv6-3phm-hcwx
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/af5fcebb37c8b5d71c237f4e59c6477015c78ce6

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41222.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41222.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 25d622ffc432acc736b14ca3904177579e733cc6
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41222
+- GHSA-cpf4-wx82-gxp6
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the implementation of `SplitV` can trigger a segfault is an attacker supplies negative
+  arguments. This occurs whenever `size_splits` contains more than one value and at
+  least one value is negative. The fix will be included in TensorFlow 2.7.0. We will
+  also cherrypick this commit on TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow
+  2.4.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41222
+modified: '2021-11-13T06:52:45.470098Z'
+published: '2021-11-05T23:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-cpf4-wx82-gxp6
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/25d622ffc432acc736b14ca3904177579e733cc6

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41223.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41223.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: aab9998916c2ffbd8f0592059fad352622f89cda
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41223
+- GHSA-f54p-f6jp-4rhr
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the implementation of `FusedBatchNorm` kernels is vulnerable to a heap OOB access.
+  The fix will be included in TensorFlow 2.7.0. We will also cherrypick this commit
+  on TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow 2.4.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-41223
+modified: '2021-11-13T06:52:45.621437Z'
+published: '2021-11-05T21:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/aab9998916c2ffbd8f0592059fad352622f89cda
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-f54p-f6jp-4rhr

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41224.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41224.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 67bfd9feeecfb3c61d80f0e46d89c170fbee682b
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41224
+- GHSA-rg3m-hqc5-344v
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the implementation of `SparseFillEmptyRows` can be made to trigger a heap OOB access.
+  This occurs whenever the size of `indices` does not match the size of `values`.
+  The fix will be included in TensorFlow 2.7.0. We will also cherrypick this commit
+  on TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow 2.4.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-41224
+modified: '2021-11-13T06:52:45.767410Z'
+published: '2021-11-05T21:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/67bfd9feeecfb3c61d80f0e46d89c170fbee682b
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-rg3m-hqc5-344v

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41225.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41225.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 68867bf01239d9e1048f98cbad185bf4761bedd3
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41225
+- GHSA-7r94-xv9v-63jw
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  TensorFlow's Grappler optimizer has a use of unitialized variable. If the `train_nodes`
+  vector (obtained from the saved model that gets optimized) does not contain a `Dequeue`
+  node, then `dequeue_node` is left unitialized. The fix will be included in TensorFlow
+  2.7.0. We will also cherrypick this commit on TensorFlow 2.6.1, TensorFlow 2.5.2,
+  and TensorFlow 2.4.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41225
+modified: '2021-11-13T06:52:45.918636Z'
+published: '2021-11-05T23:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/68867bf01239d9e1048f98cbad185bf4761bedd3
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-7r94-xv9v-63jw

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41226.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41226.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: f410212e373eb2aec4c9e60bf3702eba99a38aba
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41226
+- GHSA-374m-jm66-3vj8
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the implementation of `SparseBinCount` is vulnerable to a heap OOB access. This
+  is because of missing validation between the elements of the `values` argument and
+  the shape of the sparse output. The fix will be included in TensorFlow 2.7.0. We
+  will also cherrypick this commit on TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow
+  2.4.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41226
+modified: '2021-11-13T06:52:46.070716Z'
+published: '2021-11-05T21:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/f410212e373eb2aec4c9e60bf3702eba99a38aba
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-374m-jm66-3vj8

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41227.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41227.yaml
@@ -1,0 +1,42 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 3712a2d3455e6ccb924daa5724a3652a86f6b585
+    - fixed: 1cb6bb6c2a6019417c9adaf9e6843ba75ee2580b
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41227
+- GHSA-j8c8-67vp-6mx7
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the `ImmutableConst` operation in TensorFlow can be tricked into reading arbitrary
+  memory contents. This is because the `tstring` TensorFlow string class has a special
+  case for memory mapped strings but the operation itself does not offer any support
+  for this datatype. The fix will be included in TensorFlow 2.7.0. We will also cherrypick
+  this commit on TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow 2.4.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41227
+modified: '2021-11-13T06:52:46.221231Z'
+published: '2021-11-05T23:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-j8c8-67vp-6mx7
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/3712a2d3455e6ccb924daa5724a3652a86f6b585
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/1cb6bb6c2a6019417c9adaf9e6843ba75ee2580b

--- a/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41228.yaml
+++ b/vulns/tensorflow-cpu/PYSEC-0000-CVE-2021-41228.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-cpu
+    purl: pkg:pypi:tensorflow-cpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 8b202f08d52e8206af2bdb2112a62fafbc546ec7
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41228
+- GHSA-3rcw-9p9x-582v
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  TensorFlow's `saved_model_cli` tool is vulnerable to a code injection as it calls
+  `eval` on user supplied strings. This can be used by attackers to run arbitrary
+  code on the plaform where the CLI tool runs. However, given that the tool is always
+  run manually, the impact of this is not severe. We have patched this by adding a
+  `safe` flag which defaults to `True` and an explicit warning for users. The fix
+  will be included in TensorFlow 2.7.0. We will also cherrypick this commit on TensorFlow
+  2.6.1, TensorFlow 2.5.2, and TensorFlow 2.4.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-41228
+modified: '2021-11-13T06:52:46.380831Z'
+published: '2021-11-05T23:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/8b202f08d52e8206af2bdb2112a62fafbc546ec7
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-3rcw-9p9x-582v

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2018-10055.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2018-10055.yaml
@@ -1,0 +1,21 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 1.7.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2018-10055
+details: Invalid memory access and/or a heap buffer overflow in the TensorFlow XLA
+  compiler in Google TensorFlow before 1.7.1 could cause a crash or read from other
+  parts of process memory via a crafted configuration file.
+id: PYSEC-0000-CVE-2018-10055
+modified: '2021-08-27T03:22:22.150023Z'
+published: '2019-04-24T17:29:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/security/advisory/tfsa-2018-006.md

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2018-21233.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2018-21233.yaml
@@ -1,0 +1,28 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 49f73c55d56edffebde4bca4a407ad69c1cae433
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2018-21233
+details: TensorFlow before 1.7.0 has an integer overflow that causes an out-of-bounds
+  read, possibly causing disclosure of the contents of process memory. This occurs
+  in the DecodeBmp feature of the BMP decoder in core/kernels/decode_bmp_op.cc.
+id: PYSEC-0000-CVE-2018-21233
+modified: '2021-08-27T03:22:22.195752Z'
+published: '2020-05-04T15:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/49f73c55d56edffebde4bca4a407ad69c1cae433
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/security/advisory/tfsa-2018-001.md

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2018-7575.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2018-7575.yaml
@@ -1,0 +1,20 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 1.7.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2018-7575
+details: Google TensorFlow 1.7.x and earlier is affected by a Buffer Overflow vulnerability.
+  The type of exploitation is context-dependent.
+id: PYSEC-0000-CVE-2018-7575
+modified: '2021-08-27T03:22:22.242054Z'
+published: '2019-04-24T21:29:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/security/advisory/tfsa-2018-004.md

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2018-7576.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2018-7576.yaml
@@ -1,0 +1,20 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 1.7.0rc0
+    type: ECOSYSTEM
+aliases:
+- CVE-2018-7576
+details: 'Google TensorFlow 1.6.x and earlier is affected by: Null Pointer Dereference.
+  The type of exploitation is: context-dependent.'
+id: PYSEC-0000-CVE-2018-7576
+modified: '2021-08-27T03:22:22.321158Z'
+published: '2019-04-23T21:29:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/security/advisory/tfsa-2018-002.md

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2018-7577.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2018-7577.yaml
@@ -1,0 +1,21 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 1.7.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2018-7577
+details: Memcpy parameter overlap in Google Snappy library 1.1.4, as used in Google
+  TensorFlow before 1.7.1, could result in a crash or read from other parts of process
+  memory.
+id: PYSEC-0000-CVE-2018-7577
+modified: '2021-08-27T03:22:22.362937Z'
+published: '2019-04-24T17:29:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/security/advisory/tfsa-2018-005.md

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2018-8825.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2018-8825.yaml
@@ -1,0 +1,20 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 1.7.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2018-8825
+details: 'Google TensorFlow 1.7 and below is affected by: Buffer Overflow. The impact
+  is: execute arbitrary code (local).'
+id: PYSEC-0000-CVE-2018-8825
+modified: '2021-08-27T03:22:22.407658Z'
+published: '2019-04-23T21:29:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/security/advisory/tfsa-2018-003.md

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2019-16778.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2019-16778.yaml
@@ -1,0 +1,33 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: db4f9717c41bccc3ce10099ab61996b246099892
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 1.0.0
+    - fixed: 1.15.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2019-16778
+- GHSA-844w-j86r-4x2j
+details: In TensorFlow before 1.15, a heap buffer overflow in UnsortedSegmentSum can
+  be produced when the Index template argument is int32. In this case data_size and
+  num_segments fields are truncated from int64 to int32 and can produce negative numbers,
+  resulting in accessing out of bounds heap memory. This is unlikely to be exploitable
+  and was detected and fixed internally in TensorFlow 1.15 and 2.0.
+id: PYSEC-0000-CVE-2019-16778
+modified: '2021-08-27T03:22:22.453759Z'
+published: '2019-12-16T21:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/db4f9717c41bccc3ce10099ab61996b246099892
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/security/advisory/tfsa-2019-002.md
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-844w-j86r-4x2j

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2019-9635.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2019-9635.yaml
@@ -1,0 +1,20 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 1.12.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2019-9635
+details: NULL pointer dereference in Google TensorFlow before 1.12.2 could cause a
+  denial of service via an invalid GIF file.
+id: PYSEC-0000-CVE-2019-9635
+modified: '2021-08-27T03:22:22.500832Z'
+published: '2019-04-24T17:29:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/security/advisory/tfsa-2019-001.md

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15190.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15190.yaml
@@ -1,0 +1,47 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: da8558533d925694483d2c136a9220d6d49d843c
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.4
+    - introduced: 2.0.0
+    - fixed: 2.0.3
+    - introduced: 2.1.0
+    - fixed: 2.1.2
+    - introduced: 2.2.0
+    - fixed: 2.2.1
+    - introduced: 2.3.0
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15190
+- GHSA-4g9f-63rx-5cw4
+details: In Tensorflow before versions 1.15.4, 2.0.3, 2.1.2, 2.2.1 and 2.3.1, the
+  `tf.raw_ops.Switch` operation takes as input a tensor and a boolean and outputs
+  two tensors. Depending on the boolean value, one of the tensors is exactly the input
+  tensor whereas the other one should be an empty tensor. However, the eager runtime
+  traverses all tensors in the output. Since only one of the tensors is defined, the
+  other one is `nullptr`, hence we are binding a reference to `nullptr`. This is undefined
+  behavior and reported as an error if compiling with `-fsanitize=null`. In this case,
+  this results in a segmentation fault The issue is patched in commit da8558533d925694483d2c136a9220d6d49d843c,
+  and is released in TensorFlow versions 1.15.4, 2.0.3, 2.1.2, 2.2.1, or 2.3.1.
+id: PYSEC-0000-CVE-2020-15190
+modified: '2020-10-29T16:15:00Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/da8558533d925694483d2c136a9220d6d49d843c
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-4g9f-63rx-5cw4
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00065.html

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15191.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15191.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 22e07fb204386768e5bcbea563641ea11f96ceb8
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.1
+    - introduced: 2.3.0rc0
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15191
+- GHSA-q8qj-fc9q-cphr
+details: In Tensorflow before versions 2.2.1 and 2.3.1, if a user passes an invalid
+  argument to `dlpack.to_dlpack` the expected validations will cause variables to
+  bind to `nullptr` while setting a `status` variable to the error condition. However,
+  this `status` argument is not properly checked. Hence, code following these methods
+  will bind references to null pointers. This is undefined behavior and reported as
+  an error if compiling with `-fsanitize=null`. The issue is patched in commit 22e07fb204386768e5bcbea563641ea11f96ceb8
+  and is released in TensorFlow versions 2.2.1, or 2.3.1.
+id: PYSEC-0000-CVE-2020-15191
+modified: '2021-09-01T08:19:32.360913Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-q8qj-fc9q-cphr
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/22e07fb204386768e5bcbea563641ea11f96ceb8
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00065.html

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15192.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15192.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 22e07fb204386768e5bcbea563641ea11f96ceb8
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.1
+    - introduced: 2.3.0rc0
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15192
+- GHSA-8fxw-76px-3rxv
+details: In Tensorflow before versions 2.2.1 and 2.3.1, if a user passes a list of
+  strings to `dlpack.to_dlpack` there is a memory leak following an expected validation
+  failure. The issue occurs because the `status` argument during validation failures
+  is not properly checked. Since each of the above methods can return an error status,
+  the `status` value must be checked before continuing. The issue is patched in commit
+  22e07fb204386768e5bcbea563641ea11f96ceb8 and is released in TensorFlow versions
+  2.2.1, or 2.3.1.
+id: PYSEC-0000-CVE-2020-15192
+modified: '2021-09-01T08:19:32.462320Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-8fxw-76px-3rxv
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/22e07fb204386768e5bcbea563641ea11f96ceb8
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00065.html

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15193.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15193.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 22e07fb204386768e5bcbea563641ea11f96ceb8
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.1
+    - introduced: 2.3.0rc0
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15193
+- GHSA-rjjg-hgv6-h69v
+details: In Tensorflow before versions 2.2.1 and 2.3.1, the implementation of `dlpack.to_dlpack`
+  can be made to use uninitialized memory resulting in further memory corruption.
+  This is because the pybind11 glue code assumes that the argument is a tensor. However,
+  there is nothing stopping users from passing in a Python object instead of a tensor.
+  The uninitialized memory address is due to a `reinterpret_cast` Since the `PyObject`
+  is a Python object, not a TensorFlow Tensor, the cast to `EagerTensor` fails. The
+  issue is patched in commit 22e07fb204386768e5bcbea563641ea11f96ceb8 and is released
+  in TensorFlow versions 2.2.1, or 2.3.1.
+id: PYSEC-0000-CVE-2020-15193
+modified: '2021-09-01T08:19:32.562362Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-rjjg-hgv6-h69v
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/22e07fb204386768e5bcbea563641ea11f96ceb8
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00065.html

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15194.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15194.yaml
@@ -1,0 +1,46 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 390611e0d45c5793c7066110af37c8514e6a6c54
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.4
+    - introduced: 2.0.0
+    - fixed: 2.0.3
+    - introduced: 2.1.0
+    - fixed: 2.1.2
+    - introduced: 2.2.0
+    - fixed: 2.2.1
+    - introduced: 2.3.0
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15194
+- GHSA-9mqp-7v2h-2382
+details: In Tensorflow before versions 1.15.4, 2.0.3, 2.1.2, 2.2.1 and 2.3.1, the
+  `SparseFillEmptyRowsGrad` implementation has incomplete validation of the shapes
+  of its arguments. Although `reverse_index_map_t` and `grad_values_t` are accessed
+  in a similar pattern, only `reverse_index_map_t` is validated to be of proper shape.
+  Hence, malicious users can pass a bad `grad_values_t` to trigger an assertion failure
+  in `vec`, causing denial of service in serving installations. The issue is patched
+  in commit 390611e0d45c5793c7066110af37c8514e6a6c54, and is released in TensorFlow
+  versions 1.15.4, 2.0.3, 2.1.2, 2.2.1, or 2.3.1."
+id: PYSEC-0000-CVE-2020-15194
+modified: '2020-12-23T18:33:00Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/390611e0d45c5793c7066110af37c8514e6a6c54
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-9mqp-7v2h-2382
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00065.html

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15195.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15195.yaml
@@ -1,0 +1,43 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 390611e0d45c5793c7066110af37c8514e6a6c54
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.4
+    - introduced: 2.0.0
+    - fixed: 2.0.3
+    - introduced: 2.1.0
+    - fixed: 2.1.2
+    - introduced: 2.2.0
+    - fixed: 2.2.1
+    - introduced: 2.3.0
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15195
+- GHSA-63xm-rx5p-xvqr
+details: In Tensorflow before versions 1.15.4, 2.0.3, 2.1.2, 2.2.1 and 2.3.1, the
+  implementation of `SparseFillEmptyRowsGrad` uses a double indexing pattern. It is
+  possible for `reverse_index_map(i)` to be an index outside of bounds of `grad_values`,
+  thus resulting in a heap buffer overflow. The issue is patched in commit 390611e0d45c5793c7066110af37c8514e6a6c54,
+  and is released in TensorFlow versions 1.15.4, 2.0.3, 2.1.2, 2.2.1, or 2.3.1.
+id: PYSEC-0000-CVE-2020-15195
+modified: '2020-10-29T16:15:00Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/390611e0d45c5793c7066110af37c8514e6a6c54
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-63xm-rx5p-xvqr
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00065.html

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15196.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15196.yaml
@@ -1,0 +1,36 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 3cbb917b4714766030b28eba9fb41bb97ce9ee02
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15196
+- GHSA-pg59-2f92-5cph
+details: In Tensorflow version 2.3.0, the `SparseCountSparseOutput` and `RaggedCountSparseOutput`
+  implementations don't validate that the `weights` tensor has the same shape as the
+  data. The check exists for `DenseCountSparseOutput`, where both tensors are fully
+  specified. In the sparse and ragged count weights are still accessed in parallel
+  with the data. But, since there is no validation, a user passing fewer weights than
+  the values for the tensors can generate a read from outside the bounds of the heap
+  buffer allocated for the weights. The issue is patched in commit 3cbb917b4714766030b28eba9fb41bb97ce9ee02
+  and is released in TensorFlow version 2.3.1.
+id: PYSEC-0000-CVE-2020-15196
+modified: '2021-09-01T08:19:33.034745Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-pg59-2f92-5cph
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/3cbb917b4714766030b28eba9fb41bb97ce9ee02

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15197.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15197.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 3cbb917b4714766030b28eba9fb41bb97ce9ee02
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15197
+- GHSA-qc53-44cj-vfvx
+details: In Tensorflow before version 2.3.1, the `SparseCountSparseOutput` implementation
+  does not validate that the input arguments form a valid sparse tensor. In particular,
+  there is no validation that the `indices` tensor has rank 2. This tensor must be
+  a matrix because code assumes its elements are accessed as elements of a matrix.
+  However, malicious users can pass in tensors of different rank, resulting in a `CHECK`
+  assertion failure and a crash. This can be used to cause denial of service in serving
+  installations, if users are allowed to control the components of the input sparse
+  tensor. The issue is patched in commit 3cbb917b4714766030b28eba9fb41bb97ce9ee02
+  and is released in TensorFlow version 2.3.1.
+id: PYSEC-0000-CVE-2020-15197
+modified: '2021-09-01T08:19:33.096342Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-qc53-44cj-vfvx
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/3cbb917b4714766030b28eba9fb41bb97ce9ee02

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15198.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15198.yaml
@@ -1,0 +1,35 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 3cbb917b4714766030b28eba9fb41bb97ce9ee02
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15198
+- GHSA-jc87-6vpp-7ff3
+details: In Tensorflow before version 2.3.1, the `SparseCountSparseOutput` implementation
+  does not validate that the input arguments form a valid sparse tensor. In particular,
+  there is no validation that the `indices` tensor has the same shape as the `values`
+  one. The values in these tensors are always accessed in parallel. Thus, a shape
+  mismatch can result in accesses outside the bounds of heap allocated buffers. The
+  issue is patched in commit 3cbb917b4714766030b28eba9fb41bb97ce9ee02 and is released
+  in TensorFlow version 2.3.1.
+id: PYSEC-0000-CVE-2020-15198
+modified: '2021-09-01T08:19:33.154302Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/3cbb917b4714766030b28eba9fb41bb97ce9ee02
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-jc87-6vpp-7ff3

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15199.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15199.yaml
@@ -1,0 +1,36 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 3cbb917b4714766030b28eba9fb41bb97ce9ee02
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15199
+- GHSA-x5cp-9pcf-pp3h
+details: In Tensorflow before version 2.3.1, the `RaggedCountSparseOutput` does not
+  validate that the input arguments form a valid ragged tensor. In particular, there
+  is no validation that the `splits` tensor has the minimum required number of elements.
+  Code uses this quantity to initialize a different data structure. Since `BatchedMap`
+  is equivalent to a vector, it needs to have at least one element to not be `nullptr`.
+  If user passes a `splits` tensor that is empty or has exactly one element, we get
+  a `SIGABRT` signal raised by the operating system. The issue is patched in commit
+  3cbb917b4714766030b28eba9fb41bb97ce9ee02 and is released in TensorFlow version 2.3.1.
+id: PYSEC-0000-CVE-2020-15199
+modified: '2021-09-01T08:19:33.217572Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-x5cp-9pcf-pp3h
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/3cbb917b4714766030b28eba9fb41bb97ce9ee02

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15200.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15200.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 3cbb917b4714766030b28eba9fb41bb97ce9ee02
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15200
+- GHSA-x7rp-74x2-mjf3
+details: In Tensorflow before version 2.3.1, the `RaggedCountSparseOutput` implementation
+  does not validate that the input arguments form a valid ragged tensor. In particular,
+  there is no validation that the values in the `splits` tensor generate a valid partitioning
+  of the `values` tensor. Thus, the code sets up conditions to cause a heap buffer
+  overflow. A `BatchedMap` is equivalent to a vector where each element is a hashmap.
+  However, if the first element of `splits_values` is not 0, `batch_idx` will never
+  be 1, hence there will be no hashmap at index 0 in `per_batch_counts`. Trying to
+  access that in the user code results in a segmentation fault. The issue is patched
+  in commit 3cbb917b4714766030b28eba9fb41bb97ce9ee02 and is released in TensorFlow
+  version 2.3.1.
+id: PYSEC-0000-CVE-2020-15200
+modified: '2021-09-01T08:19:33.281926Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-x7rp-74x2-mjf3
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/3cbb917b4714766030b28eba9fb41bb97ce9ee02

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15201.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15201.yaml
@@ -1,0 +1,36 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 3cbb917b4714766030b28eba9fb41bb97ce9ee02
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15201
+- GHSA-p5f8-gfw5-33w4
+details: In Tensorflow before version 2.3.1, the `RaggedCountSparseOutput` implementation
+  does not validate that the input arguments form a valid ragged tensor. In particular,
+  there is no validation that the values in the `splits` tensor generate a valid partitioning
+  of the `values` tensor. Hence, the code is prone to heap buffer overflow. If `split_values`
+  does not end with a value at least `num_values` then the `while` loop condition
+  will trigger a read outside of the bounds of `split_values` once `batch_idx` grows
+  too large. The issue is patched in commit 3cbb917b4714766030b28eba9fb41bb97ce9ee02
+  and is released in TensorFlow version 2.3.1.
+id: PYSEC-0000-CVE-2020-15201
+modified: '2021-09-01T08:19:33.344299Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-p5f8-gfw5-33w4
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/3cbb917b4714766030b28eba9fb41bb97ce9ee02

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15202.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15202.yaml
@@ -1,0 +1,50 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 27b417360cbd671ef55915e4bb6bb06af8b8a832
+    - fixed: ca8c013b5e97b1373b3bb1c97ea655e69f31a575
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.4
+    - introduced: 2.0.0
+    - fixed: 2.0.3
+    - introduced: 2.1.0
+    - fixed: 2.1.2
+    - introduced: 2.2.0
+    - fixed: 2.2.1
+    - introduced: 2.3.0
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15202
+- GHSA-h6fg-mjxg-hqq4
+details: In Tensorflow before versions 1.15.4, 2.0.3, 2.1.2, 2.2.1 and 2.3.1, the
+  `Shard` API in TensorFlow expects the last argument to be a function taking two
+  `int64` (i.e., `long long`) arguments. However, there are several places in TensorFlow
+  where a lambda taking `int` or `int32` arguments is being used. In these cases,
+  if the amount of work to be parallelized is large enough, integer truncation occurs.
+  Depending on how the two arguments of the lambda are used, this can result in segfaults,
+  read/write outside of heap allocated arrays, stack overflows, or data corruption.
+  The issue is patched in commits 27b417360cbd671ef55915e4bb6bb06af8b8a832 and ca8c013b5e97b1373b3bb1c97ea655e69f31a575,
+  and is released in TensorFlow versions 1.15.4, 2.0.3, 2.1.2, 2.2.1, or 2.3.1.
+id: PYSEC-0000-CVE-2020-15202
+modified: '2020-10-29T16:15:00Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/27b417360cbd671ef55915e4bb6bb06af8b8a832
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-h6fg-mjxg-hqq4
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/ca8c013b5e97b1373b3bb1c97ea655e69f31a575
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00065.html

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15203.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15203.yaml
@@ -1,0 +1,44 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 33be22c65d86256e6826666662e40dbdfe70ee83
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.4
+    - introduced: 2.0.0
+    - fixed: 2.0.3
+    - introduced: 2.1.0
+    - fixed: 2.1.2
+    - introduced: 2.2.0
+    - fixed: 2.2.1
+    - introduced: 2.3.0
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15203
+- GHSA-xmq7-7fxm-rr79
+details: In Tensorflow before versions 1.15.4, 2.0.3, 2.1.2, 2.2.1 and 2.3.1, by controlling
+  the `fill` argument of tf.strings.as_string, a malicious attacker is able to trigger
+  a format string vulnerability due to the way the internal format use in a `printf`
+  call is constructed. This may result in segmentation fault. The issue is patched
+  in commit 33be22c65d86256e6826666662e40dbdfe70ee83, and is released in TensorFlow
+  versions 1.15.4, 2.0.3, 2.1.2, 2.2.1, or 2.3.1.
+id: PYSEC-0000-CVE-2020-15203
+modified: '2020-10-29T16:15:00Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/33be22c65d86256e6826666662e40dbdfe70ee83
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-xmq7-7fxm-rr79
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00065.html

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15204.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15204.yaml
@@ -1,0 +1,44 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 9a133d73ae4b4664d22bd1aa6d654fec13c52ee1
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.4
+    - introduced: 2.0.0
+    - fixed: 2.0.3
+    - introduced: 2.1.0
+    - fixed: 2.1.2
+    - introduced: 2.2.0
+    - fixed: 2.2.1
+    - introduced: 2.3.0
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15204
+- GHSA-q8gv-q7wr-9jf8
+details: In eager mode, TensorFlow before versions 1.15.4, 2.0.3, 2.1.2, 2.2.1 and
+  2.3.1 does not set the session state. Hence, calling `tf.raw_ops.GetSessionHandle`
+  or `tf.raw_ops.GetSessionHandleV2` results in a null pointer dereference In linked
+  snippet, in eager mode, `ctx->session_state()` returns `nullptr`. Since code immediately
+  dereferences this, we get a segmentation fault. The issue is patched in commit 9a133d73ae4b4664d22bd1aa6d654fec13c52ee1,
+  and is released in TensorFlow versions 1.15.4, 2.0.3, 2.1.2, 2.2.1, or 2.3.1.
+id: PYSEC-0000-CVE-2020-15204
+modified: '2020-10-29T16:15:00Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-q8gv-q7wr-9jf8
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/9a133d73ae4b4664d22bd1aa6d654fec13c52ee1
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00065.html

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15205.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15205.yaml
@@ -1,0 +1,45 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 0462de5b544ed4731aa2fb23946ac22c01856b80
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.4
+    - introduced: 2.0.0
+    - fixed: 2.0.3
+    - introduced: 2.1.0
+    - fixed: 2.1.2
+    - introduced: 2.2.0
+    - fixed: 2.2.1
+    - introduced: 2.3.0
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15205
+- GHSA-g7p5-5759-qv46
+details: In Tensorflow before versions 1.15.4, 2.0.3, 2.1.2, 2.2.1 and 2.3.1, the
+  `data_splits` argument of `tf.raw_ops.StringNGrams` lacks validation. This allows
+  a user to pass values that can cause heap overflow errors and even leak contents
+  of memory In the linked code snippet, all the binary strings after `ee ff` are contents
+  from the memory stack. Since these can contain return addresses, this data leak
+  can be used to defeat ASLR. The issue is patched in commit 0462de5b544ed4731aa2fb23946ac22c01856b80,
+  and is released in TensorFlow versions 1.15.4, 2.0.3, 2.1.2, 2.2.1, or 2.3.1.
+id: PYSEC-0000-CVE-2020-15205
+modified: '2020-10-29T16:15:00Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-g7p5-5759-qv46
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/0462de5b544ed4731aa2fb23946ac22c01856b80
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00065.html

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15206.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15206.yaml
@@ -1,0 +1,47 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: adf095206f25471e864a8e63a0f1caef53a0e3a6
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.4
+    - introduced: 2.0.0
+    - fixed: 2.0.3
+    - introduced: 2.1.0
+    - fixed: 2.1.2
+    - introduced: 2.2.0
+    - fixed: 2.2.1
+    - introduced: 2.3.0
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15206
+- GHSA-w5gh-2wr2-pm6g
+details: 'In Tensorflow before versions 1.15.4, 2.0.3, 2.1.2, 2.2.1 and 2.3.1, changing
+  the TensorFlow''s `SavedModel` protocol buffer and altering the name of required
+  keys results in segfaults and data corruption while loading the model. This can
+  cause a denial of service in products using `tensorflow-serving` or other inference-as-a-service
+  installments. Fixed were added in commits f760f88b4267d981e13f4b302c437ae800445968
+  and fcfef195637c6e365577829c4d67681695956e7d (both going into TensorFlow 2.2.0 and
+  2.3.0 but not yet backported to earlier versions). However, this was not enough,
+  as #41097 reports a different failure mode. The issue is patched in commit adf095206f25471e864a8e63a0f1caef53a0e3a6,
+  and is released in TensorFlow versions 1.15.4, 2.0.3, 2.1.2, 2.2.1, or 2.3.1.'
+id: PYSEC-0000-CVE-2020-15206
+modified: '2020-10-29T16:15:00Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-w5gh-2wr2-pm6g
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/adf095206f25471e864a8e63a0f1caef53a0e3a6
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00065.html

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15207.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15207.yaml
@@ -1,0 +1,46 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 2d88f470dea2671b430884260f3626b1fe99830a
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.4
+    - introduced: 2.0.0
+    - fixed: 2.0.3
+    - introduced: 2.1.0
+    - fixed: 2.1.2
+    - introduced: 2.2.0
+    - fixed: 2.2.1
+    - introduced: 2.3.0
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15207
+- GHSA-q4qf-3fc6-8x34
+details: In tensorflow-lite before versions 1.15.4, 2.0.3, 2.1.2, 2.2.1 and 2.3.1,
+  to mimic Python's indexing with negative values, TFLite uses `ResolveAxis` to convert
+  negative values to positive indices. However, the only check that the converted
+  index is now valid is only present in debug builds. If the `DCHECK` does not trigger,
+  then code execution moves ahead with a negative index. This, in turn, results in
+  accessing data out of bounds which results in segfaults and/or data corruption.
+  The issue is patched in commit 2d88f470dea2671b430884260f3626b1fe99830a, and is
+  released in TensorFlow versions 1.15.4, 2.0.3, 2.1.2, 2.2.1, or 2.3.1.
+id: PYSEC-0000-CVE-2020-15207
+modified: '2020-10-29T16:15:00Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/2d88f470dea2671b430884260f3626b1fe99830a
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-q4qf-3fc6-8x34
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00065.html

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15208.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15208.yaml
@@ -1,0 +1,46 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 8ee24e7949a203d234489f9da2c5bf45a7d5157d
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.4
+    - introduced: 2.0.0
+    - fixed: 2.0.3
+    - introduced: 2.1.0
+    - fixed: 2.1.2
+    - introduced: 2.2.0
+    - fixed: 2.2.1
+    - introduced: 2.3.0
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15208
+- GHSA-mxjj-953w-2c2v
+details: In tensorflow-lite before versions 1.15.4, 2.0.3, 2.1.2, 2.2.1 and 2.3.1,
+  when determining the common dimension size of two tensors, TFLite uses a `DCHECK`
+  which is no-op outside of debug compilation modes. Since the function always returns
+  the dimension of the first tensor, malicious attackers can craft cases where this
+  is larger than that of the second tensor. In turn, this would result in reads/writes
+  outside of bounds since the interpreter will wrongly assume that there is enough
+  data in both tensors. The issue is patched in commit 8ee24e7949a203d234489f9da2c5bf45a7d5157d,
+  and is released in TensorFlow versions 1.15.4, 2.0.3, 2.1.2, 2.2.1, or 2.3.1.
+id: PYSEC-0000-CVE-2020-15208
+modified: '2020-10-29T16:15:00Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/8ee24e7949a203d234489f9da2c5bf45a7d5157d
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-mxjj-953w-2c2v
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00065.html

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15209.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15209.yaml
@@ -1,0 +1,47 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 0b5662bc2be13a8c8f044d925d87fb6e56247cd8
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.4
+    - introduced: 2.0.0
+    - fixed: 2.0.3
+    - introduced: 2.1.0
+    - fixed: 2.1.2
+    - introduced: 2.2.0
+    - fixed: 2.2.1
+    - introduced: 2.3.0
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15209
+- GHSA-qh32-6jjc-qprm
+details: In tensorflow-lite before versions 1.15.4, 2.0.3, 2.1.2, 2.2.1 and 2.3.1,
+  a crafted TFLite model can force a node to have as input a tensor backed by a `nullptr`
+  buffer. This can be achieved by changing a buffer index in the flatbuffer serialization
+  to convert a read-only tensor to a read-write one. The runtime assumes that these
+  buffers are written to before a possible read, hence they are initialized with `nullptr`.
+  However, by changing the buffer index for a tensor and implicitly converting that
+  tensor to be a read-write one, as there is nothing in the model that writes to it,
+  we get a null pointer dereference. The issue is patched in commit 0b5662bc, and
+  is released in TensorFlow versions 1.15.4, 2.0.3, 2.1.2, 2.2.1, or 2.3.1.
+id: PYSEC-0000-CVE-2020-15209
+modified: '2020-10-29T16:15:00Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-qh32-6jjc-qprm
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/0b5662bc2be13a8c8f044d925d87fb6e56247cd8
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00065.html

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15210.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15210.yaml
@@ -1,0 +1,44 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: d58c96946b2880991d63d1dacacb32f0a4dfa453
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.4
+    - introduced: 2.0.0
+    - fixed: 2.0.3
+    - introduced: 2.1.0
+    - fixed: 2.1.2
+    - introduced: 2.2.0
+    - fixed: 2.2.1
+    - introduced: 2.3.0
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15210
+- GHSA-x9j7-x98r-r4w2
+details: In tensorflow-lite before versions 1.15.4, 2.0.3, 2.1.2, 2.2.1 and 2.3.1,
+  if a TFLite saved model uses the same tensor as both input and output of an operator,
+  then, depending on the operator, we can observe a segmentation fault or just memory
+  corruption. We have patched the issue in d58c96946b and will release patch releases
+  for all versions between 1.15 and 2.3. We recommend users to upgrade to TensorFlow
+  1.15.4, 2.0.3, 2.1.2, 2.2.1, or 2.3.1.
+id: PYSEC-0000-CVE-2020-15210
+modified: '2020-10-29T16:15:00Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/d58c96946b2880991d63d1dacacb32f0a4dfa453
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-x9j7-x98r-r4w2
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00065.html

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15211.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15211.yaml
@@ -1,0 +1,73 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: e11f55585f614645b360563072ffeb5c3eeff162
+    - fixed: cd31fd0ce0449a9e0f83dcad08d6ed7f1d6bef3f
+    - fixed: 46d5b0852528ddfd614ded79bccc75589f801bd9
+    - fixed: 00302787b788c5ff04cb6f62aed5a74d936e86c0
+    - fixed: fff2c8326280c07733828f990548979bdc893859
+    - fixed: 1970c2158b1ffa416d159d03c3370b9a462aee35
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.4
+    - introduced: 2.0.0
+    - fixed: 2.0.3
+    - introduced: 2.1.0
+    - fixed: 2.1.2
+    - introduced: 2.2.0
+    - fixed: 2.2.1
+    - introduced: 2.3.0
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15211
+- GHSA-cvpc-8phh-8f45
+details: 'In TensorFlow Lite before versions 1.15.4, 2.0.3, 2.1.2, 2.2.1 and 2.3.1,
+  saved models in the flatbuffer format use a double indexing scheme: a model has
+  a set of subgraphs, each subgraph has a set of operators and each operator has a
+  set of input/output tensors. The flatbuffer format uses indices for the tensors,
+  indexing into an array of tensors that is owned by the subgraph. This results in
+  a pattern of double array indexing when trying to get the data of each tensor. However,
+  some operators can have some tensors be optional. To handle this scenario, the flatbuffer
+  model uses a negative `-1` value as index for these tensors. This results in special
+  casing during validation at model loading time. Unfortunately, this means that the
+  `-1` index is a valid tensor index for any operator, including those that don''t
+  expect optional inputs and including for output tensors. Thus, this allows writing
+  and reading from outside the bounds of heap allocated arrays, although only at a
+  specific offset from the start of these arrays. This results in both read and write
+  gadgets, albeit very limited in scope. The issue is patched in several commits (46d5b0852,
+  00302787b7, e11f5558, cd31fd0ce, 1970c21, and fff2c83), and is released in TensorFlow
+  versions 1.15.4, 2.0.3, 2.1.2, 2.2.1, or 2.3.1. A potential workaround would be
+  to add a custom `Verifier` to the model loading code to ensure that only operators
+  which accept optional inputs use the `-1` special value and only for the tensors
+  that they expect to be optional. Since this allow-list type approach is erro-prone,
+  we advise upgrading to the patched code.'
+id: PYSEC-0000-CVE-2020-15211
+modified: '2020-10-29T16:15:00Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/e11f55585f614645b360563072ffeb5c3eeff162
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/cd31fd0ce0449a9e0f83dcad08d6ed7f1d6bef3f
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/46d5b0852528ddfd614ded79bccc75589f801bd9
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/00302787b788c5ff04cb6f62aed5a74d936e86c0
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-cvpc-8phh-8f45
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/fff2c8326280c07733828f990548979bdc893859
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/1970c2158b1ffa416d159d03c3370b9a462aee35
+- type: WEB
+  url: http://lists.opensuse.org/opensuse-security-announce/2020-10/msg00065.html

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15212.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15212.yaml
@@ -1,0 +1,44 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 204945b19e44b57906c9344c0d00120eeeae178a
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.1
+    - introduced: 2.2.0
+    - fixed: 2.2.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15212
+- GHSA-hx2x-85gr-wrpq
+details: In TensorFlow Lite before versions 2.2.1 and 2.3.1, models using segment
+  sum can trigger writes outside of bounds of heap allocated buffers by inserting
+  negative elements in the segment ids tensor. Users having access to `segment_ids_data`
+  can alter `output_index` and then write to outside of `output_data` buffer. This
+  might result in a segmentation fault but it can also be used to further corrupt
+  the memory and can be chained with other vulnerabilities to create more advanced
+  exploits. The issue is patched in commit 204945b19e44b57906c9344c0d00120eeeae178a
+  and is released in TensorFlow versions 2.2.1, or 2.3.1. A potential workaround would
+  be to add a custom `Verifier` to the model loading code to ensure that the segment
+  ids are all positive, although this only handles the case when the segment ids are
+  stored statically in the model. A similar validation could be done if the segment
+  ids are generated at runtime between inference steps. If the segment ids are generated
+  as outputs of a tensor during inference steps, then there are no possible workaround
+  and users are advised to upgrade to patched code.
+id: PYSEC-0000-CVE-2020-15212
+modified: '2020-10-01T18:20:00Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-hx2x-85gr-wrpq
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/204945b19e44b57906c9344c0d00120eeeae178a

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15213.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15213.yaml
@@ -1,0 +1,42 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 204945b19e44b57906c9344c0d00120eeeae178a
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.2.0
+    - fixed: 2.2.1
+    - introduced: 2.3.0
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15213
+- GHSA-hjmq-236j-8m87
+details: In TensorFlow Lite before versions 2.2.1 and 2.3.1, models using segment
+  sum can trigger a denial of service by causing an out of memory allocation in the
+  implementation of segment sum. Since code uses the last element of the tensor holding
+  them to determine the dimensionality of output tensor, attackers can use a very
+  large value to trigger a large allocation. The issue is patched in commit 204945b19e44b57906c9344c0d00120eeeae178a
+  and is released in TensorFlow versions 2.2.1, or 2.3.1. A potential workaround would
+  be to add a custom `Verifier` to limit the maximum value in the segment ids tensor.
+  This only handles the case when the segment ids are stored statically in the model,
+  but a similar validation could be done if the segment ids are generated at runtime,
+  between inference steps. However, if the segment ids are generated as outputs of
+  a tensor during inference steps, then there are no possible workaround and users
+  are advised to upgrade to patched code.
+id: PYSEC-0000-CVE-2020-15213
+modified: '2020-10-01T23:15:00Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-hjmq-236j-8m87
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/204945b19e44b57906c9344c0d00120eeeae178a

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15214.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15214.yaml
@@ -1,0 +1,45 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 204945b19e44b57906c9344c0d00120eeeae178a
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.2.0
+    - fixed: 2.2.1
+    - introduced: 2.3.0
+    - fixed: 2.3.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15214
+- GHSA-p2cq-cprg-frvm
+details: In TensorFlow Lite before versions 2.2.1 and 2.3.1, models using segment
+  sum can trigger a write out bounds / segmentation fault if the segment ids are not
+  sorted. Code assumes that the segment ids are in increasing order, using the last
+  element of the tensor holding them to determine the dimensionality of output tensor.
+  This results in allocating insufficient memory for the output tensor and in a write
+  outside the bounds of the output array. This usually results in a segmentation fault,
+  but depending on runtime conditions it can provide for a write gadget to be used
+  in future memory corruption-based exploits. The issue is patched in commit 204945b19e44b57906c9344c0d00120eeeae178a
+  and is released in TensorFlow versions 2.2.1, or 2.3.1. A potential workaround would
+  be to add a custom `Verifier` to the model loading code to ensure that the segment
+  ids are sorted, although this only handles the case when the segment ids are stored
+  statically in the model. A similar validation could be done if the segment ids are
+  generated at runtime between inference steps. If the segment ids are generated as
+  outputs of a tensor during inference steps, then there are no possible workaround
+  and users are advised to upgrade to patched code.
+id: PYSEC-0000-CVE-2020-15214
+modified: '2020-10-01T18:36:00Z'
+published: '2020-09-25T19:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-p2cq-cprg-frvm
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.3.1
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/204945b19e44b57906c9344c0d00120eeeae178a

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15265.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15265.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: eccb7ec454e6617738554a255d77f08e60ee0808
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15265
+- GHSA-rrfp-j2mp-hq9c
+details: In Tensorflow before version 2.4.0, an attacker can pass an invalid `axis`
+  value to `tf.quantization.quantize_and_dequantize`. This results in accessing a
+  dimension outside the rank of the input tensor in the C++ kernel implementation.
+  However, dim_size only does a DCHECK to validate the argument and then uses it to
+  access the corresponding element of an array. Since in normal builds, `DCHECK`-like
+  macros are no-ops, this results in segfault and access out of bounds of the array.
+  The issue is patched in eccb7ec454e6617738554a255d77f08e60ee0808 and TensorFlow
+  2.4.0 will be released containing the patch. TensorFlow nightly packages after this
+  commit will also have the issue resolved.
+id: PYSEC-0000-CVE-2020-15265
+modified: '2021-09-01T08:19:35.574576Z'
+published: '2020-10-21T21:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/eccb7ec454e6617738554a255d77f08e60ee0808
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-rrfp-j2mp-hq9c
+- type: REPORT
+  url: https://github.com/tensorflow/tensorflow/issues/42105

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15266.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-15266.yaml
@@ -1,0 +1,29 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-15266
+- GHSA-xwhf-g6j5-j5gc
+details: In Tensorflow before version 2.4.0, when the `boxes` argument of `tf.image.crop_and_resize`
+  has a very large value, the CPU kernel implementation receives it as a C++ `nan`
+  floating point value. Attempting to operate on this is undefined behavior which
+  later produces a segmentation fault. The issue is patched in eccb7ec454e6617738554a255d77f08e60ee0808
+  and TensorFlow 2.4.0 will be released containing the patch. TensorFlow nightly packages
+  after this commit will also have the issue resolved.
+id: PYSEC-0000-CVE-2020-15266
+modified: '2021-09-01T08:19:35.637564Z'
+published: '2020-10-21T21:15:00Z'
+references:
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/pull/42143/commits/3ade2efec2e90c6237de32a19680caaa3ebc2845
+- type: REPORT
+  url: https://github.com/tensorflow/tensorflow/issues/42129
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-xwhf-g6j5-j5gc

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-26266.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-26266.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: ace0c15a22f7f054abcc1f53eabbcb0a1239a9e2
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.5
+    - introduced: 2.0.0
+    - fixed: 2.0.4
+    - introduced: 2.1.0
+    - fixed: 2.1.3
+    - introduced: 2.2.0
+    - fixed: 2.2.2
+    - introduced: 2.3.0
+    - fixed: 2.3.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-26266
+- GHSA-qhxx-j73r-qpm2
+details: In affected versions of TensorFlow under certain cases a saved model can
+  trigger use of uninitialized values during code execution. This is caused by having
+  tensor buffers be filled with the default value of the type but forgetting to default
+  initialize the quantized floating point types in Eigen. This is fixed in versions
+  1.15.5, 2.0.4, 2.1.3, 2.2.2, 2.3.2, and 2.4.0.
+id: PYSEC-0000-CVE-2020-26266
+modified: '2021-08-27T03:22:22.698179Z'
+published: '2020-12-10T23:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/ace0c15a22f7f054abcc1f53eabbcb0a1239a9e2
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-qhxx-j73r-qpm2

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-26267.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-26267.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: ebc70b7a592420d3d2f359e4b1694c236b82c7ae
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.5
+    - introduced: 2.0.0
+    - fixed: 2.0.4
+    - introduced: 2.1.0
+    - fixed: 2.1.3
+    - introduced: 2.2.0
+    - fixed: 2.2.2
+    - introduced: 2.3.0
+    - fixed: 2.3.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-26267
+- GHSA-c9f3-9wfr-wgh7
+details: In affected versions of TensorFlow the tf.raw_ops.DataFormatVecPermute API
+  does not validate the src_format and dst_format attributes. The code assumes that
+  these two arguments define a permutation of NHWC. This can result in uninitialized
+  memory accesses, read outside of bounds and even crashes. This is fixed in versions
+  1.15.5, 2.0.4, 2.1.3, 2.2.2, 2.3.2, and 2.4.0.
+id: PYSEC-0000-CVE-2020-26267
+modified: '2020-12-14T19:08:00Z'
+published: '2020-12-10T23:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/ebc70b7a592420d3d2f359e4b1694c236b82c7ae
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-c9f3-9wfr-wgh7

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-26268.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-26268.yaml
@@ -1,0 +1,44 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: c1e1fc899ad5f8c725dcbb6470069890b5060bc7
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.5
+    - introduced: 2.0.0
+    - fixed: 2.0.4
+    - introduced: 2.1.0
+    - fixed: 2.1.3
+    - introduced: 2.2.0
+    - fixed: 2.2.2
+    - introduced: 2.3.0
+    - fixed: 2.3.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-26268
+- GHSA-hhvc-g5hv-48c6
+details: In affected versions of TensorFlow the tf.raw_ops.ImmutableConst operation
+  returns a constant tensor created from a memory mapped file which is assumed immutable.
+  However, if the type of the tensor is not an integral type, the operation crashes
+  the Python interpreter as it tries to write to the memory area. If the file is too
+  small, TensorFlow properly returns an error as the memory area has fewer bytes than
+  what is needed for the tensor it creates. However, as soon as there are enough bytes,
+  the above snippet causes a segmentation fault. This is because the allocator used
+  to return the buffer data is not marked as returning an opaque handle since the
+  needed virtual method is not overridden. This is fixed in versions 1.15.5, 2.0.4,
+  2.1.3, 2.2.2, 2.3.2, and 2.4.0.
+id: PYSEC-0000-CVE-2020-26268
+modified: '2021-08-27T03:22:22.907995Z'
+published: '2020-12-10T23:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/c1e1fc899ad5f8c725dcbb6470069890b5060bc7
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-hhvc-g5hv-48c6

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-26269.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-26269.yaml
@@ -1,0 +1,34 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 8b5b9dc96666a3a5d27fad7179ff215e3b74b67c
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.4.0rc0
+    - fixed: 2.4.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-26269
+- GHSA-9jjw-hf72-3mxw
+details: 'In TensorFlow release candidate versions 2.4.0rc*, the general implementation
+  for matching filesystem paths to globbing pattern is vulnerable to an access out
+  of bounds of the array holding the directories. There are multiple invariants and
+  preconditions that are assumed by the parallel implementation of GetMatchingPaths
+  but are not verified by the PRs introducing it (#40861 and #44310). Thus, we are
+  completely rewriting the implementation to fully specify and validate these. This
+  is patched in version 2.4.0. This issue only impacts master branch and the release
+  candidates for TF version 2.4. The final release of the 2.4 release will be patched.'
+id: PYSEC-0000-CVE-2020-26269
+modified: '2020-12-14T17:42:00Z'
+published: '2020-12-10T23:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-9jjw-hf72-3mxw
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/8b5b9dc96666a3a5d27fad7179ff215e3b74b67c

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-26270.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-26270.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 14755416e364f17fb1870882fa778c7fec7f16e3
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.5
+    - introduced: 2.0.0
+    - fixed: 2.0.4
+    - introduced: 2.1.0
+    - fixed: 2.1.3
+    - introduced: 2.2.0
+    - fixed: 2.2.2
+    - introduced: 2.3.0
+    - fixed: 2.3.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-26270
+- GHSA-m648-33qf-v3gp
+details: In affected versions of TensorFlow running an LSTM/GRU model where the LSTM/GRU
+  layer receives an input with zero-length results in a CHECK failure when using the
+  CUDA backend. This can result in a query-of-death vulnerability, via denial of service,
+  if users can control the input to the layer. This is fixed in versions 1.15.5, 2.0.4,
+  2.1.3, 2.2.2, 2.3.2, and 2.4.0.
+id: PYSEC-0000-CVE-2020-26270
+modified: '2021-08-27T03:22:23.120464Z'
+published: '2020-12-10T23:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-m648-33qf-v3gp
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/14755416e364f17fb1870882fa778c7fec7f16e3

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-26271.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-26271.yaml
@@ -1,0 +1,46 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 0cc38aaa4064fd9e79101994ce9872c6d91f816b
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.5
+    - introduced: 2.0.0
+    - fixed: 2.0.4
+    - introduced: 2.1.0
+    - fixed: 2.1.3
+    - introduced: 2.2.0
+    - fixed: 2.2.2
+    - introduced: 2.3.0
+    - fixed: 2.3.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-26271
+- GHSA-q263-fvxm-m5mw
+details: In affected versions of TensorFlow under certain cases, loading a saved model
+  can result in accessing uninitialized memory while building the computation graph.
+  The MakeEdge function creates an edge between one output tensor of the src node
+  (given by output_index) and the input slot of the dst node (given by input_index).
+  This is only possible if the types of the tensors on both sides coincide, so the
+  function begins by obtaining the corresponding DataType values and comparing these
+  for equality. However, there is no check that the indices point to inside of the
+  arrays they index into. Thus, this can result in accessing data out of bounds of
+  the corresponding heap allocated arrays. In most scenarios, this can manifest as
+  unitialized data access, but if the index points far away from the boundaries of
+  the arrays this can be used to leak addresses from the library. This is fixed in
+  versions 1.15.5, 2.0.4, 2.1.3, 2.2.2, 2.3.2, and 2.4.0.
+id: PYSEC-0000-CVE-2020-26271
+modified: '2021-08-27T03:22:23.329750Z'
+published: '2020-12-10T22:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-q263-fvxm-m5mw
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/0cc38aaa4064fd9e79101994ce9872c6d91f816b

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-5215.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2020-5215.yaml
@@ -1,0 +1,43 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 5ac1b9e24ff6afc465756edf845d2e9660bd34bf
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 1.15.2
+    - introduced: 2.0.0
+    - fixed: 2.0.1
+    type: ECOSYSTEM
+aliases:
+- CVE-2020-5215
+- GHSA-977j-xj7q-2jr9
+details: In TensorFlow before 1.15.2 and 2.0.1, converting a string (from Python)
+  to a tf.float16 value results in a segmentation fault in eager mode as the format
+  checks for this use case are only in the graph mode. This issue can lead to denial
+  of service in inference/training where a malicious attacker can send a data point
+  which contains a string instead of a tf.float16 value. Similar effects can be obtained
+  by manipulating saved models and checkpoints whereby replacing a scalar tf.float16
+  value with a scalar string will trigger this issue due to automatic conversions.
+  This can be easily reproduced by tf.constant("hello", tf.float16), if eager execution
+  is enabled. This issue is patched in TensorFlow 1.15.1 and 2.0.1 with this vulnerability
+  patched. TensorFlow 2.1.0 was released after we fixed the issue, thus it is not
+  affected. Users are encouraged to switch to TensorFlow 1.15.1, 2.0.1 or 2.1.0.
+id: PYSEC-0000-CVE-2020-5215
+modified: '2021-08-27T03:22:23.423115Z'
+published: '2020-01-28T22:15:00Z'
+references:
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v1.15.2
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/5ac1b9e24ff6afc465756edf845d2e9660bd34bf
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/releases/tag/v2.0.1
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-977j-xj7q-2jr9

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29512.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29512.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: eebb96c2830d48597d055d247c0e9aebaea94cd5
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29512
+- GHSA-4278-2v5v-65r4
+details: TensorFlow is an end-to-end open source platform for machine learning. If
+  the `splits` argument of `RaggedBincount` does not specify a valid `SparseTensor`(https://www.tensorflow.org/api_docs/python/tf/sparse/SparseTensor),
+  then an attacker can trigger a heap buffer overflow. This will cause a read from
+  outside the bounds of the `splits` tensor buffer in the implementation of the `RaggedBincount`
+  op(https://github.com/tensorflow/tensorflow/blob/8b677d79167799f71c42fd3fa074476e0295413a/tensorflow/core/kernels/bincount_op.cc#L430-L433).
+  Before the `for` loop, `batch_idx` is set to 0. The user controls the `splits` array,
+  making it contain only one element, 0. Thus, the code in the `while` loop would
+  increment `batch_idx` and then try to read `splits(1)`, which is outside of bounds.
+  The fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit
+  on TensorFlow 2.4.2 and TensorFlow 2.3.3, as these are also affected.
+id: PYSEC-0000-CVE-2021-29512
+modified: '2021-08-27T03:22:23.518786Z'
+published: '2021-05-14T19:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-4278-2v5v-65r4
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/eebb96c2830d48597d055d247c0e9aebaea94cd5

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29513.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29513.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 030af767d357d1b4088c4a25c72cb3906abac489
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29513
+- GHSA-452g-f7fp-9jf7
+details: TensorFlow is an end-to-end open source platform for machine learning. Calling
+  TF operations with tensors of non-numeric types when the operations expect numeric
+  tensors result in null pointer dereferences. The conversion from Python array to
+  C++ array(https://github.com/tensorflow/tensorflow/blob/ff70c47a396ef1e3cb73c90513da4f5cb71bebba/tensorflow/python/lib/core/ndarray_tensor.cc#L113-L169)
+  is vulnerable to a type confusion. The fix will be included in TensorFlow 2.5.0.
+  We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow
+  2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29513
+modified: '2021-08-27T03:22:23.682962Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/030af767d357d1b4088c4a25c72cb3906abac489
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-452g-f7fp-9jf7

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29514.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29514.yaml
@@ -1,0 +1,43 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: eebb96c2830d48597d055d247c0e9aebaea94cd5
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29514
+- GHSA-8h46-5m9h-7553
+details: TensorFlow is an end-to-end open source platform for machine learning. If
+  the `splits` argument of `RaggedBincount` does not specify a valid `SparseTensor`(https://www.tensorflow.org/api_docs/python/tf/sparse/SparseTensor),
+  then an attacker can trigger a heap buffer overflow. This will cause a read from
+  outside the bounds of the `splits` tensor buffer in the implementation of the `RaggedBincount`
+  op(https://github.com/tensorflow/tensorflow/blob/8b677d79167799f71c42fd3fa074476e0295413a/tensorflow/core/kernels/bincount_op.cc#L430-L446).
+  Before the `for` loop, `batch_idx` is set to 0. The attacker sets `splits(0)` to
+  be 7, hence the `while` loop does not execute and `batch_idx` remains 0. This then
+  results in writing to `out(-1, bin)`, which is before the heap allocated buffer
+  for the output tensor. The fix will be included in TensorFlow 2.5.0. We will also
+  cherrypick this commit on TensorFlow 2.4.2 and TensorFlow 2.3.3, as these are also
+  affected.
+id: PYSEC-0000-CVE-2021-29514
+modified: '2021-08-27T03:22:23.861341Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/eebb96c2830d48597d055d247c0e9aebaea94cd5
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-8h46-5m9h-7553

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29515.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29515.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: a7116dd3913c4a4afd2a3a938573aa7c785fdfc6
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29515
+- GHSA-hc6c-75p4-hmq4
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of `MatrixDiag*` operations(https://github.com/tensorflow/tensorflow/blob/4c4f420e68f1cfaf8f4b6e8e3eb857e9e4c3ff33/tensorflow/core/kernels/linalg/matrix_diag_op.cc#L195-L197)
+  does not validate that the tensor arguments are non-empty. The fix will be included
+  in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow
+  2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-29515
+modified: '2021-08-27T03:22:24.038004Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/a7116dd3913c4a4afd2a3a938573aa7c785fdfc6
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-hc6c-75p4-hmq4

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29516.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29516.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: b055b9c474cd376259dde8779908f9eeaf097d93
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29516
+- GHSA-84mw-34w6-2q43
+details: TensorFlow is an end-to-end open source platform for machine learning. Calling
+  `tf.raw_ops.RaggedTensorToVariant` with arguments specifying an invalid ragged tensor
+  results in a null pointer dereference. The implementation of `RaggedTensorToVariant`
+  operations(https://github.com/tensorflow/tensorflow/blob/904b3926ed1c6c70380d5313d282d248a776baa1/tensorflow/core/kernels/ragged_tensor_to_variant_op.cc#L39-L40)
+  does not validate that the ragged tensor argument is non-empty. Since `batched_ragged`
+  contains no elements, `batched_ragged.splits` is a null vector, thus `batched_ragged.splits(0)`
+  will result in dereferencing `nullptr`. The fix will be included in TensorFlow 2.5.0.
+  We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow
+  2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29516
+modified: '2021-08-27T03:22:24.214869Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-84mw-34w6-2q43
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/b055b9c474cd376259dde8779908f9eeaf097d93

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29517.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29517.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 799f835a3dfa00a4d852defa29b15841eea9d64f
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29517
+- GHSA-772p-x54p-hjrv
+details: TensorFlow is an end-to-end open source platform for machine learning. A
+  malicious user could trigger a division by 0 in `Conv3D` implementation. The implementation(https://github.com/tensorflow/tensorflow/blob/42033603003965bffac51ae171b51801565e002d/tensorflow/core/kernels/conv_ops_3d.cc#L143-L145)
+  does a modulo operation based on user controlled input. Thus, when `filter` has
+  a 0 as the fifth element, this results in a division by 0. Additionally, if the
+  shape of the two tensors is not valid, an Eigen assertion can be triggered, resulting
+  in a program crash. The fix will be included in TensorFlow 2.5.0. We will also cherrypick
+  this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow
+  2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29517
+modified: '2021-08-27T03:22:24.411852Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-772p-x54p-hjrv
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/799f835a3dfa00a4d852defa29b15841eea9d64f

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29518.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29518.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: ff70c47a396ef1e3cb73c90513da4f5cb71bebba
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29518
+- GHSA-62gx-355r-9fhg
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  eager mode (default in TF 2.0 and later), session operations are invalid. However,
+  users could still call the raw ops associated with them and trigger a null pointer
+  dereference. The implementation(https://github.com/tensorflow/tensorflow/blob/eebb96c2830d48597d055d247c0e9aebaea94cd5/tensorflow/core/kernels/session_ops.cc#L104)
+  dereferences the session state pointer without checking if it is valid. Thus, in
+  eager mode, `ctx->session_state()` is nullptr and the call of the member function
+  is undefined behavior. The fix will be included in TensorFlow 2.5.0. We will also
+  cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and
+  TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29518
+modified: '2021-08-27T03:22:24.585448Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/ff70c47a396ef1e3cb73c90513da4f5cb71bebba
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-62gx-355r-9fhg

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29519.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29519.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: b1cc5e5a50e7cee09f2c6eb48eb40ee9c4125025
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29519
+- GHSA-772j-h9xw-ffp5
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  API of `tf.raw_ops.SparseCross` allows combinations which would result in a `CHECK`-failure
+  and denial of service. This is because the implementation(https://github.com/tensorflow/tensorflow/blob/3d782b7d47b1bf2ed32bd4a246d6d6cadc4c903d/tensorflow/core/kernels/sparse_cross_op.cc#L114-L116)
+  is tricked to consider a tensor of type `tstring` which in fact contains integral
+  elements. Fixing the type confusion by preventing mixing `DT_STRING` and `DT_INT64`
+  types solves this issue. The fix will be included in TensorFlow 2.5.0. We will also
+  cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and
+  TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29519
+modified: '2021-08-27T03:22:24.765492Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-772j-h9xw-ffp5
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/b1cc5e5a50e7cee09f2c6eb48eb40ee9c4125025

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29520.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29520.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 8f37b52e1320d8d72a9529b2468277791a261197
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29520
+- GHSA-wcv5-qrj6-9pfm
+details: TensorFlow is an end-to-end open source platform for machine learning. Missing
+  validation between arguments to `tf.raw_ops.Conv3DBackprop*` operations can result
+  in heap buffer overflows. This is because the implementation(https://github.com/tensorflow/tensorflow/blob/4814fafb0ca6b5ab58a09411523b2193fed23fed/tensorflow/core/kernels/conv_grad_shape_utils.cc#L94-L153)
+  assumes that the `input`, `filter_sizes` and `out_backprop` tensors have the same
+  shape, as they are accessed in parallel. The fix will be included in TensorFlow
+  2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3,
+  TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported
+  range.
+id: PYSEC-0000-CVE-2021-29520
+modified: '2021-08-27T03:22:24.934633Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/8f37b52e1320d8d72a9529b2468277791a261197
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-wcv5-qrj6-9pfm

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29521.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29521.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: c57c0b9f3a4f8684f3489dd9a9ec627ad8b599f5
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29521
+- GHSA-hr84-fqvp-48mm
+details: TensorFlow is an end-to-end open source platform for machine learning. Specifying
+  a negative dense shape in `tf.raw_ops.SparseCountSparseOutput` results in a segmentation
+  fault being thrown out from the standard library as `std::vector` invariants are
+  broken. This is because the implementation(https://github.com/tensorflow/tensorflow/blob/8f7b60ee8c0206a2c99802e3a4d1bb55d2bc0624/tensorflow/core/kernels/count_ops.cc#L199-L213)
+  assumes the first element of the dense shape is always positive and uses it to initialize
+  a `BatchedMap<T>` (i.e., `std::vector<absl::flat_hash_map<int64,T>>`(https://github.com/tensorflow/tensorflow/blob/8f7b60ee8c0206a2c99802e3a4d1bb55d2bc0624/tensorflow/core/kernels/count_ops.cc#L27))
+  data structure. If the `shape` tensor has more than one element, `num_batches` is
+  the first value in `shape`. Ensuring that the `dense_shape` argument is a valid
+  tensor shape (that is, all elements are non-negative) solves this issue. The fix
+  will be included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2 and TensorFlow 2.3.3.
+id: PYSEC-0000-CVE-2021-29521
+modified: '2021-08-27T03:22:25.027733Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/c57c0b9f3a4f8684f3489dd9a9ec627ad8b599f5
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-hr84-fqvp-48mm

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29522.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29522.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 311403edbc9816df80274bd1ea8b3c0c0f22c3fa
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29522
+- GHSA-c968-pq7h-7fxv
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  `tf.raw_ops.Conv3DBackprop*` operations fail to validate that the input tensors
+  are not empty. In turn, this would result in a division by 0. This is because the
+  implementation(https://github.com/tensorflow/tensorflow/blob/a91bb59769f19146d5a0c20060244378e878f140/tensorflow/core/kernels/conv_grad_ops_3d.cc#L430-L450)
+  does not check that the divisor used in computing the shard size is not zero. Thus,
+  if attacker controls the input sizes, they can trigger a denial of service via a
+  division by zero error. The fix will be included in TensorFlow 2.5.0. We will also
+  cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and
+  TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29522
+modified: '2021-08-27T03:22:25.206676Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-c968-pq7h-7fxv
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/311403edbc9816df80274bd1ea8b3c0c0f22c3fa

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29523.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29523.yaml
@@ -1,0 +1,43 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 69c68ecbb24dff3fa0e46da0d16c821a2dd22d7c
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29523
+- GHSA-2cpx-427x-q2c6
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a denial of service via a `CHECK`-fail in `tf.raw_ops.AddManySparseToTensorsMap`.
+  This is because the implementation(https://github.com/tensorflow/tensorflow/blob/6f9896890c4c703ae0a0845394086e2e1e523299/tensorflow/core/kernels/sparse_tensors_map_ops.cc#L257)
+  takes the values specified in `sparse_shape` as dimensions for the output shape.
+  The `TensorShape` constructor(https://github.com/tensorflow/tensorflow/blob/6f9896890c4c703ae0a0845394086e2e1e523299/tensorflow/core/framework/tensor_shape.cc#L183-L188)
+  uses a `CHECK` operation which triggers when `InitDims`(https://github.com/tensorflow/tensorflow/blob/6f9896890c4c703ae0a0845394086e2e1e523299/tensorflow/core/framework/tensor_shape.cc#L212-L296)
+  returns a non-OK status. This is a legacy implementation of the constructor and
+  operations should use `BuildTensorShapeBase` or `AddDimWithStatus` to prevent `CHECK`-failures
+  in the presence of overflows. The fix will be included in TensorFlow 2.5.0. We will
+  also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3
+  and TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29523
+modified: '2021-08-27T03:22:25.367237Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/69c68ecbb24dff3fa0e46da0d16c821a2dd22d7c
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-2cpx-427x-q2c6

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29524.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29524.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: fca9874a9b42a2134f907d2fb46ab774a831404a
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29524
+- GHSA-r4pj-74mg-8868
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a division by 0 in `tf.raw_ops.Conv2DBackpropFilter`. This
+  is because the implementation(https://github.com/tensorflow/tensorflow/blob/496c2630e51c1a478f095b084329acedb253db6b/tensorflow/core/kernels/conv_grad_shape_utils.cc#L130)
+  does a modulus operation where the divisor is controlled by the caller. The fix
+  will be included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29524
+modified: '2021-08-27T03:22:25.604287Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/fca9874a9b42a2134f907d2fb46ab774a831404a
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-r4pj-74mg-8868

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29525.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29525.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 2be2cdf3a123e231b16f766aa0e27d56b4606535
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29525
+- GHSA-xm2v-8rrw-w9pm
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a division by 0 in `tf.raw_ops.Conv2DBackpropInput`. This is
+  because the implementation(https://github.com/tensorflow/tensorflow/blob/b40060c9f697b044e3107917c797ba052f4506ab/tensorflow/core/kernels/conv_grad_input_ops.h#L625-L655)
+  does a division by a quantity that is controlled by the caller. The fix will be
+  included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29525
+modified: '2021-08-27T03:22:25.775857Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-xm2v-8rrw-w9pm
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/2be2cdf3a123e231b16f766aa0e27d56b4606535

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29526.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29526.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: b12aa1d44352de21d1a6faaf04172d8c2508b42b
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29526
+- GHSA-4vf2-4xcg-65cx
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a division by 0 in `tf.raw_ops.Conv2D`. This is because the
+  implementation(https://github.com/tensorflow/tensorflow/blob/988087bd83f144af14087fe4fecee2d250d93737/tensorflow/core/kernels/conv_ops.cc#L261-L263)
+  does a division by a quantity that is controlled by the caller. The fix will be
+  included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29526
+modified: '2021-08-27T03:22:25.990763Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-4vf2-4xcg-65cx
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/b12aa1d44352de21d1a6faaf04172d8c2508b42b

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29527.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29527.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: cfa91be9863a91d5105a3b4941096044ab32036b
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29527
+- GHSA-x4g7-fvjj-prg8
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a division by 0 in `tf.raw_ops.QuantizedConv2D`. This is because
+  the implementation(https://github.com/tensorflow/tensorflow/blob/00e9a4d67d76703fa1aee33dac582acf317e0e81/tensorflow/core/kernels/quantized_conv_ops.cc#L257-L259)
+  does a division by a quantity that is controlled by the caller. The fix will be
+  included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29527
+modified: '2021-08-27T03:22:26.181060Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/cfa91be9863a91d5105a3b4941096044ab32036b
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-x4g7-fvjj-prg8

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29528.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29528.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: a1b11d2fdd1e51bfe18bb1ede804f60abfa92da6
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29528
+- GHSA-6f84-42vf-ppwp
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a division by 0 in `tf.raw_ops.QuantizedMul`. This is because
+  the implementation(https://github.com/tensorflow/tensorflow/blob/55900e961ed4a23b438392024912154a2c2f5e85/tensorflow/core/kernels/quantized_mul_op.cc#L188-L198)
+  does a division by a quantity that is controlled by the caller. The fix will be
+  included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29528
+modified: '2021-08-27T03:22:26.348588Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/a1b11d2fdd1e51bfe18bb1ede804f60abfa92da6
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-6f84-42vf-ppwp

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29529.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29529.yaml
@@ -1,0 +1,45 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: f851613f8f0fb0c838d160ced13c134f778e3ce7
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29529
+- GHSA-jfp7-4j67-8r3q
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a heap buffer overflow in `tf.raw_ops.QuantizedResizeBilinear`
+  by manipulating input values so that float rounding results in off-by-one error
+  in accessing image elements. This is because the implementation(https://github.com/tensorflow/tensorflow/blob/44b7f486c0143f68b56c34e2d01e146ee445134a/tensorflow/core/kernels/quantized_resize_bilinear_op.cc#L62-L66)
+  computes two integers (representing the upper and lower bounds for interpolation)
+  by ceiling and flooring a floating point value. For some values of `in`, `interpolation->upper[i]`
+  might be smaller than `interpolation->lower[i]`. This is an issue if `interpolation->upper[i]`
+  is capped at `in_size-1` as it means that `interpolation->lower[i]` points outside
+  of the image. Then, in the interpolation code(https://github.com/tensorflow/tensorflow/blob/44b7f486c0143f68b56c34e2d01e146ee445134a/tensorflow/core/kernels/quantized_resize_bilinear_op.cc#L245-L264),
+  this would result in heap buffer overflow. The fix will be included in TensorFlow
+  2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3,
+  TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported
+  range.
+id: PYSEC-0000-CVE-2021-29529
+modified: '2021-08-27T03:22:26.519373Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/f851613f8f0fb0c838d160ced13c134f778e3ce7
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-jfp7-4j67-8r3q

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29530.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29530.yaml
@@ -1,0 +1,45 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: e6a7c7cc18c3aaad1ae0872cb0a959f5c923d2bd
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29530
+- GHSA-xcwj-wfcm-m23c
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a null pointer dereference by providing an invalid `permutation`
+  to `tf.raw_ops.SparseMatrixSparseCholesky`. This is because the implementation(https://github.com/tensorflow/tensorflow/blob/080f1d9e257589f78b3ffb75debf584168aa6062/tensorflow/core/kernels/sparse/sparse_cholesky_op.cc#L85-L86)
+  fails to properly validate the input arguments. Although `ValidateInputs` is called
+  and there are checks in the body of this function, the code proceeds to the next
+  line in `ValidateInputs` since `OP_REQUIRES`(https://github.com/tensorflow/tensorflow/blob/080f1d9e257589f78b3ffb75debf584168aa6062/tensorflow/core/framework/op_requires.h#L41-L48)
+  is a macro that only exits the current function. Thus, the first validation condition
+  that fails in `ValidateInputs` will cause an early return from that function. However,
+  the caller will continue execution from the next line. The fix is to either explicitly
+  check `context->status()` or to convert `ValidateInputs` to return a `Status`. The
+  fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit on
+  TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29530
+modified: '2021-08-27T03:22:26.683297Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-xcwj-wfcm-m23c
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/e6a7c7cc18c3aaad1ae0872cb0a959f5c923d2bd

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29531.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29531.yaml
@@ -1,0 +1,45 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 26eb323554ffccd173e8a79a8c05c15b685ae4d1
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29531
+- GHSA-3qxp-qjq7-w4hf
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a `CHECK` fail in PNG encoding by providing an empty input
+  tensor as the pixel data. This is because the implementation(https://github.com/tensorflow/tensorflow/blob/e312e0791ce486a80c9d23110841525c6f7c3289/tensorflow/core/kernels/image/encode_png_op.cc#L57-L60)
+  only validates that the total number of pixels in the image does not overflow. Thus,
+  an attacker can send an empty matrix for encoding. However, if the tensor is empty,
+  then the associated buffer is `nullptr`. Hence, when calling `png::WriteImageToBuffer`(https://github.com/tensorflow/tensorflow/blob/e312e0791ce486a80c9d23110841525c6f7c3289/tensorflow/core/kernels/image/encode_png_op.cc#L79-L93),
+  the first argument (i.e., `image.flat<T>().data()`) is `NULL`. This then triggers
+  the `CHECK_NOTNULL` in the first line of `png::WriteImageToBuffer`(https://github.com/tensorflow/tensorflow/blob/e312e0791ce486a80c9d23110841525c6f7c3289/tensorflow/core/lib/png/png_io.cc#L345-L349).
+  Since `image` is null, this results in `abort` being called after printing the stacktrace.
+  Effectively, this allows an attacker to mount a denial of service attack. The fix
+  will be included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29531
+modified: '2021-08-27T03:22:26.851089Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/26eb323554ffccd173e8a79a8c05c15b685ae4d1
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-3qxp-qjq7-w4hf

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29532.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29532.yaml
@@ -1,0 +1,42 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 44b7f486c0143f68b56c34e2d01e146ee445134a
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29532
+- GHSA-j47f-4232-hvv8
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can force accesses outside the bounds of heap allocated arrays by passing
+  in invalid tensor values to `tf.raw_ops.RaggedCross`. This is because the implementation(https://github.com/tensorflow/tensorflow/blob/efea03b38fb8d3b81762237dc85e579cc5fc6e87/tensorflow/core/kernels/ragged_cross_op.cc#L456-L487)
+  lacks validation for the user supplied arguments. Each of the above branches call
+  a helper function after accessing array elements via a `*_list[next_*]` pattern,
+  followed by incrementing the `next_*` index. However, as there is no validation
+  that the `next_*` values are in the valid range for the corresponding `*_list` arrays,
+  this results in heap OOB reads. The fix will be included in TensorFlow 2.5.0. We
+  will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow
+  2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29532
+modified: '2021-08-27T03:22:27.051975Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/44b7f486c0143f68b56c34e2d01e146ee445134a
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-j47f-4232-hvv8

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29533.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29533.yaml
@@ -1,0 +1,43 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: b432a38fe0e1b4b904a6c222cbce794c39703e87
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29533
+- GHSA-393f-2jr3-cp69
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a denial of service via a `CHECK` failure by passing an empty
+  image to `tf.raw_ops.DrawBoundingBoxes`. This is because the implementation(https://github.com/tensorflow/tensorflow/blob/ea34a18dc3f5c8d80a40ccca1404f343b5d55f91/tensorflow/core/kernels/image/draw_bounding_box_op.cc#L148-L165)
+  uses `CHECK_*` assertions instead of `OP_REQUIRES` to validate user controlled inputs.
+  Whereas `OP_REQUIRES` allows returning an error condition back to the user, the
+  `CHECK_*` macros result in a crash if the condition is false, similar to `assert`.
+  In this case, `height` is 0 from the `images` input. This results in `max_box_row_clamp`
+  being negative and the assertion being falsified, followed by aborting program execution.
+  The fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit
+  on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as
+  these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29533
+modified: '2021-08-27T03:22:27.240459Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-393f-2jr3-cp69
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/b432a38fe0e1b4b904a6c222cbce794c39703e87

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29534.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29534.yaml
@@ -1,0 +1,43 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 69c68ecbb24dff3fa0e46da0d16c821a2dd22d7c
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29534
+- GHSA-6j9c-grc6-5m6g
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a denial of service via a `CHECK`-fail in `tf.raw_ops.SparseConcat`.
+  This is because the implementation(https://github.com/tensorflow/tensorflow/blob/b432a38fe0e1b4b904a6c222cbce794c39703e87/tensorflow/core/kernels/sparse_concat_op.cc#L76)
+  takes the values specified in `shapes[0]` as dimensions for the output shape. The
+  `TensorShape` constructor(https://github.com/tensorflow/tensorflow/blob/6f9896890c4c703ae0a0845394086e2e1e523299/tensorflow/core/framework/tensor_shape.cc#L183-L188)
+  uses a `CHECK` operation which triggers when `InitDims`(https://github.com/tensorflow/tensorflow/blob/6f9896890c4c703ae0a0845394086e2e1e523299/tensorflow/core/framework/tensor_shape.cc#L212-L296)
+  returns a non-OK status. This is a legacy implementation of the constructor and
+  operations should use `BuildTensorShapeBase` or `AddDimWithStatus` to prevent `CHECK`-failures
+  in the presence of overflows. The fix will be included in TensorFlow 2.5.0. We will
+  also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3
+  and TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29534
+modified: '2021-08-27T03:22:27.421981Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/69c68ecbb24dff3fa0e46da0d16c821a2dd22d7c
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-6j9c-grc6-5m6g

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29535.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29535.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: efea03b38fb8d3b81762237dc85e579cc5fc6e87
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29535
+- GHSA-m3f9-w3p3-p669
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a heap buffer overflow in `QuantizedMul` by passing in invalid
+  thresholds for the quantization. This is because the implementation(https://github.com/tensorflow/tensorflow/blob/87cf4d3ea9949051e50ca3f071fc909538a51cd0/tensorflow/core/kernels/quantized_mul_op.cc#L287-L290)
+  assumes that the 4 arguments are always valid scalars and tries to access the numeric
+  value directly. However, if any of these tensors is empty, then `.flat<T>()` is
+  an empty buffer and accessing the element at position 0 results in overflow. The
+  fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit on
+  TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29535
+modified: '2021-08-27T03:22:27.629630Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-m3f9-w3p3-p669
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/efea03b38fb8d3b81762237dc85e579cc5fc6e87

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29536.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29536.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: a324ac84e573fba362a5e53d4e74d5de6729933e
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29536
+- GHSA-2gfx-95x2-5v3x
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a heap buffer overflow in `QuantizedReshape` by passing in invalid
+  thresholds for the quantization. This is because the implementation(https://github.com/tensorflow/tensorflow/blob/a324ac84e573fba362a5e53d4e74d5de6729933e/tensorflow/core/kernels/quantized_reshape_op.cc#L38-L55)
+  assumes that the 2 arguments are always valid scalars and tries to access the numeric
+  value directly. However, if any of these tensors is empty, then `.flat<T>()` is
+  an empty buffer and accessing the element at position 0 results in overflow. The
+  fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit on
+  TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29536
+modified: '2021-08-27T03:22:27.845923Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-2gfx-95x2-5v3x
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/a324ac84e573fba362a5e53d4e74d5de6729933e

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29537.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29537.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: f6c40f0c6cbf00d46c7717a26419f2062f2f8694
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29537
+- GHSA-8c89-2vwr-chcq
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a heap buffer overflow in `QuantizedResizeBilinear` by passing
+  in invalid thresholds for the quantization. This is because the implementation(https://github.com/tensorflow/tensorflow/blob/50711818d2e61ccce012591eeb4fdf93a8496726/tensorflow/core/kernels/quantized_resize_bilinear_op.cc#L705-L706)
+  assumes that the 2 arguments are always valid scalars and tries to access the numeric
+  value directly. The fix will be included in TensorFlow 2.5.0. We will also cherrypick
+  this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow
+  2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29537
+modified: '2021-08-27T03:22:28.012732Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-8c89-2vwr-chcq
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/f6c40f0c6cbf00d46c7717a26419f2062f2f8694

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29538.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29538.yaml
@@ -1,0 +1,42 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: c570e2ecfc822941335ad48f6e10df4e21f11c96
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29538
+- GHSA-j8qc-5fqr-52fp
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a division by zero to occur in `Conv2DBackpropFilter`. This is
+  because the implementation(https://github.com/tensorflow/tensorflow/blob/1b0296c3b8dd9bd948f924aa8cd62f87dbb7c3da/tensorflow/core/kernels/conv_grad_filter_ops.cc#L513-L522)
+  computes a divisor based on user provided data (i.e., the shape of the tensors given
+  as arguments). If all shapes are empty then `work_unit_size` is 0. Since there is
+  no check for this case before division, this results in a runtime exception, with
+  potential to be abused for a denial of service. The fix will be included in TensorFlow
+  2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3,
+  TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported
+  range.
+id: PYSEC-0000-CVE-2021-29538
+modified: '2021-08-27T03:22:28.180235Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/c570e2ecfc822941335ad48f6e10df4e21f11c96
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-j8qc-5fqr-52fp

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29539.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29539.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 4f663d4b8f0bec1b48da6fa091a7d29609980fa4
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29539
+- GHSA-g4h2-gqm3-c9wq
+details: TensorFlow is an end-to-end open source platform for machine learning. Calling
+  `tf.raw_ops.ImmutableConst`(https://www.tensorflow.org/api_docs/python/tf/raw_ops/ImmutableConst)
+  with a `dtype` of `tf.resource` or `tf.variant` results in a segfault in the implementation
+  as code assumes that the tensor contents are pure scalars. We have patched the issue
+  in 4f663d4b8f0bec1b48da6fa091a7d29609980fa4 and will release TensorFlow 2.5.0 containing
+  the patch. TensorFlow nightly packages after this commit will also have the issue
+  resolved. If using `tf.raw_ops.ImmutableConst` in code, you can prevent the segfault
+  by inserting a filter for the `dtype` argument.
+id: PYSEC-0000-CVE-2021-29539
+modified: '2021-08-27T03:22:28.395200Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-g4h2-gqm3-c9wq
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/4f663d4b8f0bec1b48da6fa091a7d29609980fa4

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29540.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29540.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: c570e2ecfc822941335ad48f6e10df4e21f11c96
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29540
+- GHSA-xgc3-m89p-vr3x
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a heap buffer overflow to occur in `Conv2DBackpropFilter`. This
+  is because the implementation(https://github.com/tensorflow/tensorflow/blob/1b0296c3b8dd9bd948f924aa8cd62f87dbb7c3da/tensorflow/core/kernels/conv_grad_filter_ops.cc#L495-L497)
+  computes the size of the filter tensor but does not validate that it matches the
+  number of elements in `filter_sizes`. Later, when reading/writing to this buffer,
+  code uses the value computed here, instead of the number of elements in the tensor.
+  The fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit
+  on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as
+  these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29540
+modified: '2021-08-27T03:22:28.584780Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-xgc3-m89p-vr3x
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/c570e2ecfc822941335ad48f6e10df4e21f11c96

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29541.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29541.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: ba424dd8f16f7110eea526a8086f1a155f14f22b
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29541
+- GHSA-xqfj-35wv-m3cr
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a dereference of a null pointer in `tf.raw_ops.StringNGrams`.
+  This is because the implementation(https://github.com/tensorflow/tensorflow/blob/1cdd4da14282210cc759e468d9781741ac7d01bf/tensorflow/core/kernels/string_ngrams_op.cc#L67-L74)
+  does not fully validate the `data_splits` argument. This would result in `ngrams_data`(https://github.com/tensorflow/tensorflow/blob/1cdd4da14282210cc759e468d9781741ac7d01bf/tensorflow/core/kernels/string_ngrams_op.cc#L106-L110)
+  to be a null pointer when the output would be computed to have 0 or negative size.
+  Later writes to the output tensor would then cause a null pointer dereference. The
+  fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit on
+  TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29541
+modified: '2021-08-27T03:22:28.768951Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/ba424dd8f16f7110eea526a8086f1a155f14f22b
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-xqfj-35wv-m3cr

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29542.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29542.yaml
@@ -1,0 +1,42 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: ba424dd8f16f7110eea526a8086f1a155f14f22b
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29542
+- GHSA-4hrh-9vmp-2jgg
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a heap buffer overflow by passing crafted inputs to `tf.raw_ops.StringNGrams`.
+  This is because the implementation(https://github.com/tensorflow/tensorflow/blob/1cdd4da14282210cc759e468d9781741ac7d01bf/tensorflow/core/kernels/string_ngrams_op.cc#L171-L185)
+  fails to consider corner cases where input would be split in such a way that the
+  generated tokens should only contain padding elements. If input is such that `num_tokens`
+  is 0, then, for `data_start_index=0` (when left padding is present), the marked
+  line would result in reading `data[-1]`. The fix will be included in TensorFlow
+  2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3,
+  TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported
+  range.
+id: PYSEC-0000-CVE-2021-29542
+modified: '2021-08-27T03:22:28.937409Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-4hrh-9vmp-2jgg
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/ba424dd8f16f7110eea526a8086f1a155f14f22b

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29543.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29543.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: ea3b43e98c32c97b35d52b4c66f9107452ca8fb2
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29543
+- GHSA-fphq-gw9m-ghrv
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a denial of service via a `CHECK`-fail in `tf.raw_ops.CTCGreedyDecoder`.
+  This is because the implementation(https://github.com/tensorflow/tensorflow/blob/1615440b17b364b875eb06f43d087381f1460a65/tensorflow/core/kernels/ctc_decoder_ops.cc#L37-L50)
+  has a `CHECK_LT` inserted to validate some invariants. When this condition is false,
+  the program aborts, instead of returning a valid error to the user. This abnormal
+  termination can be weaponized in denial of service attacks. The fix will be included
+  in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow
+  2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-29543
+modified: '2021-08-27T03:22:29.100995Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/ea3b43e98c32c97b35d52b4c66f9107452ca8fb2
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-fphq-gw9m-ghrv

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29544.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29544.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 20431e9044cf2ad3c0323c34888b192f3289af6b
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29544
+- GHSA-6g85-3hm8-83f9
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a denial of service via a `CHECK`-fail in `tf.raw_ops.QuantizeAndDequantizeV4Grad`.
+  This is because the implementation(https://github.com/tensorflow/tensorflow/blob/95078c145b5a7a43ee046144005f733092756ab5/tensorflow/core/kernels/quantize_and_dequantize_op.cc#L162-L163)
+  does not validate the rank of the `input_*` tensors. In turn, this results in the
+  tensors being passes as they are to `QuantizeAndDequantizePerChannelGradientImpl`(https://github.com/tensorflow/tensorflow/blob/95078c145b5a7a43ee046144005f733092756ab5/tensorflow/core/kernels/quantize_and_dequantize_op.h#L295-L306).
+  However, the `vec<T>` method, requires the rank to 1 and triggers a `CHECK` failure
+  otherwise. The fix will be included in TensorFlow 2.5.0. We will also cherrypick
+  this commit on TensorFlow 2.4.2 as this is the only other affected version.
+id: PYSEC-0000-CVE-2021-29544
+modified: '2021-08-27T03:22:29.285990Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/20431e9044cf2ad3c0323c34888b192f3289af6b
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-6g85-3hm8-83f9

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29545.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29545.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 1e922ccdf6bf46a3a52641f99fd47d54c1decd13
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29545
+- GHSA-hmg3-c7xj-6qwm
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a denial of service via a `CHECK`-fail in converting sparse
+  tensors to CSR Sparse matrices. This is because the implementation(https://github.com/tensorflow/tensorflow/blob/800346f2c03a27e182dd4fba48295f65e7790739/tensorflow/core/kernels/sparse/kernels.cc#L66)
+  does a double redirection to access an element of an array allocated on the heap.
+  If the value at `indices(i, 0)` is such that `indices(i, 0) + 1` is outside the
+  bounds of `csr_row_ptr`, this results in writing outside of bounds of heap allocated
+  data. The fix will be included in TensorFlow 2.5.0. We will also cherrypick this
+  commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4,
+  as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29545
+modified: '2021-08-27T03:22:29.446413Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-hmg3-c7xj-6qwm
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/1e922ccdf6bf46a3a52641f99fd47d54c1decd13

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29546.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29546.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 67784700869470d65d5f2ef20aeb5e97c31673cb
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29546
+- GHSA-m34j-p8rj-wjxq
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger an integer division by zero undefined behavior in `tf.raw_ops.QuantizedBiasAdd`.
+  This is because the implementation of the Eigen kernel(https://github.com/tensorflow/tensorflow/blob/61bca8bd5ba8a68b2d97435ddfafcdf2b85672cd/tensorflow/core/kernels/quantization_utils.h#L812-L849)
+  does a division by the number of elements of the smaller input (based on shape)
+  without checking that this is not zero. The fix will be included in TensorFlow 2.5.0.
+  We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow
+  2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29546
+modified: '2021-08-27T03:22:29.613359Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/67784700869470d65d5f2ef20aeb5e97c31673cb
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-m34j-p8rj-wjxq

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29547.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29547.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: d6ed5bcfe1dcab9e85a4d39931bd18d99018e75b
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29547
+- GHSA-4fg4-p75j-w5xj
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a segfault and denial of service via accessing data outside of
+  bounds in `tf.raw_ops.QuantizedBatchNormWithGlobalNormalization`. This is because
+  the implementation(https://github.com/tensorflow/tensorflow/blob/55a97caa9e99c7f37a0bbbeb414dc55553d3ae7f/tensorflow/core/kernels/quantized_batch_norm_op.cc#L176-L189)
+  assumes the inputs are not empty. If any of these inputs is empty, `.flat<T>()`
+  is an empty buffer, so accessing the element at index 0 is accessing data outside
+  of bounds. The fix will be included in TensorFlow 2.5.0. We will also cherrypick
+  this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow
+  2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29547
+modified: '2021-08-27T03:22:29.791310Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-4fg4-p75j-w5xj
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/d6ed5bcfe1dcab9e85a4d39931bd18d99018e75b

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29548.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29548.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: d6ed5bcfe1dcab9e85a4d39931bd18d99018e75b
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29548
+- GHSA-p45v-v4pw-77jr
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a runtime division by zero error and denial of service in `tf.raw_ops.QuantizedBatchNormWithGlobalNormalization`.
+  This is because the implementation(https://github.com/tensorflow/tensorflow/blob/55a97caa9e99c7f37a0bbbeb414dc55553d3ae7f/tensorflow/core/kernels/quantized_batch_norm_op.cc)
+  does not validate all constraints specified in the op's contract(https://www.tensorflow.org/api_docs/python/tf/raw_ops/QuantizedBatchNormWithGlobalNormalization).
+  The fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit
+  on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as
+  these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29548
+modified: '2021-08-27T03:22:29.986611Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/d6ed5bcfe1dcab9e85a4d39931bd18d99018e75b
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-p45v-v4pw-77jr

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29549.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29549.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 744009c9e5cc5d0447f0dc39d055f917e1fd9e16
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29549
+- GHSA-x83m-p7pv-ch8v
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a runtime division by zero error and denial of service in `tf.raw_ops.QuantizedBatchNormWithGlobalNormalization`.
+  This is because the implementation(https://github.com/tensorflow/tensorflow/blob/6f26b3f3418201479c264f2a02000880d8df151c/tensorflow/core/kernels/quantized_add_op.cc#L289-L295)
+  computes a modulo operation without validating that the divisor is not zero. Since
+  `vector_num_elements` is determined based on input shapes(https://github.com/tensorflow/tensorflow/blob/6f26b3f3418201479c264f2a02000880d8df151c/tensorflow/core/kernels/quantized_add_op.cc#L522-L544),
+  a user can trigger scenarios where this quantity is 0. The fix will be included
+  in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow
+  2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-29549
+modified: '2021-08-27T03:22:30.167299Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-x83m-p7pv-ch8v
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/744009c9e5cc5d0447f0dc39d055f917e1fd9e16

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29550.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29550.yaml
@@ -1,0 +1,47 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 548b5eaf23685d86f722233d8fbc21d0a4aecb96
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29550
+- GHSA-f78g-q7r4-9wcv
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a runtime division by zero error and denial of service in `tf.raw_ops.FractionalAvgPool`.
+  This is because the implementation(https://github.com/tensorflow/tensorflow/blob/acc8ee69f5f46f92a3f1f11230f49c6ac266f10c/tensorflow/core/kernels/fractional_avg_pool_op.cc#L85-L89)
+  computes a divisor quantity by dividing two user controlled values. The user controls
+  the values of `input_size[i]` and `pooling_ratio_[i]` (via the `value.shape()` and
+  `pooling_ratio` arguments). If the value in `input_size[i]` is smaller than the
+  `pooling_ratio_[i]`, then the floor operation results in `output_size[i]` being
+  0. The `DCHECK_GT` line is a no-op outside of debug mode, so in released versions
+  of TF this does not trigger. Later, these computed values are used as arguments(https://github.com/tensorflow/tensorflow/blob/acc8ee69f5f46f92a3f1f11230f49c6ac266f10c/tensorflow/core/kernels/fractional_avg_pool_op.cc#L96-L99)
+  to `GeneratePoolingSequence`(https://github.com/tensorflow/tensorflow/blob/acc8ee69f5f46f92a3f1f11230f49c6ac266f10c/tensorflow/core/kernels/fractional_pool_common.cc#L100-L108).
+  There, the first computation is a division in a modulo operation. Since `output_length`
+  can be 0, this results in runtime crashing. The fix will be included in TensorFlow
+  2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3,
+  TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported
+  range.
+id: PYSEC-0000-CVE-2021-29550
+modified: '2021-08-27T03:22:30.332227Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-f78g-q7r4-9wcv
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/548b5eaf23685d86f722233d8fbc21d0a4aecb96

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29551.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29551.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 480641e3599775a8895254ffbc0fc45621334f68
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29551
+- GHSA-vqw6-72r7-fgw7
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of `MatrixTriangularSolve`(https://github.com/tensorflow/tensorflow/blob/8cae746d8449c7dda5298327353d68613f16e798/tensorflow/core/kernels/linalg/matrix_triangular_solve_op_impl.h#L160-L240)
+  fails to terminate kernel execution if one validation condition fails. The fix will
+  be included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29551
+modified: '2021-08-27T03:22:30.499582Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/480641e3599775a8895254ffbc0fc45621334f68
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-vqw6-72r7-fgw7

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29552.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29552.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 704866eabe03a9aeda044ec91a8d0c83fc1ebdbe
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29552
+- GHSA-jhq9-wm9m-cf89
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a denial of service by controlling the values of `num_segments`
+  tensor argument for `UnsortedSegmentJoin`. This is because the implementation(https://github.com/tensorflow/tensorflow/blob/a2a607db15c7cd01d754d37e5448d72a13491bdb/tensorflow/core/kernels/unsorted_segment_join_op.cc#L92-L93)
+  assumes that the `num_segments` tensor is a valid scalar. Since the tensor is empty
+  the `CHECK` involved in `.scalar<T>()()` that checks that the number of elements
+  is exactly 1 will be invalidated and this would result in process termination. The
+  fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit on
+  TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29552
+modified: '2021-08-27T03:22:30.663551Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-jhq9-wm9m-cf89
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/704866eabe03a9aeda044ec91a8d0c83fc1ebdbe

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29553.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29553.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 99085e8ff02c3763a0ec2263e44daec416f6a387
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29553
+- GHSA-h9px-9vqg-222h
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can read data outside of bounds of heap allocated buffer in `tf.raw_ops.QuantizeAndDequantizeV3`.
+  This is because the implementation(https://github.com/tensorflow/tensorflow/blob/11ff7f80667e6490d7b5174aa6bf5e01886e770f/tensorflow/core/kernels/quantize_and_dequantize_op.cc#L237)
+  does not validate the value of user supplied `axis` attribute before using it to
+  index in the array backing the `input` argument. The fix will be included in TensorFlow
+  2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3,
+  TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported
+  range.
+id: PYSEC-0000-CVE-2021-29553
+modified: '2021-08-27T03:22:30.834118Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/99085e8ff02c3763a0ec2263e44daec416f6a387
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-h9px-9vqg-222h

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29554.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29554.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: da5ff2daf618591f64b2b62d9d9803951b945e9f
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29554
+- GHSA-qg48-85hg-mqc5
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a denial of service via a FPE runtime error in `tf.raw_ops.DenseCountSparseOutput`.
+  This is because the implementation(https://github.com/tensorflow/tensorflow/blob/efff014f3b2d8ef6141da30c806faf141297eca1/tensorflow/core/kernels/count_ops.cc#L123-L127)
+  computes a divisor value from user data but does not check that the result is 0
+  before doing the division. Since `data` is given by the `values` argument, `num_batch_elements`
+  is 0. The fix will be included in TensorFlow 2.5.0. We will also cherrypick this
+  commit on TensorFlow 2.4.2, and TensorFlow 2.3.3, as these are also affected.
+id: PYSEC-0000-CVE-2021-29554
+modified: '2021-08-27T03:22:31.001831Z'
+published: '2021-05-14T19:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-qg48-85hg-mqc5
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/da5ff2daf618591f64b2b62d9d9803951b945e9f

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29555.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29555.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 1a2a87229d1d61e23a39373777c056161eb4084d
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29555
+- GHSA-r35g-4525-29fq
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a denial of service via a FPE runtime error in `tf.raw_ops.FusedBatchNorm`.
+  This is because the implementation(https://github.com/tensorflow/tensorflow/blob/828f346274841fa7505f7020e88ca36c22e557ab/tensorflow/core/kernels/fused_batch_norm_op.cc#L295-L297)
+  performs a division based on the last dimension of the `x` tensor. Since this is
+  controlled by the user, an attacker can trigger a denial of service. The fix will
+  be included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29555
+modified: '2021-08-27T03:22:31.200110Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-r35g-4525-29fq
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/1a2a87229d1d61e23a39373777c056161eb4084d

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29556.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29556.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 4071d8e2f6c45c1955a811fee757ca2adbe462c1
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29556
+- GHSA-fxqh-cfjm-fp93
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a denial of service via a FPE runtime error in `tf.raw_ops.Reverse`.
+  This is because the implementation(https://github.com/tensorflow/tensorflow/blob/36229ea9e9451dac14a8b1f4711c435a1d84a594/tensorflow/core/kernels/reverse_op.cc#L75-L76)
+  performs a division based on the first dimension of the tensor argument. The fix
+  will be included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29556
+modified: '2021-08-27T03:22:31.368222Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-fxqh-cfjm-fp93
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/4071d8e2f6c45c1955a811fee757ca2adbe462c1

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29557.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29557.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 7f283ff806b2031f407db64c4d3edcda8fb9f9f5
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29557
+- GHSA-xw93-v57j-fcgh
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a denial of service via a FPE runtime error in `tf.raw_ops.SparseMatMul`.
+  The division by 0 occurs deep in Eigen code because the `b` tensor is empty. The
+  fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit on
+  TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29557
+modified: '2021-08-27T03:22:31.559796Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/7f283ff806b2031f407db64c4d3edcda8fb9f9f5
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-xw93-v57j-fcgh

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29558.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29558.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 8ba6fa29cd8bf9cef9b718dc31c78c73081f5b31
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29558
+- GHSA-mqh2-9wrp-vx84
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a heap buffer overflow in `tf.raw_ops.SparseSplit`. This is because
+  the implementation(https://github.com/tensorflow/tensorflow/blob/699bff5d961f0abfde8fa3f876e6d241681fbef8/tensorflow/core/util/sparse/sparse_tensor.h#L528-L530)
+  accesses an array element based on a user controlled offset. The fix will be included
+  in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow
+  2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-29558
+modified: '2021-08-27T03:22:31.758663Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-mqh2-9wrp-vx84
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/8ba6fa29cd8bf9cef9b718dc31c78c73081f5b31

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29559.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29559.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 51300ba1cc2f487aefec6e6631fef03b0e08b298
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29559
+- GHSA-59q2-x2qc-4c97
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can access data outside of bounds of heap allocated array in `tf.raw_ops.UnicodeEncode`.
+  This is because the implementation(https://github.com/tensorflow/tensorflow/blob/472c1f12ad9063405737679d4f6bd43094e1d36d/tensorflow/core/kernels/unicode_ops.cc)
+  assumes that the `input_value`/`input_splits` pair specify a valid sparse tensor.
+  The fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit
+  on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as
+  these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29559
+modified: '2021-08-27T03:22:31.940947Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/51300ba1cc2f487aefec6e6631fef03b0e08b298
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-59q2-x2qc-4c97

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29560.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29560.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: a84358aa12f0b1518e606095ab9cfddbf597c121
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29560
+- GHSA-8gv3-57p6-g35r
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a heap buffer overflow in `tf.raw_ops.RaggedTensorToTensor`.
+  This is because the implementation(https://github.com/tensorflow/tensorflow/blob/d94227d43aa125ad8b54115c03cece54f6a1977b/tensorflow/core/kernels/ragged_tensor_to_tensor_op.cc#L219-L222)
+  uses the same index to access two arrays in parallel. Since the user controls the
+  shape of the input arguments, an attacker could trigger a heap OOB access when `parent_output_index`
+  is shorter than `row_split`. The fix will be included in TensorFlow 2.5.0. We will
+  also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3
+  and TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29560
+modified: '2021-08-27T03:22:32.127822Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-8gv3-57p6-g35r
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/a84358aa12f0b1518e606095ab9cfddbf597c121

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29561.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29561.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 77dd114513d7796e1e2b8aece214a380af26fbf4
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29561
+- GHSA-gvm4-h8j3-rjrq
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a denial of service by exploiting a `CHECK`-failure coming from
+  `tf.raw_ops.LoadAndRemapMatrix`. This is because the implementation(https://github.com/tensorflow/tensorflow/blob/d94227d43aa125ad8b54115c03cece54f6a1977b/tensorflow/core/kernels/ragged_tensor_to_tensor_op.cc#L219-L222)
+  assumes that the `ckpt_path` is always a valid scalar. However, an attacker can
+  send any other tensor as the first argument of `LoadAndRemapMatrix`. This would
+  cause the rank `CHECK` in `scalar<T>()()` to trigger and terminate the process.
+  The fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit
+  on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as
+  these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29561
+modified: '2021-08-27T03:22:32.310582Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/77dd114513d7796e1e2b8aece214a380af26fbf4
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-gvm4-h8j3-rjrq

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29562.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29562.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 1c56f53be0b722ca657cbc7df461ed676c8642a2
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29562
+- GHSA-36vm-xw34-x4pj
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a denial of service by exploiting a `CHECK`-failure coming from
+  the implementation of `tf.raw_ops.IRFFT`. The fix will be included in TensorFlow
+  2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3,
+  TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported
+  range.
+id: PYSEC-0000-CVE-2021-29562
+modified: '2021-08-27T03:22:32.482991Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/1c56f53be0b722ca657cbc7df461ed676c8642a2
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-36vm-xw34-x4pj

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29563.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29563.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 31bd5026304677faa8a0b77602c6154171b9aec1
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29563
+- GHSA-ph87-fvjr-v33w
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a denial of service by exploiting a `CHECK`-failure coming from
+  the implementation of `tf.raw_ops.RFFT`. Eigen code operating on an empty matrix
+  can trigger on an assertion and will cause program termination. The fix will be
+  included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29563
+modified: '2021-08-27T03:22:32.655132Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-ph87-fvjr-v33w
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/31bd5026304677faa8a0b77602c6154171b9aec1

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29564.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29564.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: f4c364a5d6880557f6f5b6eb5cee2c407f0186b3
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29564
+- GHSA-75f6-78jr-4656
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a null pointer dereference in the implementation of `tf.raw_ops.EditDistance`.
+  This is because the implementation(https://github.com/tensorflow/tensorflow/blob/79865b542f9ffdc9caeb255631f7c56f1d4b6517/tensorflow/core/kernels/edit_distance_op.cc#L103-L159)
+  has incomplete validation of the input parameters. The fix will be included in TensorFlow
+  2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3,
+  TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported
+  range.
+id: PYSEC-0000-CVE-2021-29564
+modified: '2021-08-27T03:22:32.823380Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-75f6-78jr-4656
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/f4c364a5d6880557f6f5b6eb5cee2c407f0186b3

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29565.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29565.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: faa76f39014ed3b5e2c158593b1335522e573c7f
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29565
+- GHSA-r6pg-pjwc-j585
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a null pointer dereference in the implementation of `tf.raw_ops.SparseFillEmptyRows`.
+  This is because of missing validation(https://github.com/tensorflow/tensorflow/blob/fdc82089d206e281c628a93771336bf87863d5e8/tensorflow/core/kernels/sparse_fill_empty_rows_op.cc#L230-L231)
+  that was covered under a `TODO`. If the `dense_shape` tensor is empty, then `dense_shape_t.vec<>()`
+  would cause a null pointer dereference in the implementation of the op. The fix
+  will be included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29565
+modified: '2021-08-27T03:22:32.984830Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-r6pg-pjwc-j585
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/faa76f39014ed3b5e2c158593b1335522e573c7f

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29566.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29566.yaml
@@ -1,0 +1,42 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 3f6fe4dfef6f57e768260b48166c27d148f3015f
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29566
+- GHSA-pvrc-hg3f-58r6
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can write outside the bounds of heap allocated arrays by passing invalid
+  arguments to `tf.raw_ops.Dilation2DBackpropInput`. This is because the implementation(https://github.com/tensorflow/tensorflow/blob/afd954e65f15aea4d438d0a219136fc4a63a573d/tensorflow/core/kernels/dilation_ops.cc#L321-L322)
+  does not validate before writing to the output array. The values for `h_out` and
+  `w_out` are guaranteed to be in range for `out_backprop` (as they are loop indices
+  bounded by the size of the array). However, there are no similar guarantees relating
+  `h_in_max`/`w_in_max` and `in_backprop`. The fix will be included in TensorFlow
+  2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3,
+  TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported
+  range.
+id: PYSEC-0000-CVE-2021-29566
+modified: '2021-08-27T03:22:33.149908Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/3f6fe4dfef6f57e768260b48166c27d148f3015f
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-pvrc-hg3f-58r6

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29567.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29567.yaml
@@ -1,0 +1,42 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 7ae2af34087fb4b5c8915279efd03da3b81028bc
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29567
+- GHSA-wp3c-xw9g-gpcg
+details: TensorFlow is an end-to-end open source platform for machine learning. Due
+  to lack of validation in `tf.raw_ops.SparseDenseCwiseMul`, an attacker can trigger
+  denial of service via `CHECK`-fails or accesses to outside the bounds of heap allocated
+  data. Since the implementation(https://github.com/tensorflow/tensorflow/blob/38178a2f7a681a7835bb0912702a134bfe3b4d84/tensorflow/core/kernels/sparse_dense_binary_op_shared.cc#L68-L80)
+  only validates the rank of the input arguments but no constraints between dimensions(https://www.tensorflow.org/api_docs/python/tf/raw_ops/SparseDenseCwiseMul),
+  an attacker can abuse them to trigger internal `CHECK` assertions (and cause program
+  termination, denial of service) or to write to memory outside of bounds of heap
+  allocated tensor buffers. The fix will be included in TensorFlow 2.5.0. We will
+  also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3
+  and TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29567
+modified: '2021-08-27T03:22:33.334705Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-wp3c-xw9g-gpcg
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/7ae2af34087fb4b5c8915279efd03da3b81028bc

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29568.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29568.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 5e52ef5a461570cfb68f3bdbbebfe972cb4e0fd8
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29568
+- GHSA-4p4p-www8-8fv9
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger undefined behavior by binding to null pointer in `tf.raw_ops.ParameterizedTruncatedNormal`.
+  This is because the implementation(https://github.com/tensorflow/tensorflow/blob/3f6fe4dfef6f57e768260b48166c27d148f3015f/tensorflow/core/kernels/parameterized_truncated_normal_op.cc#L630)
+  does not validate input arguments before accessing the first element of `shape`.
+  If `shape` argument is empty, then `shape_tensor.flat<T>()` is an empty array. The
+  fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit on
+  TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29568
+modified: '2021-08-27T03:22:33.499981Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-4p4p-www8-8fv9
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/5e52ef5a461570cfb68f3bdbbebfe972cb4e0fd8

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29569.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29569.yaml
@@ -1,0 +1,42 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: ef0c008ee84bad91ec6725ddc42091e19a30cf0e
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29569
+- GHSA-3h8m-483j-7xxm
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of `tf.raw_ops.MaxPoolGradWithArgmax` can cause reads outside of
+  bounds of heap allocated data if attacker supplies specially crafted inputs. The
+  implementation(https://github.com/tensorflow/tensorflow/blob/ac328eaa3870491ababc147822cd04e91a790643/tensorflow/core/kernels/requantization_range_op.cc#L49-L50)
+  assumes that the `input_min` and `input_max` tensors have at least one element,
+  as it accesses the first element in two arrays. If the tensors are empty, `.flat<T>()`
+  is an empty object, backed by an empty array. Hence, accesing even the 0th element
+  is a read outside the bounds. The fix will be included in TensorFlow 2.5.0. We will
+  also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3
+  and TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29569
+modified: '2021-08-27T03:22:33.683964Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-3h8m-483j-7xxm
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/ef0c008ee84bad91ec6725ddc42091e19a30cf0e

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29570.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29570.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: dcd7867de0fea4b72a2b34bd41eb74548dc23886
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29570
+- GHSA-545v-42p7-98fq
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of `tf.raw_ops.MaxPoolGradWithArgmax` can cause reads outside of
+  bounds of heap allocated data if attacker supplies specially crafted inputs. The
+  implementation(https://github.com/tensorflow/tensorflow/blob/ef0c008ee84bad91ec6725ddc42091e19a30cf0e/tensorflow/core/kernels/maxpooling_op.cc#L1016-L1017)
+  uses the same value to index in two different arrays but there is no guarantee that
+  the sizes are identical. The fix will be included in TensorFlow 2.5.0. We will also
+  cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and
+  TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29570
+modified: '2021-08-27T03:22:33.847369Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/dcd7867de0fea4b72a2b34bd41eb74548dc23886
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-545v-42p7-98fq

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29571.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29571.yaml
@@ -1,0 +1,44 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 79865b542f9ffdc9caeb255631f7c56f1d4b6517
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29571
+- GHSA-whr9-vfh2-7hm6
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of `tf.raw_ops.MaxPoolGradWithArgmax` can cause reads outside of
+  bounds of heap allocated data if attacker supplies specially crafted inputs. The
+  implementation(https://github.com/tensorflow/tensorflow/blob/31bd5026304677faa8a0b77602c6154171b9aec1/tensorflow/core/kernels/image/draw_bounding_box_op.cc#L116-L130)
+  assumes that the last element of `boxes` input is 4, as required by [the op](https://www.tensorflow.org/api_docs/python/tf/raw_ops/DrawBoundingBoxesV2).
+  Since this is not checked attackers passing values less than 4 can write outside
+  of bounds of heap allocated objects and cause memory corruption. If the last dimension
+  in `boxes` is less than 4, accesses similar to `tboxes(b, bb, 3)` will access data
+  outside of bounds. Further during code execution there are also writes to these
+  indices. The fix will be included in TensorFlow 2.5.0. We will also cherrypick this
+  commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4,
+  as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29571
+modified: '2021-08-27T03:22:34.015475Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/79865b542f9ffdc9caeb255631f7c56f1d4b6517
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-whr9-vfh2-7hm6

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29572.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29572.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: f7cc8755ac6683131fdfa7a8a121f9d7a9dec6fb
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29572
+- GHSA-5gqf-456p-4836
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of `tf.raw_ops.SdcaOptimizer` triggers undefined behavior due to
+  dereferencing a null pointer. The implementation(https://github.com/tensorflow/tensorflow/blob/60a45c8b6192a4699f2e2709a2645a751d435cc3/tensorflow/core/kernels/sdca_internal.cc)
+  does not validate that the user supplied arguments satisfy all constraints expected
+  by the op(https://www.tensorflow.org/api_docs/python/tf/raw_ops/SdcaOptimizer).
+  The fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit
+  on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as
+  these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29572
+modified: '2021-08-27T03:22:34.191182Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/f7cc8755ac6683131fdfa7a8a121f9d7a9dec6fb
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-5gqf-456p-4836

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29573.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29573.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 376c352a37ce5a68b721406dc7e77ac4b6cf483d
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29573
+- GHSA-9vpm-rcf4-9wqw
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of `tf.raw_ops.MaxPoolGradWithArgmax` is vulnerable to a division
+  by 0. The implementation(https://github.com/tensorflow/tensorflow/blob/279bab6efa22752a2827621b7edb56a730233bd8/tensorflow/core/kernels/maxpooling_op.cc#L1033-L1034)
+  fails to validate that the batch dimension of the tensor is non-zero, before dividing
+  by this quantity. The fix will be included in TensorFlow 2.5.0. We will also cherrypick
+  this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow
+  2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29573
+modified: '2021-08-27T03:22:34.367051Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-9vpm-rcf4-9wqw
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/376c352a37ce5a68b721406dc7e77ac4b6cf483d

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29574.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29574.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: a3d9f9be9ac2296615644061b40cefcee341dcc4
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29574
+- GHSA-828x-qc2p-wprq
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of `tf.raw_ops.MaxPool3DGradGrad` exhibits undefined behavior by
+  dereferencing null pointers backing attacker-supplied empty tensors. The implementation(https://github.com/tensorflow/tensorflow/blob/72fe792967e7fd25234342068806707bbc116618/tensorflow/core/kernels/pooling_ops_3d.cc#L679-L703)
+  fails to validate that the 3 tensor inputs are not empty. If any of them is empty,
+  then accessing the elements in the tensor results in dereferencing a null pointer.
+  The fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit
+  on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as
+  these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29574
+modified: '2021-08-27T03:22:34.535736Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-828x-qc2p-wprq
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/a3d9f9be9ac2296615644061b40cefcee341dcc4

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29575.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29575.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: ecf768cbe50cedc0a45ce1ee223146a3d3d26d23
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29575
+- GHSA-6qgm-fv6v-rfpv
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of `tf.raw_ops.ReverseSequence` allows for stack overflow and/or
+  `CHECK`-fail based denial of service. The implementation(https://github.com/tensorflow/tensorflow/blob/5b3b071975e01f0d250c928b2a8f901cd53b90a7/tensorflow/core/kernels/reverse_sequence_op.cc#L114-L118)
+  fails to validate that `seq_dim` and `batch_dim` arguments are valid. Negative values
+  for `seq_dim` can result in stack overflow or `CHECK`-failure, depending on the
+  version of Eigen code used to implement the operation. Similar behavior can be exhibited
+  by invalid values of `batch_dim`. The fix will be included in TensorFlow 2.5.0.
+  We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow
+  2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29575
+modified: '2021-08-27T03:22:34.716646Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-6qgm-fv6v-rfpv
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/ecf768cbe50cedc0a45ce1ee223146a3d3d26d23

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29576.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29576.yaml
@@ -1,0 +1,43 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 63c6a29d0f2d692b247f7bf81f8732d6442fad09
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29576
+- GHSA-7cqx-92hp-x6wh
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of `tf.raw_ops.MaxPool3DGradGrad` is vulnerable to a heap buffer
+  overflow. The implementation(https://github.com/tensorflow/tensorflow/blob/596c05a159b6fbb9e39ca10b3f7753b7244fa1e9/tensorflow/core/kernels/pooling_ops_3d.cc#L694-L696)
+  does not check that the initialization of `Pool3dParameters` completes successfully.
+  Since the constructor(https://github.com/tensorflow/tensorflow/blob/596c05a159b6fbb9e39ca10b3f7753b7244fa1e9/tensorflow/core/kernels/pooling_ops_3d.cc#L48-L88)
+  uses `OP_REQUIRES` to validate conditions, the first assertion that fails interrupts
+  the initialization of `params`, making it contain invalid data. In turn, this might
+  cause a heap buffer overflow, depending on default initialized values. The fix will
+  be included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29576
+modified: '2021-08-27T03:22:34.891385Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-7cqx-92hp-x6wh
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/63c6a29d0f2d692b247f7bf81f8732d6442fad09

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29577.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29577.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 6fc9141f42f6a72180ecd24021c3e6b36165fe0d
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29577
+- GHSA-v6r6-84gr-92rm
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of `tf.raw_ops.AvgPool3DGrad` is vulnerable to a heap buffer overflow.
+  The implementation(https://github.com/tensorflow/tensorflow/blob/d80ffba9702dc19d1fac74fc4b766b3fa1ee976b/tensorflow/core/kernels/pooling_ops_3d.cc#L376-L450)
+  assumes that the `orig_input_shape` and `grad` tensors have similar first and last
+  dimensions but does not check that this assumption is validated. The fix will be
+  included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29577
+modified: '2021-08-27T03:22:35.059356Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-v6r6-84gr-92rm
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/6fc9141f42f6a72180ecd24021c3e6b36165fe0d

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29578.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29578.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 12c727cee857fa19be717f336943d95fca4ffe4f
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29578
+- GHSA-6f89-8j54-29xf
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of `tf.raw_ops.FractionalAvgPoolGrad` is vulnerable to a heap buffer
+  overflow. The implementation(https://github.com/tensorflow/tensorflow/blob/dcba796a28364d6d7f003f6fe733d82726dda713/tensorflow/core/kernels/fractional_avg_pool_op.cc#L216)
+  fails to validate that the pooling sequence arguments have enough elements as required
+  by the `out_backprop` tensor shape. The fix will be included in TensorFlow 2.5.0.
+  We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow
+  2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29578
+modified: '2021-08-27T03:22:35.223640Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/12c727cee857fa19be717f336943d95fca4ffe4f
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-6f89-8j54-29xf

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29579.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29579.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: a74768f8e4efbda4def9f16ee7e13cf3922ac5f7
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29579
+- GHSA-79fv-9865-4qcv
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of `tf.raw_ops.MaxPoolGrad` is vulnerable to a heap buffer overflow.
+  The implementation(https://github.com/tensorflow/tensorflow/blob/ab1e644b48c82cb71493f4362b4dd38f4577a1cf/tensorflow/core/kernels/maxpooling_op.cc#L194-L203)
+  fails to validate that indices used to access elements of input/output arrays are
+  valid. Whereas accesses to `input_backprop_flat` are guarded by `FastBoundsCheck`,
+  the indexing in `out_backprop_flat` can result in OOB access. The fix will be included
+  in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow
+  2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-29579
+modified: '2021-08-27T03:22:35.384566Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-79fv-9865-4qcv
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/a74768f8e4efbda4def9f16ee7e13cf3922ac5f7

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29580.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29580.yaml
@@ -1,0 +1,42 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 32fdcbff9d06d010d908fcc4bd4b36eb3ce15925
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29580
+- GHSA-x8h6-xgqx-jqgp
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of `tf.raw_ops.FractionalMaxPoolGrad` triggers an undefined behavior
+  if one of the input tensors is empty. The code is also vulnerable to a denial of
+  service attack as a `CHECK` condition becomes false and aborts the process. The
+  implementation(https://github.com/tensorflow/tensorflow/blob/169054888d50ce488dfde9ca55d91d6325efbd5b/tensorflow/core/kernels/fractional_max_pool_op.cc#L215)
+  fails to validate that input and output tensors are not empty and are of the same
+  rank. Each of these unchecked assumptions is responsible for the above issues. The
+  fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit on
+  TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29580
+modified: '2021-08-27T03:22:35.567916Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-x8h6-xgqx-jqgp
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/32fdcbff9d06d010d908fcc4bd4b36eb3ce15925

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29581.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29581.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: b1b323042264740c398140da32e93fb9c2c9f33e
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29581
+- GHSA-vq2r-5xvm-3hc3
+details: TensorFlow is an end-to-end open source platform for machine learning. Due
+  to lack of validation in `tf.raw_ops.CTCBeamSearchDecoder`, an attacker can trigger
+  denial of service via segmentation faults. The implementation(https://github.com/tensorflow/tensorflow/blob/a74768f8e4efbda4def9f16ee7e13cf3922ac5f7/tensorflow/core/kernels/ctc_decoder_ops.cc#L68-L79)
+  fails to detect cases when the input tensor is empty and proceeds to read data from
+  a null buffer. The fix will be included in TensorFlow 2.5.0. We will also cherrypick
+  this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow
+  2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29581
+modified: '2021-08-27T03:22:35.737731Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-vq2r-5xvm-3hc3
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/b1b323042264740c398140da32e93fb9c2c9f33e

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29582.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29582.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 5899741d0421391ca878da47907b1452f06aaf1b
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29582
+- GHSA-c45w-2wxr-pp53
+details: TensorFlow is an end-to-end open source platform for machine learning. Due
+  to lack of validation in `tf.raw_ops.Dequantize`, an attacker can trigger a read
+  from outside of bounds of heap allocated data. The implementation(https://github.com/tensorflow/tensorflow/blob/26003593aa94b1742f34dc22ce88a1e17776a67d/tensorflow/core/kernels/dequantize_op.cc#L106-L131)
+  accesses the `min_range` and `max_range` tensors in parallel but fails to check
+  that they have the same shape. The fix will be included in TensorFlow 2.5.0. We
+  will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow
+  2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29582
+modified: '2021-08-27T03:22:35.924594Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/5899741d0421391ca878da47907b1452f06aaf1b
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-c45w-2wxr-pp53

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29583.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29583.yaml
@@ -1,0 +1,44 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 6972f9dfe325636b3db4e0bc517ee22a159365c0
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29583
+- GHSA-9xh4-23q4-v6wr
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of `tf.raw_ops.FusedBatchNorm` is vulnerable to a heap buffer overflow.
+  If the tensors are empty, the same implementation can trigger undefined behavior
+  by dereferencing null pointers. The implementation(https://github.com/tensorflow/tensorflow/blob/57d86e0db5d1365f19adcce848dfc1bf89fdd4c7/tensorflow/core/kernels/fused_batch_norm_op.cc)
+  fails to validate that `scale`, `offset`, `mean` and `variance` (the last two only
+  when required) all have the same number of elements as the number of channels of
+  `x`. This results in heap out of bounds reads when the buffers backing these tensors
+  are indexed past their boundary. If the tensors are empty, the validation mentioned
+  in the above paragraph would also trigger and prevent the undefined behavior. The
+  fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit on
+  TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29583
+modified: '2021-08-27T03:22:36.144215Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/6972f9dfe325636b3db4e0bc517ee22a159365c0
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-9xh4-23q4-v6wr

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29584.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29584.yaml
@@ -1,0 +1,43 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 4c0ee937c0f61c4fc5f5d32d9bb4c67428012a60
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29584
+- GHSA-xvjm-fvxx-q3hv
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a denial of service via a `CHECK`-fail in caused by an integer
+  overflow in constructing a new tensor shape. This is because the implementation(https://github.com/tensorflow/tensorflow/blob/0908c2f2397c099338b901b067f6495a5b96760b/tensorflow/core/kernels/sparse_split_op.cc#L66-L70)
+  builds a dense shape without checking that the dimensions would not result in overflow.
+  The `TensorShape` constructor(https://github.com/tensorflow/tensorflow/blob/6f9896890c4c703ae0a0845394086e2e1e523299/tensorflow/core/framework/tensor_shape.cc#L183-L188)
+  uses a `CHECK` operation which triggers when `InitDims`(https://github.com/tensorflow/tensorflow/blob/6f9896890c4c703ae0a0845394086e2e1e523299/tensorflow/core/framework/tensor_shape.cc#L212-L296)
+  returns a non-OK status. This is a legacy implementation of the constructor and
+  operations should use `BuildTensorShapeBase` or `AddDimWithStatus` to prevent `CHECK`-failures
+  in the presence of overflows. The fix will be included in TensorFlow 2.5.0. We will
+  also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3
+  and TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29584
+modified: '2021-08-27T03:22:36.340283Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-xvjm-fvxx-q3hv
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/4c0ee937c0f61c4fc5f5d32d9bb4c67428012a60

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29585.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29585.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 49847ae69a4e1a97ae7f2db5e217c77721e37948
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29585
+- GHSA-mv78-g7wq-mhp4
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  TFLite computation for size of output after padding, `ComputeOutSize`(https://github.com/tensorflow/tensorflow/blob/0c9692ae7b1671c983569e5d3de5565843d500cf/tensorflow/lite/kernels/padding.h#L43-L55),
+  does not check that the `stride` argument is not 0 before doing the division. Users
+  can craft special models such that `ComputeOutSize` is called with `stride` set
+  to 0. The fix will be included in TensorFlow 2.5.0. We will also cherrypick this
+  commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4,
+  as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29585
+modified: '2021-08-27T03:22:36.517027Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/49847ae69a4e1a97ae7f2db5e217c77721e37948
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-mv78-g7wq-mhp4

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29586.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29586.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 5f7975d09eac0f10ed8a17dbb6f5964977725adc
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29586
+- GHSA-26j7-6w8w-7922
+details: TensorFlow is an end-to-end open source platform for machine learning. Optimized
+  pooling implementations in TFLite fail to check that the stride arguments are not
+  0 before calling `ComputePaddingHeightWidth`(https://github.com/tensorflow/tensorflow/blob/3f24ccd932546416ec906a02ddd183b48a1d2c83/tensorflow/lite/kernels/pooling.cc#L90).
+  Since users can craft special models which will have `params->stride_{height,width}`
+  be zero, this will result in a division by zero. The fix will be included in TensorFlow
+  2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3,
+  TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported
+  range.
+id: PYSEC-0000-CVE-2021-29586
+modified: '2021-08-27T03:22:36.699869Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/5f7975d09eac0f10ed8a17dbb6f5964977725adc
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-26j7-6w8w-7922

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29587.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29587.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 0d45ea1ca641b21b73bcf9c00e0179cda284e7e7
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29587
+- GHSA-j7rm-8ww4-xx2g
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  `Prepare` step of the `SpaceToDepth` TFLite operator does not check for 0 before
+  division(https://github.com/tensorflow/tensorflow/blob/5f7975d09eac0f10ed8a17dbb6f5964977725adc/tensorflow/lite/kernels/space_to_depth.cc#L63-L67).
+  An attacker can craft a model such that `params->block_size` would be zero. The
+  fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit on
+  TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29587
+modified: '2021-08-27T03:22:36.876924Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-j7rm-8ww4-xx2g
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/0d45ea1ca641b21b73bcf9c00e0179cda284e7e7

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29588.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29588.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 801c1c6be5324219689c98e1bd3e0ca365ee834d
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29588
+- GHSA-vfr4-x8j2-3rf9
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  optimized implementation of the `TransposeConv` TFLite operator is [vulnerable to
+  a division by zero error](https://github.com/tensorflow/tensorflow/blob/0d45ea1ca641b21b73bcf9c00e0179cda284e7e7/tensorflow/lite/kernels/internal/optimized/optimized_ops.h#L5221-L5222).
+  An attacker can craft a model such that `stride_{h,w}` values are 0. Code calling
+  this function must validate these arguments. The fix will be included in TensorFlow
+  2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3,
+  TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported
+  range.
+id: PYSEC-0000-CVE-2021-29588
+modified: '2021-08-27T03:22:37.053061Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/801c1c6be5324219689c98e1bd3e0ca365ee834d
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-vfr4-x8j2-3rf9

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29589.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29589.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 8e45822aa0b9f5df4b4c64f221e64dc930a70a9d
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29589
+- GHSA-3w67-q784-6w7c
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  reference implementation of the `GatherNd` TFLite operator is vulnerable to a division
+  by zero error(https://github.com/tensorflow/tensorflow/blob/0d45ea1ca641b21b73bcf9c00e0179cda284e7e7/tensorflow/lite/kernels/internal/reference/reference_ops.h#L966).
+  An attacker can craft a model such that `params` input would be an empty tensor.
+  In turn, `params_shape.Dims(.)` would be zero, in at least one dimension. The fix
+  will be included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29589
+modified: '2021-08-27T03:22:37.235055Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/8e45822aa0b9f5df4b4c64f221e64dc930a70a9d
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-3w67-q784-6w7c

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29590.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29590.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 953f28dca13c92839ba389c055587cfe6c723578
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29590
+- GHSA-24x6-8c7m-hv3f
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementations of the `Minimum` and `Maximum` TFLite operators can be used to read
+  data outside of bounds of heap allocated objects, if any of the two input tensor
+  arguments are empty. This is because the broadcasting implementation(https://github.com/tensorflow/tensorflow/blob/0d45ea1ca641b21b73bcf9c00e0179cda284e7e7/tensorflow/lite/kernels/internal/reference/maximum_minimum.h#L52-L56)
+  indexes in both tensors with the same index but does not validate that the index
+  is within bounds. The fix will be included in TensorFlow 2.5.0. We will also cherrypick
+  this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow
+  2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29590
+modified: '2021-08-27T03:22:37.400702Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/953f28dca13c92839ba389c055587cfe6c723578
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-24x6-8c7m-hv3f

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29591.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29591.yaml
@@ -1,0 +1,48 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 9c1dc920d8ffb4893d6c9d27d1f039607b326743
+    - fixed: c6173f5fe66cdbab74f4f869311fe6aae2ba35f4
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29591
+- GHSA-cwv3-863g-39vx
+details: TensorFlow is an end-to-end open source platform for machine learning. TFlite
+  graphs must not have loops between nodes. However, this condition was not checked
+  and an attacker could craft models that would result in infinite loop during evaluation.
+  In certain cases, the infinite loop would be replaced by stack overflow due to too
+  many recursive calls. For example, the `While` implementation(https://github.com/tensorflow/tensorflow/blob/106d8f4fb89335a2c52d7c895b7a7485465ca8d9/tensorflow/lite/kernels/while.cc)
+  could be tricked into a scneario where both the body and the loop subgraphs are
+  the same. Evaluating one of the subgraphs means calling the `Eval` function for
+  the other and this quickly exhaust all stack space. The fix will be included in
+  TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow
+  2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still
+  in supported range. Please consult our security guide(https://github.com/tensorflow/tensorflow/blob/master/SECURITY.md)
+  for more information regarding the security model and how to contact us with issues
+  and questions.
+id: PYSEC-0000-CVE-2021-29591
+modified: '2021-08-27T03:22:37.582991Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-cwv3-863g-39vx
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/9c1dc920d8ffb4893d6c9d27d1f039607b326743
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/c6173f5fe66cdbab74f4f869311fe6aae2ba35f4

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29592.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29592.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: f8378920345f4f4604202d4ab15ef64b2aceaa16
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29592
+- GHSA-jjr8-m8g8-p6wv
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  fix for CVE-2020-15209(https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15209)
+  missed the case when the target shape of `Reshape` operator is given by the elements
+  of a 1-D tensor. As such, the fix for the vulnerability(https://github.com/tensorflow/tensorflow/blob/9c1dc920d8ffb4893d6c9d27d1f039607b326743/tensorflow/lite/core/subgraph.cc#L1062-L1074)
+  allowed passing a null-buffer-backed tensor with a 1D shape. The fix will be included
+  in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow
+  2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-29592
+modified: '2021-08-27T03:22:37.768858Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/f8378920345f4f4604202d4ab15ef64b2aceaa16
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-jjr8-m8g8-p6wv

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29593.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29593.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 2c74674348a4708ced58ad6eb1b23354df8ee044
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29593
+- GHSA-cfx7-2xpc-8w4h
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of the `BatchToSpaceNd` TFLite operator is vulnerable to a division
+  by zero error(https://github.com/tensorflow/tensorflow/blob/b5ed552fe55895aee8bd8b191f744a069957d18d/tensorflow/lite/kernels/batch_to_space_nd.cc#L81-L82).
+  An attacker can craft a model such that one dimension of the `block` input is 0.
+  Hence, the corresponding value in `block_shape` is 0. The fix will be included in
+  TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow
+  2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-29593
+modified: '2021-08-27T03:22:37.941172Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/2c74674348a4708ced58ad6eb1b23354df8ee044
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-cfx7-2xpc-8w4h

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29594.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29594.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: ff489d95a9006be080ad14feb378f2b4dac35552
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29594
+- GHSA-3qgw-p4fm-x7gf
+details: TensorFlow is an end-to-end open source platform for machine learning. TFLite's
+  convolution code(https://github.com/tensorflow/tensorflow/blob/09c73bca7d648e961dd05898292d91a8322a9d45/tensorflow/lite/kernels/conv.cc)
+  has multiple division where the divisor is controlled by the user and not checked
+  to be non-zero. The fix will be included in TensorFlow 2.5.0. We will also cherrypick
+  this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow
+  2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29594
+modified: '2021-08-27T03:22:38.125295Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/ff489d95a9006be080ad14feb378f2b4dac35552
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-3qgw-p4fm-x7gf

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29595.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29595.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 106d8f4fb89335a2c52d7c895b7a7485465ca8d9
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29595
+- GHSA-vf94-36g5-69v8
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of the `DepthToSpace` TFLite operator is vulnerable to a division
+  by zero error(https://github.com/tensorflow/tensorflow/blob/0d45ea1ca641b21b73bcf9c00e0179cda284e7e7/tensorflow/lite/kernels/depth_to_space.cc#L63-L69).
+  An attacker can craft a model such that `params->block_size` is 0. The fix will
+  be included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29595
+modified: '2021-08-27T03:22:38.313497Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-vf94-36g5-69v8
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/106d8f4fb89335a2c52d7c895b7a7485465ca8d9

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29596.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29596.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: f61c57bd425878be108ec787f4d96390579fb83e
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29596
+- GHSA-4vrf-ff7v-hpgr
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of the `EmbeddingLookup` TFLite operator is vulnerable to a division
+  by zero error(https://github.com/tensorflow/tensorflow/blob/e4b29809543b250bc9b19678ec4776299dd569ba/tensorflow/lite/kernels/embedding_lookup.cc#L73-L74).
+  An attacker can craft a model such that the first dimension of the `value` input
+  is 0. The fix will be included in TensorFlow 2.5.0. We will also cherrypick this
+  commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4,
+  as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29596
+modified: '2021-08-27T03:22:38.479573Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-4vrf-ff7v-hpgr
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/f61c57bd425878be108ec787f4d96390579fb83e

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29597.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29597.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 6d36ba65577006affb272335b7c1abd829010708
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29597
+- GHSA-v52p-hfjf-wg88
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of the `SpaceToBatchNd` TFLite operator is [vulnerable to a division
+  by zero error](https://github.com/tensorflow/tensorflow/blob/412c7d9bb8f8a762c5b266c9e73bfa165f29aac8/tensorflow/lite/kernels/space_to_batch_nd.cc#L82-L83).
+  An attacker can craft a model such that one dimension of the `block` input is 0.
+  Hence, the corresponding value in `block_shape` is 0. The fix will be included in
+  TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow
+  2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-29597
+modified: '2021-08-27T03:22:38.644851Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/6d36ba65577006affb272335b7c1abd829010708
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-v52p-hfjf-wg88

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29598.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29598.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 6841e522a3e7d48706a02e8819836e809f738682
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29598
+- GHSA-pmpr-55fj-r229
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of the `SVDF` TFLite operator is vulnerable to a division by zero
+  error(https://github.com/tensorflow/tensorflow/blob/7f283ff806b2031f407db64c4d3edcda8fb9f9f5/tensorflow/lite/kernels/svdf.cc#L99-L102).
+  An attacker can craft a model such that `params->rank` would be 0. The fix will
+  be included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29598
+modified: '2021-08-27T03:22:38.832523Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-pmpr-55fj-r229
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/6841e522a3e7d48706a02e8819836e809f738682

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29599.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29599.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: b22786e7e9b7bdb6a56936ff29cc7e9968d7bc1d
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29599
+- GHSA-97wf-p777-86jq
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of the `Split` TFLite operator is vulnerable to a division by zero
+  error(https://github.com/tensorflow/tensorflow/blob/e2752089ef7ce9bcf3db0ec618ebd23ea119d0c7/tensorflow/lite/kernels/split.cc#L63-L65).
+  An attacker can craft a model such that `num_splits` would be 0. The fix will be
+  included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29599
+modified: '2021-08-27T03:22:39.020093Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/b22786e7e9b7bdb6a56936ff29cc7e9968d7bc1d
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-97wf-p777-86jq

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29600.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29600.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 3ebedd7e345453d68e279cfc3e4072648e5e12e5
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29600
+- GHSA-j8qh-3xrq-c825
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of the `OneHot` TFLite operator is vulnerable to a division by zero
+  error(https://github.com/tensorflow/tensorflow/blob/f61c57bd425878be108ec787f4d96390579fb83e/tensorflow/lite/kernels/one_hot.cc#L68-L72).
+  An attacker can craft a model such that at least one of the dimensions of `indices`
+  would be 0. In turn, the `prefix_dim_size` value would become 0. The fix will be
+  included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29600
+modified: '2021-08-27T03:22:39.194303Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-j8qh-3xrq-c825
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/3ebedd7e345453d68e279cfc3e4072648e5e12e5

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29601.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29601.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 4253f96a58486ffe84b61c0415bb234a4632ee73
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29601
+- GHSA-9c84-4hx6-xmm4
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  TFLite implementation of concatenation is vulnerable to an integer overflow issue(https://github.com/tensorflow/tensorflow/blob/7b7352a724b690b11bfaae2cd54bc3907daf6285/tensorflow/lite/kernels/concatenation.cc#L70-L76).
+  An attacker can craft a model such that the dimensions of one of the concatenation
+  input overflow the values of `int`. TFLite uses `int` to represent tensor dimensions,
+  whereas TF uses `int64`. Hence, valid TF models can trigger an integer overflow
+  when converted to TFLite format. The fix will be included in TensorFlow 2.5.0. We
+  will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow
+  2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29601
+modified: '2021-08-27T03:22:39.383979Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-9c84-4hx6-xmm4
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/4253f96a58486ffe84b61c0415bb234a4632ee73

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29602.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29602.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: cbda3c6b2dbbd3fbdc482ff8c0170a78ec2e97d0
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29602
+- GHSA-rf3h-xgv5-2q39
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of the `DepthwiseConv` TFLite operator is vulnerable to a division
+  by zero error(https://github.com/tensorflow/tensorflow/blob/1a8e885b864c818198a5b2c0cbbeca5a1e833bc8/tensorflow/lite/kernels/depthwise_conv.cc#L287-L288).
+  An attacker can craft a model such that `input`'s fourth dimension would be 0. The
+  fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit on
+  TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29602
+modified: '2021-08-27T03:22:39.570829Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/cbda3c6b2dbbd3fbdc482ff8c0170a78ec2e97d0
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-rf3h-xgv5-2q39

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29603.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29603.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: c59c37e7b2d563967da813fa50fe20b21f4da683
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29603
+- GHSA-crch-j389-5f84
+details: TensorFlow is an end-to-end open source platform for machine learning. A
+  specially crafted TFLite model could trigger an OOB write on heap in the TFLite
+  implementation of `ArgMin`/`ArgMax`(https://github.com/tensorflow/tensorflow/blob/102b211d892f3abc14f845a72047809b39cc65ab/tensorflow/lite/kernels/arg_min_max.cc#L52-L59).
+  If `axis_value` is not a value between 0 and `NumDimensions(input)`, then the condition
+  in the `if` is never true, so code writes past the last valid element of `output_dims->data`.
+  The fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit
+  on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as
+  these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29603
+modified: '2021-08-27T03:22:39.733041Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-crch-j389-5f84
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/c59c37e7b2d563967da813fa50fe20b21f4da683

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29604.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29604.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 5117e0851348065ed59c991562c0ec80d9193db2
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29604
+- GHSA-8rm6-75mf-7r7r
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  TFLite implementation of hashtable lookup is vulnerable to a division by zero error(https://github.com/tensorflow/tensorflow/blob/1a8e885b864c818198a5b2c0cbbeca5a1e833bc8/tensorflow/lite/kernels/hashtable_lookup.cc#L114-L115)
+  An attacker can craft a model such that `values`'s first dimension would be 0. The
+  fix will be included in TensorFlow 2.5.0. We will also cherrypick this commit on
+  TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29604
+modified: '2021-08-27T03:22:39.893665Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-8rm6-75mf-7r7r
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/5117e0851348065ed59c991562c0ec80d9193db2

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29605.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29605.yaml
@@ -1,0 +1,42 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 7c8cc4ec69cd348e44ad6a2699057ca88faad3e5
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29605
+- GHSA-jf7h-7m85-w2v2
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  TFLite code for allocating `TFLiteIntArray`s is vulnerable to an integer overflow
+  issue(https://github.com/tensorflow/tensorflow/blob/4ceffae632721e52bf3501b736e4fe9d1221cdfa/tensorflow/lite/c/common.c#L24-L27).
+  An attacker can craft a model such that the `size` multiplier is so large that the
+  return value overflows the `int` datatype and becomes negative. In turn, this results
+  in invalid value being given to `malloc`(https://github.com/tensorflow/tensorflow/blob/4ceffae632721e52bf3501b736e4fe9d1221cdfa/tensorflow/lite/c/common.c#L47-L52).
+  In this case, `ret->size` would dereference an invalid pointer. The fix will be
+  included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also
+  affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29605
+modified: '2021-08-27T03:22:40.058012Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-jf7h-7m85-w2v2
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/7c8cc4ec69cd348e44ad6a2699057ca88faad3e5

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29606.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29606.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: ae2daeb45abfe2c6dda539cf8d0d6f653d3ef412
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29606
+- GHSA-h4pc-gx2w-f2xv
+details: TensorFlow is an end-to-end open source platform for machine learning. A
+  specially crafted TFLite model could trigger an OOB read on heap in the TFLite implementation
+  of `Split_V`(https://github.com/tensorflow/tensorflow/blob/c59c37e7b2d563967da813fa50fe20b21f4da683/tensorflow/lite/kernels/split_v.cc#L99).
+  If `axis_value` is not a value between 0 and `NumDimensions(input)`, then the `SizeOfDimension`
+  function(https://github.com/tensorflow/tensorflow/blob/102b211d892f3abc14f845a72047809b39cc65ab/tensorflow/lite/kernels/kernel_util.h#L148-L150)
+  will access data outside the bounds of the tensor shape array. The fix will be included
+  in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow
+  2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-29606
+modified: '2021-08-27T03:22:40.241160Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-h4pc-gx2w-f2xv
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/ae2daeb45abfe2c6dda539cf8d0d6f653d3ef412

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29607.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29607.yaml
@@ -1,0 +1,46 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: ba6822bd7b7324ba201a28b2f278c29a98edbef2
+    - fixed: f6fde895ef9c77d848061c0517f19d0ec2682f3a
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29607
+- GHSA-gv26-jpj9-c8gq
+details: TensorFlow is an end-to-end open source platform for machine learning. Incomplete
+  validation in `SparseAdd` results in allowing attackers to exploit undefined behavior
+  (dereferencing null pointers) as well as write outside of bounds of heap allocated
+  data. The implementation(https://github.com/tensorflow/tensorflow/blob/656e7673b14acd7835dc778867f84916c6d1cac2/tensorflow/core/kernels/sparse_sparse_binary_op_shared.cc)
+  has a large set of validation for the two sparse tensor inputs (6 tensors in total),
+  but does not validate that the tensors are not empty or that the second dimension
+  of `*_indices` matches the size of corresponding `*_shape`. This allows attackers
+  to send tensor triples that represent invalid sparse tensors to abuse code assumptions
+  that are not protected by validation. The fix will be included in TensorFlow 2.5.0.
+  We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow
+  2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29607
+modified: '2021-08-27T03:22:40.417025Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/ba6822bd7b7324ba201a28b2f278c29a98edbef2
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/f6fde895ef9c77d848061c0517f19d0ec2682f3a
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-gv26-jpj9-c8gq

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29608.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29608.yaml
@@ -1,0 +1,47 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: c4d7afb6a5986b04505aca4466ae1951686c80f6
+    - fixed: f94ef358bb3e91d517446454edff6535bcfe8e4a
+    - fixed: b761c9b652af2107cfbc33efd19be0ce41daa33e
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29608
+- GHSA-rgvq-pcvf-hx75
+details: TensorFlow is an end-to-end open source platform for machine learning. Due
+  to lack of validation in `tf.raw_ops.RaggedTensorToTensor`, an attacker can exploit
+  an undefined behavior if input arguments are empty. The implementation(https://github.com/tensorflow/tensorflow/blob/656e7673b14acd7835dc778867f84916c6d1cac2/tensorflow/core/kernels/ragged_tensor_to_tensor_op.cc#L356-L360)
+  only checks that one of the tensors is not empty, but does not check for the other
+  ones. There are multiple `DCHECK` validations to prevent heap OOB, but these are
+  no-op in release builds, hence they don't prevent anything. The fix will be included
+  in TensorFlow 2.5.0. We will also cherrypick these commits on TensorFlow 2.4.2,
+  TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-29608
+modified: '2021-08-27T03:22:40.610515Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/c4d7afb6a5986b04505aca4466ae1951686c80f6
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/f94ef358bb3e91d517446454edff6535bcfe8e4a
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-rgvq-pcvf-hx75
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/b761c9b652af2107cfbc33efd19be0ce41daa33e

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29609.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29609.yaml
@@ -1,0 +1,46 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 41727ff06111117bdf86b37db198217fd7a143cc
+    - fixed: 6fd02f44810754ae7481838b6a67c5df7f909ca3
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29609
+- GHSA-cjc7-49v2-jp64
+details: TensorFlow is an end-to-end open source platform for machine learning. Incomplete
+  validation in `SparseAdd` results in allowing attackers to exploit undefined behavior
+  (dereferencing null pointers) as well as write outside of bounds of heap allocated
+  data. The implementation(https://github.com/tensorflow/tensorflow/blob/656e7673b14acd7835dc778867f84916c6d1cac2/tensorflow/core/kernels/sparse_add_op.cc)
+  has a large set of validation for the two sparse tensor inputs (6 tensors in total),
+  but does not validate that the tensors are not empty or that the second dimension
+  of `*_indices` matches the size of corresponding `*_shape`. This allows attackers
+  to send tensor triples that represent invalid sparse tensors to abuse code assumptions
+  that are not protected by validation. The fix will be included in TensorFlow 2.5.0.
+  We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow
+  2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29609
+modified: '2021-08-27T03:22:40.807777Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/41727ff06111117bdf86b37db198217fd7a143cc
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-cjc7-49v2-jp64
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/6fd02f44810754ae7481838b6a67c5df7f909ca3

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29610.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29610.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: c5b0d5f8ac19888e46ca14b0e27562e7fbbee9a9
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29610
+- GHSA-mq5c-prh3-3f3h
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  validation in `tf.raw_ops.QuantizeAndDequantizeV2` allows invalid values for `axis`
+  argument:. The validation(https://github.com/tensorflow/tensorflow/blob/eccb7ec454e6617738554a255d77f08e60ee0808/tensorflow/core/kernels/quantize_and_dequantize_op.cc#L74-L77)
+  uses `||` to mix two different conditions. If `axis_ < -1` the condition in `OP_REQUIRES`
+  will still be true, but this value of `axis_` results in heap underflow. This allows
+  attackers to read/write to other data on the heap. The fix will be included in TensorFlow
+  2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3,
+  TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported
+  range.
+id: PYSEC-0000-CVE-2021-29610
+modified: '2021-08-27T03:22:41.001819Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-mq5c-prh3-3f3h
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/c5b0d5f8ac19888e46ca14b0e27562e7fbbee9a9

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29611.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29611.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 1d04d7d93f4ed3854abf75d6b712d72c3f70d6b6
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29611
+- GHSA-9rpc-5v9q-5r7f
+details: TensorFlow is an end-to-end open source platform for machine learning. Incomplete
+  validation in `SparseReshape` results in a denial of service based on a `CHECK`-failure.
+  The implementation(https://github.com/tensorflow/tensorflow/blob/e87b51ce05c3eb172065a6ea5f48415854223285/tensorflow/core/kernels/sparse_reshape_op.cc#L40)
+  has no validation that the input arguments specify a valid sparse tensor. The fix
+  will be included in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow
+  2.4.2 and TensorFlow 2.3.3, as these are the only affected versions.
+id: PYSEC-0000-CVE-2021-29611
+modified: '2021-08-27T03:22:41.176381Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-9rpc-5v9q-5r7f
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/1d04d7d93f4ed3854abf75d6b712d72c3f70d6b6

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29612.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29612.yaml
@@ -1,0 +1,47 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: ba6822bd7b7324ba201a28b2f278c29a98edbef2
+    - fixed: 0ab290774f91a23bebe30a358fde4e53ab4876a0
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29612
+- GHSA-2xgj-xhgf-ggjv
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can trigger a heap buffer overflow in Eigen implementation of `tf.raw_ops.BandedTriangularSolve`.
+  The implementation(https://github.com/tensorflow/tensorflow/blob/eccb7ec454e6617738554a255d77f08e60ee0808/tensorflow/core/kernels/linalg/banded_triangular_solve_op.cc#L269-L278)
+  calls `ValidateInputTensors` for input validation but fails to validate that the
+  two tensors are not empty. Furthermore, since `OP_REQUIRES` macro only stops execution
+  of current function after setting `ctx->status()` to a non-OK value, callers of
+  helper functions that use `OP_REQUIRES` must check value of `ctx->status()` before
+  continuing. This doesn't happen in this op's implementation(https://github.com/tensorflow/tensorflow/blob/eccb7ec454e6617738554a255d77f08e60ee0808/tensorflow/core/kernels/linalg/banded_triangular_solve_op.cc#L219),
+  hence the validation that is present is also not effective. The fix will be included
+  in TensorFlow 2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow
+  2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-29612
+modified: '2021-08-27T03:22:41.356902Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-2xgj-xhgf-ggjv
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/ba6822bd7b7324ba201a28b2f278c29a98edbef2
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/0ab290774f91a23bebe30a358fde4e53ab4876a0

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29613.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29613.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 14607c0707040d775e06b6817325640cb4b5864c
+    - fixed: 4504a081af71514bb1828048363e6540f797005b
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29613
+- GHSA-vvg4-vgrv-xfr7
+details: TensorFlow is an end-to-end open source platform for machine learning. Incomplete
+  validation in `tf.raw_ops.CTCLoss` allows an attacker to trigger an OOB read from
+  heap. The fix will be included in TensorFlow 2.5.0. We will also cherrypick these
+  commits on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4,
+  as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29613
+modified: '2021-08-27T03:22:41.522961Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-vvg4-vgrv-xfr7
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/14607c0707040d775e06b6817325640cb4b5864c
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/4504a081af71514bb1828048363e6540f797005b

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29614.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29614.yaml
@@ -1,0 +1,51 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 698e01511f62a3c185754db78ebce0eee1f0184d
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29614
+- GHSA-8pmx-p244-g88h
+details: 'TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of `tf.io.decode_raw` produces incorrect results and crashes the
+  Python interpreter when combining `fixed_length` and wider datatypes. The implementation
+  of the padded version(https://github.com/tensorflow/tensorflow/blob/1d8903e5b167ed0432077a3db6e462daf781d1fe/tensorflow/core/kernels/decode_padded_raw_op.cc)
+  is buggy due to a confusion about pointer arithmetic rules. First, the code computes(https://github.com/tensorflow/tensorflow/blob/1d8903e5b167ed0432077a3db6e462daf781d1fe/tensorflow/core/kernels/decode_padded_raw_op.cc#L61)
+  the width of each output element by dividing the `fixed_length` value to the size
+  of the type argument. The `fixed_length` argument is also used to determine the
+  size needed for the output tensor(https://github.com/tensorflow/tensorflow/blob/1d8903e5b167ed0432077a3db6e462daf781d1fe/tensorflow/core/kernels/decode_padded_raw_op.cc#L63-L79).
+  This is followed by reencoding code(https://github.com/tensorflow/tensorflow/blob/1d8903e5b167ed0432077a3db6e462daf781d1fe/tensorflow/core/kernels/decode_padded_raw_op.cc#L85-L94).
+  The erroneous code is the last line above: it is moving the `out_data` pointer by
+  `fixed_length * sizeof(T)` bytes whereas it only copied at most `fixed_length` bytes
+  from the input. This results in parts of the input not being decoded into the output.
+  Furthermore, because the pointer advance is far wider than desired, this quickly
+  leads to writing to outside the bounds of the backing data. This OOB write leads
+  to interpreter crash in the reproducer mentioned here, but more severe attacks can
+  be mounted too, given that this gadget allows writing to periodically placed locations
+  in memory. The fix will be included in TensorFlow 2.5.0. We will also cherrypick
+  this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow
+  2.1.4, as these are also affected and still in supported range.'
+id: PYSEC-0000-CVE-2021-29614
+modified: '2021-08-27T03:22:41.712204Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/698e01511f62a3c185754db78ebce0eee1f0184d
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-8pmx-p244-g88h

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29615.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29615.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: e07e1c3d26492c06f078c7e5bf2d138043e199c1
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29615
+- GHSA-qw5h-7f53-xrp6
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of `ParseAttrValue`(https://github.com/tensorflow/tensorflow/blob/c22d88d6ff33031aa113e48aa3fc9aa74ed79595/tensorflow/core/framework/attr_value_util.cc#L397-L453)
+  can be tricked into stack overflow due to recursion by giving in a specially crafted
+  input. The fix will be included in TensorFlow 2.5.0. We will also cherrypick this
+  commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow 2.1.4,
+  as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29615
+modified: '2021-08-27T03:22:41.882183Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/e07e1c3d26492c06f078c7e5bf2d138043e199c1
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-qw5h-7f53-xrp6

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29616.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29616.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: e6340f0665d53716ef3197ada88936c2a5f7a2d3
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29616
+- GHSA-4hvv-7x94-7vq8
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  implementation of TrySimplify(https://github.com/tensorflow/tensorflow/blob/c22d88d6ff33031aa113e48aa3fc9aa74ed79595/tensorflow/core/grappler/optimizers/arithmetic_optimizer.cc#L390-L401)
+  has undefined behavior due to dereferencing a null pointer in corner cases that
+  result in optimizing a node with no inputs. The fix will be included in TensorFlow
+  2.5.0. We will also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3,
+  TensorFlow 2.2.3 and TensorFlow 2.1.4, as these are also affected and still in supported
+  range.
+id: PYSEC-0000-CVE-2021-29616
+modified: '2021-08-27T03:22:42.041590Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-4hvv-7x94-7vq8
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/e6340f0665d53716ef3197ada88936c2a5f7a2d3

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29617.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29617.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 890f7164b70354c57d40eda52dcdd7658677c09f
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29617
+- GHSA-mmq6-q8r3-48fm
+details: TensorFlow is an end-to-end open source platform for machine learning. An
+  attacker can cause a denial of service via `CHECK`-fail in `tf.strings.substr` with
+  invalid arguments. The fix will be included in TensorFlow 2.5.0. We will also cherrypick
+  this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and TensorFlow
+  2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29617
+modified: '2021-08-27T03:22:42.200654Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/890f7164b70354c57d40eda52dcdd7658677c09f
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-mmq6-q8r3-48fm
+- type: REPORT
+  url: https://github.com/tensorflow/issues/46974
+- type: REPORT
+  url: https://github.com/tensorflow/issues/46900

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29618.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29618.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 1dc6a7ce6e0b3e27a7ae650bfc05b195ca793f88
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.2.0rc0
+    - introduced: 2.2.0
+    - fixed: 2.3.0rc0
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29618
+- GHSA-xqfj-cr6q-pc8w
+details: TensorFlow is an end-to-end open source platform for machine learning. Passing
+  a complex argument to `tf.transpose` at the same time as passing `conjugate=True`
+  argument results in a crash. The fix will be included in TensorFlow 2.5.0. We will
+  also cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3
+  and TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29618
+modified: '2021-08-27T03:22:42.358462Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/1dc6a7ce6e0b3e27a7ae650bfc05b195ca793f88
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-xqfj-cr6q-pc8w
+- type: REPORT
+  url: https://github.com/tensorflow/issues/46973
+- type: REPORT
+  url: https://github.com/tensorflow/issues/42105

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29619.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-29619.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 82e6203221865de4008445b13c69b6826d2b28d9
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.1.4
+    - introduced: 2.2.0
+    - fixed: 2.2.3
+    - introduced: 2.3.0
+    - fixed: 2.3.3
+    - introduced: 2.4.0
+    - fixed: 2.4.2
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-29619
+- GHSA-wvjw-p9f5-vq28
+details: TensorFlow is an end-to-end open source platform for machine learning. Passing
+  invalid arguments (e.g., discovered via fuzzing) to `tf.raw_ops.SparseCountSparseOutput`
+  results in segfault. The fix will be included in TensorFlow 2.5.0. We will also
+  cherrypick this commit on TensorFlow 2.4.2, TensorFlow 2.3.3, TensorFlow 2.2.3 and
+  TensorFlow 2.1.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-29619
+modified: '2021-08-27T03:22:42.523296Z'
+published: '2021-05-14T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/82e6203221865de4008445b13c69b6826d2b28d9
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-wvjw-p9f5-vq28

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37635.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37635.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 87158f43f05f2720a374f3e6d22a7aaa3a33f750
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37635
+- GHSA-cgfm-62j4-v4rf
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions the implementation of sparse reduction operations in TensorFlow
+  can trigger accesses outside of bounds of heap allocated data. The [implementation](https://github.com/tensorflow/tensorflow/blob/a1bc56203f21a5a4995311825ffaba7a670d7747/tensorflow/core/kernels/sparse_reduce_op.cc#L217-L228)
+  fails to validate that each reduction group does not overflow and that each corresponding
+  index does not point to outside the bounds of the input tensor. We have patched
+  the issue in GitHub commit 87158f43f05f2720a374f3e6d22a7aaa3a33f750. The fix will
+  be included in TensorFlow 2.6.0. We will also cherrypick this commit on TensorFlow
+  2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-37635
+modified: '2021-08-27T03:22:42.637508Z'
+published: '2021-08-12T21:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/87158f43f05f2720a374f3e6d22a7aaa3a33f750
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-cgfm-62j4-v4rf

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37636.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37636.yaml
@@ -1,0 +1,36 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: d9204be9f49520cdaaeb2541d1dc5187b23f31d9
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37636
+- GHSA-hp4c-x6r7-6555
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions the implementation of `tf.raw_ops.SparseDenseCwiseDiv` is vulnerable
+  to a division by 0 error. The [implementation](https://github.com/tensorflow/tensorflow/blob/a1bc56203f21a5a4995311825ffaba7a670d7747/tensorflow/core/kernels/sparse_dense_binary_op_shared.cc#L56)
+  uses a common class for all binary operations but fails to treat the division by
+  0 case separately. We have patched the issue in GitHub commit d9204be9f49520cdaaeb2541d1dc5187b23f31d9.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37636
+modified: '2021-08-27T03:22:42.737707Z'
+published: '2021-08-12T18:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-hp4c-x6r7-6555
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/d9204be9f49520cdaaeb2541d1dc5187b23f31d9

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37637.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37637.yaml
@@ -1,0 +1,36 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 5dc7f6981fdaf74c8c5be41f393df705841fb7c5
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37637
+- GHSA-c9qf-r67m-p7cg
+details: TensorFlow is an end-to-end open source platform for machine learning. It
+  is possible to trigger a null pointer dereference in TensorFlow by passing an invalid
+  input to `tf.raw_ops.CompressElement`. The [implementation](https://github.com/tensorflow/tensorflow/blob/47a06f40411a69c99f381495f490536972152ac0/tensorflow/core/data/compression_utils.cc#L34)
+  was accessing the size of a buffer obtained from the return of a separate function
+  call before validating that said buffer is valid. We have patched the issue in GitHub
+  commit 5dc7f6981fdaf74c8c5be41f393df705841fb7c5. The fix will be included in TensorFlow
+  2.6.0. We will also cherrypick this commit on TensorFlow 2.5.1, TensorFlow 2.4.3,
+  and TensorFlow 2.3.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-37637
+modified: '2021-08-27T03:22:42.844418Z'
+published: '2021-08-12T19:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/5dc7f6981fdaf74c8c5be41f393df705841fb7c5
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-c9qf-r67m-p7cg

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37638.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37638.yaml
@@ -1,0 +1,36 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 301ae88b331d37a2a16159b65b255f4f9eb39314
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37638
+- GHSA-hwr7-8gxx-fj5p
+details: TensorFlow is an end-to-end open source platform for machine learning. Sending
+  invalid argument for `row_partition_types` of `tf.raw_ops.RaggedTensorToTensor`
+  API results in a null pointer dereference and undefined behavior. The [implementation](https://github.com/tensorflow/tensorflow/blob/47a06f40411a69c99f381495f490536972152ac0/tensorflow/core/kernels/ragged_tensor_to_tensor_op.cc#L328)
+  accesses the first element of a user supplied list of values without validating
+  that the provided list is not empty. We have patched the issue in GitHub commit
+  301ae88b331d37a2a16159b65b255f4f9eb39314. The fix will be included in TensorFlow
+  2.6.0. We will also cherrypick this commit on TensorFlow 2.5.1, TensorFlow 2.4.3,
+  and TensorFlow 2.3.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-37638
+modified: '2021-08-27T03:22:42.935785Z'
+published: '2021-08-12T19:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-hwr7-8gxx-fj5p
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/301ae88b331d37a2a16159b65b255f4f9eb39314

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37639.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37639.yaml
@@ -1,0 +1,42 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 9e82dce6e6bd1f36a57e08fa85af213e2b2f2622
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37639
+- GHSA-gh6x-4whr-2qv4
+details: TensorFlow is an end-to-end open source platform for machine learning. When
+  restoring tensors via raw APIs, if the tensor name is not provided, TensorFlow can
+  be tricked into dereferencing a null pointer. Alternatively, attackers can read
+  memory outside the bounds of heap allocated data by providing some tensor names
+  but not enough for a successful restoration. The [implementation](https://github.com/tensorflow/tensorflow/blob/47a06f40411a69c99f381495f490536972152ac0/tensorflow/core/kernels/save_restore_tensor.cc#L158-L159)
+  retrieves the tensor list corresponding to the `tensor_name` user controlled input
+  and immediately retrieves the tensor at the restoration index (controlled via `preferred_shard`
+  argument). This occurs without validating that the provided list has enough values.
+  If the list is empty this results in dereferencing a null pointer (undefined behavior).
+  If, however, the list has some elements, if the restoration index is outside the
+  bounds this results in heap OOB read. We have patched the issue in GitHub commit
+  9e82dce6e6bd1f36a57e08fa85af213e2b2f2622. The fix will be included in TensorFlow
+  2.6.0. We will also cherrypick this commit on TensorFlow 2.5.1, TensorFlow 2.4.3,
+  and TensorFlow 2.3.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-37639
+modified: '2021-08-27T03:22:43.020795Z'
+published: '2021-08-12T19:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-gh6x-4whr-2qv4
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/9e82dce6e6bd1f36a57e08fa85af213e2b2f2622

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37640.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37640.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 4923de56ec94fff7770df259ab7f2288a74feb41
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37640
+- GHSA-95xm-g58g-3p88
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions the implementation of `tf.raw_ops.SparseReshape` can be made to
+  trigger an integral division by 0 exception. The [implementation](https://github.com/tensorflow/tensorflow/blob/8d72537c6abf5a44103b57b9c2e22c14f5f49698/tensorflow/core/kernels/reshape_util.cc#L176-L181)
+  calls the reshaping functor whenever there is at least an index in the input but
+  does not check that shape of the input or the target shape have both a non-zero
+  number of elements. The [reshape functor](https://github.com/tensorflow/tensorflow/blob/8d72537c6abf5a44103b57b9c2e22c14f5f49698/tensorflow/core/kernels/reshape_util.cc#L40-L78)
+  blindly divides by the dimensions of the target shape. Hence, if this is not checked,
+  code will result in a division by 0. We have patched the issue in GitHub commit
+  4923de56ec94fff7770df259ab7f2288a74feb41. The fix will be included in TensorFlow
+  2.6.0. We will also cherrypick this commit on TensorFlow 2.5.1 as this is the other
+  affected version.
+id: PYSEC-0000-CVE-2021-37640
+modified: '2021-08-27T03:22:43.107664Z'
+published: '2021-08-12T18:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-95xm-g58g-3p88
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/4923de56ec94fff7770df259ab7f2288a74feb41

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37641.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37641.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: a2b743f6017d7b97af1fe49087ae15f0ac634373
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37641
+- GHSA-9c8h-vvrj-w2p8
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions if the arguments to `tf.raw_ops.RaggedGather` don't determine
+  a valid ragged tensor code can trigger a read from outside of bounds of heap allocated
+  buffers. The [implementation](https://github.com/tensorflow/tensorflow/blob/8d72537c6abf5a44103b57b9c2e22c14f5f49698/tensorflow/core/kernels/ragged_gather_op.cc#L70)
+  directly reads the first dimension of a tensor shape before checking that said tensor
+  has rank of at least 1 (i.e., it is not a scalar). Furthermore, the implementation
+  does not check that the list given by `params_nested_splits` is not an empty list
+  of tensors. We have patched the issue in GitHub commit a2b743f6017d7b97af1fe49087ae15f0ac634373.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37641
+modified: '2021-08-27T03:22:43.190554Z'
+published: '2021-08-12T21:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/a2b743f6017d7b97af1fe49087ae15f0ac634373
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-9c8h-vvrj-w2p8

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37642.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37642.yaml
@@ -1,0 +1,36 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 4aacb30888638da75023e6601149415b39763d76
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37642
+- GHSA-ch4f-829c-v5pw
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions the implementation of `tf.raw_ops.ResourceScatterDiv` is vulnerable
+  to a division by 0 error. The [implementation](https://github.com/tensorflow/tensorflow/blob/8d72537c6abf5a44103b57b9c2e22c14f5f49698/tensorflow/core/kernels/resource_variable_ops.cc#L865)
+  uses a common class for all binary operations but fails to treat the division by
+  0 case separately. We have patched the issue in GitHub commit 4aacb30888638da75023e6601149415b39763d76.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37642
+modified: '2021-08-27T03:22:43.277267Z'
+published: '2021-08-12T18:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/4aacb30888638da75023e6601149415b39763d76
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-ch4f-829c-v5pw

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37643.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37643.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 482da92095c4d48f8784b1f00dda4f81c28d2988
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37643
+- GHSA-fcwc-p4fc-c5cc
+details: TensorFlow is an end-to-end open source platform for machine learning. If
+  a user does not provide a valid padding value to `tf.raw_ops.MatrixDiagPartOp`,
+  then the code triggers a null pointer dereference (if input is empty) or produces
+  invalid behavior, ignoring all values after the first. The [implementation](https://github.com/tensorflow/tensorflow/blob/8d72537c6abf5a44103b57b9c2e22c14f5f49698/tensorflow/core/kernels/linalg/matrix_diag_op.cc#L89)
+  reads the first value from a tensor buffer without first checking that the tensor
+  has values to read from. We have patched the issue in GitHub commit 482da92095c4d48f8784b1f00dda4f81c28d2988.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37643
+modified: '2021-08-27T03:22:43.365129Z'
+published: '2021-08-12T19:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/482da92095c4d48f8784b1f00dda4f81c28d2988
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-fcwc-p4fc-c5cc

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37644.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37644.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 8a6e874437670045e6c7dc6154c7412b4a2135e2
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37644
+- GHSA-27j5-4p9v-pp67
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions providing a negative element to `num_elements` list argument of
+  `tf.raw_ops.TensorListReserve` causes the runtime to abort the process due to reallocating
+  a `std::vector` to have a negative number of elements. The [implementation](https://github.com/tensorflow/tensorflow/blob/8d72537c6abf5a44103b57b9c2e22c14f5f49698/tensorflow/core/kernels/list_kernels.cc#L312)
+  calls `std::vector.resize()` with the new size controlled by input given by the
+  user, without checking that this input is valid. We have patched the issue in GitHub
+  commit 8a6e874437670045e6c7dc6154c7412b4a2135e2. The fix will be included in TensorFlow
+  2.6.0. We will also cherrypick this commit on TensorFlow 2.5.1, TensorFlow 2.4.3,
+  and TensorFlow 2.3.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-37644
+modified: '2021-08-27T03:22:43.455188Z'
+published: '2021-08-12T21:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-27j5-4p9v-pp67
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/8a6e874437670045e6c7dc6154c7412b4a2135e2

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37645.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37645.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 96f364a1ca3009f98980021c4b32be5fdcca33a1
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37645
+- GHSA-9w2p-5mgw-p94c
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions the implementation of `tf.raw_ops.QuantizeAndDequantizeV4Grad`
+  is vulnerable to an integer overflow issue caused by converting a signed integer
+  value to an unsigned one and then allocating memory based on this value. The [implementation](https://github.com/tensorflow/tensorflow/blob/8d72537c6abf5a44103b57b9c2e22c14f5f49698/tensorflow/core/kernels/quantize_and_dequantize_op.cc#L126)
+  uses the `axis` value as the size argument to `absl::InlinedVector` constructor.
+  But, the constructor uses an unsigned type for the argument, so the implicit conversion
+  transforms the negative value to a large integer. We have patched the issue in GitHub
+  commit 96f364a1ca3009f98980021c4b32be5fdcca33a1. The fix will be included in TensorFlow
+  2.6.0. We will also cherrypick this commit on TensorFlow 2.5.1, and TensorFlow 2.4.3,
+  as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-37645
+modified: '2021-08-27T03:22:43.539250Z'
+published: '2021-08-12T21:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-9w2p-5mgw-p94c
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/96f364a1ca3009f98980021c4b32be5fdcca33a1

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37646.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37646.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: c283e542a3f422420cfdb332414543b62fc4e4a5
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37646
+- GHSA-h6jh-7gv5-28vg
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions the implementation of `tf.raw_ops.StringNGrams` is vulnerable
+  to an integer overflow issue caused by converting a signed integer value to an unsigned
+  one and then allocating memory based on this value. The [implementation](https://github.com/tensorflow/tensorflow/blob/8d72537c6abf5a44103b57b9c2e22c14f5f49698/tensorflow/core/kernels/string_ngrams_op.cc#L184)
+  calls `reserve` on a `tstring` with a value that sometimes can be negative if user
+  supplies negative `ngram_widths`. The `reserve` method calls `TF_TString_Reserve`
+  which has an `unsigned long` argument for the size of the buffer. Hence, the implicit
+  conversion transforms the negative value to a large integer. We have patched the
+  issue in GitHub commit c283e542a3f422420cfdb332414543b62fc4e4a5. The fix will be
+  included in TensorFlow 2.6.0. We will also cherrypick this commit on TensorFlow
+  2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-37646
+modified: '2021-08-27T03:22:43.623027Z'
+published: '2021-08-12T21:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/c283e542a3f422420cfdb332414543b62fc4e4a5
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-h6jh-7gv5-28vg

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37647.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37647.yaml
@@ -1,0 +1,42 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 02cc160e29d20631de3859c6653184e3f876b9d7
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37647
+- GHSA-c5x2-p679-95wc
+details: TensorFlow is an end-to-end open source platform for machine learning. When
+  a user does not supply arguments that determine a valid sparse tensor, `tf.raw_ops.SparseTensorSliceDataset`
+  implementation can be made to dereference a null pointer. The [implementation](https://github.com/tensorflow/tensorflow/blob/8d72537c6abf5a44103b57b9c2e22c14f5f49698/tensorflow/core/kernels/data/sparse_tensor_slice_dataset_op.cc#L240-L251)
+  has some argument validation but fails to consider the case when either `indices`
+  or `values` are provided for an empty sparse tensor when the other is not. If `indices`
+  is empty, then [code that performs validation](https://github.com/tensorflow/tensorflow/blob/8d72537c6abf5a44103b57b9c2e22c14f5f49698/tensorflow/core/kernels/data/sparse_tensor_slice_dataset_op.cc#L260-L261)
+  (i.e., checking that the indices are monotonically increasing) results in a null
+  pointer dereference. If `indices` as provided by the user is empty, then `indices`
+  in the C++ code above is backed by an empty `std::vector`, hence calling `indices->dim_size(0)`
+  results in null pointer dereferencing (same as calling `std::vector::at()` on an
+  empty vector). We have patched the issue in GitHub commit 02cc160e29d20631de3859c6653184e3f876b9d7.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37647
+modified: '2021-08-27T03:22:43.708163Z'
+published: '2021-08-12T19:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-c5x2-p679-95wc
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/02cc160e29d20631de3859c6653184e3f876b9d7

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37648.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37648.yaml
@@ -1,0 +1,42 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 9728c60e136912a12d99ca56e106b7cce7af5986
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37648
+- GHSA-wp77-4gmm-7cq8
+details: 'TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions the code for `tf.raw_ops.SaveV2` does not properly validate the
+  inputs and an attacker can trigger a null pointer dereference. The [implementation](https://github.com/tensorflow/tensorflow/blob/8d72537c6abf5a44103b57b9c2e22c14f5f49698/tensorflow/core/kernels/save_restore_v2_ops.cc)
+  uses `ValidateInputs` to check that the input arguments are valid. This validation
+  would have caught the illegal state represented by the reproducer above. However,
+  the validation uses `OP_REQUIRES` which translates to setting the `Status` object
+  of the current `OpKernelContext` to an error status, followed by an empty `return`
+  statement which just terminates the execution of the function it is present in.
+  However, this does not mean that the kernel execution is finalized: instead, execution
+  continues from the next line in `Compute` that follows the call to `ValidateInputs`.
+  This is equivalent to lacking the validation. We have patched the issue in GitHub
+  commit 9728c60e136912a12d99ca56e106b7cce7af5986. The fix will be included in TensorFlow
+  2.6.0. We will also cherrypick this commit on TensorFlow 2.5.1, TensorFlow 2.4.3,
+  and TensorFlow 2.3.4, as these are also affected and still in supported range.'
+id: PYSEC-0000-CVE-2021-37648
+modified: '2021-08-27T03:22:43.792593Z'
+published: '2021-08-12T22:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/9728c60e136912a12d99ca56e106b7cce7af5986
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-wp77-4gmm-7cq8

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37649.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37649.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 7bdf50bb4f5c54a4997c379092888546c97c3ebd
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37649
+- GHSA-6gv8-p3vj-pxvr
+details: TensorFlow is an end-to-end open source platform for machine learning. The
+  code for `tf.raw_ops.UncompressElement` can be made to trigger a null pointer dereference.
+  The [implementation](https://github.com/tensorflow/tensorflow/blob/f24faa153ad31a4b51578f8181d3aaab77a1ddeb/tensorflow/core/kernels/data/experimental/compression_ops.cc#L50-L53)
+  obtains a pointer to a `CompressedElement` from a `Variant` tensor and then proceeds
+  to dereference it for decompressing. There is no check that the `Variant` tensor
+  contained a `CompressedElement`, so the pointer is actually `nullptr`. We have patched
+  the issue in GitHub commit 7bdf50bb4f5c54a4997c379092888546c97c3ebd. The fix will
+  be included in TensorFlow 2.6.0. We will also cherrypick this commit on TensorFlow
+  2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-37649
+modified: '2021-08-27T03:22:43.879548Z'
+published: '2021-08-12T19:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/7bdf50bb4f5c54a4997c379092888546c97c3ebd
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-6gv8-p3vj-pxvr

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37650.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37650.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: e0b6e58c328059829c3eb968136f17aa72b6c876
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37650
+- GHSA-f8h4-7rgh-q2gm
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions the implementation for `tf.raw_ops.ExperimentalDatasetToTFRecord`
+  and `tf.raw_ops.DatasetToTFRecord` can trigger heap buffer overflow and segmentation
+  fault. The [implementation](https://github.com/tensorflow/tensorflow/blob/f24faa153ad31a4b51578f8181d3aaab77a1ddeb/tensorflow/core/kernels/data/experimental/to_tf_record_op.cc#L93-L102)
+  assumes that all records in the dataset are of string type. However, there is no
+  check for that, and the example given above uses numeric types. We have patched
+  the issue in GitHub commit e0b6e58c328059829c3eb968136f17aa72b6c876. The fix will
+  be included in TensorFlow 2.6.0. We will also cherrypick this commit on TensorFlow
+  2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-37650
+modified: '2021-08-27T03:22:43.967494Z'
+published: '2021-08-12T21:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/e0b6e58c328059829c3eb968136f17aa72b6c876
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-f8h4-7rgh-q2gm

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37651.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37651.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 0f931751fb20f565c4e94aa6df58d54a003cdb30
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37651
+- GHSA-hpv4-7p9c-mvfr
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions the implementation for `tf.raw_ops.FractionalAvgPoolGrad` can
+  be tricked into accessing data outside of bounds of heap allocated buffers. The
+  [implementation](https://github.com/tensorflow/tensorflow/blob/f24faa153ad31a4b51578f8181d3aaab77a1ddeb/tensorflow/core/kernels/fractional_avg_pool_op.cc#L205)
+  does not validate that the input tensor is non-empty. Thus, code constructs an empty
+  `EigenDoubleMatrixMap` and then accesses this buffer with indices that are outside
+  of the empty area. We have patched the issue in GitHub commit 0f931751fb20f565c4e94aa6df58d54a003cdb30.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37651
+modified: '2021-08-27T03:22:44.051773Z'
+published: '2021-08-12T21:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-hpv4-7p9c-mvfr
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/0f931751fb20f565c4e94aa6df58d54a003cdb30

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37652.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37652.yaml
@@ -1,0 +1,43 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 5ecec9c6fbdbc6be03295685190a45e7eee726ab
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37652
+- GHSA-m7fm-4jfh-jrg6
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions the implementation for `tf.raw_ops.BoostedTreesCreateEnsemble`
+  can result in a use after free error if an attacker supplies specially crafted arguments.
+  The [implementation](https://github.com/tensorflow/tensorflow/blob/f24faa153ad31a4b51578f8181d3aaab77a1ddeb/tensorflow/core/kernels/boosted_trees/resource_ops.cc#L55)
+  uses a reference counted resource and decrements the refcount if the initialization
+  fails, as it should. However, when the code was written, the resource was represented
+  as a naked pointer but later refactoring has changed it to be a smart pointer. Thus,
+  when the pointer leaves the scope, a subsequent `free`-ing of the resource occurs,
+  but this fails to take into account that the refcount has already reached 0, thus
+  the resource has been already freed. During this double-free process, members of
+  the resource object are accessed for cleanup but they are invalid as the entire
+  resource has been freed. We have patched the issue in GitHub commit 5ecec9c6fbdbc6be03295685190a45e7eee726ab.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37652
+modified: '2021-08-27T03:22:44.162996Z'
+published: '2021-08-12T22:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/5ecec9c6fbdbc6be03295685190a45e7eee726ab
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-m7fm-4jfh-jrg6

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37653.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37653.yaml
@@ -1,0 +1,36 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: ac117ee8a8ea57b73d34665cdf00ef3303bc0b11
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37653
+- GHSA-qjj8-32p7-h289
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can trigger a crash via a floating point exception
+  in `tf.raw_ops.ResourceGather`. The [implementation](https://github.com/tensorflow/tensorflow/blob/f24faa153ad31a4b51578f8181d3aaab77a1ddeb/tensorflow/core/kernels/resource_variable_ops.cc#L725-L731)
+  computes the value of a value, `batch_size`, and then divides by it without checking
+  that this value is not 0. We have patched the issue in GitHub commit ac117ee8a8ea57b73d34665cdf00ef3303bc0b11.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37653
+modified: '2021-08-27T03:22:44.260808Z'
+published: '2021-08-12T18:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-qjj8-32p7-h289
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/ac117ee8a8ea57b73d34665cdf00ef3303bc0b11

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37654.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37654.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: bc9c546ce7015c57c2f15c168b3d9201de679a1d
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37654
+- GHSA-2r8p-fg3c-wcj4
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can trigger a crash via a `CHECK`-fail in debug builds
+  of TensorFlow using `tf.raw_ops.ResourceGather` or a read from outside the bounds
+  of heap allocated data in the same API in a release build. The [implementation](https://github.com/tensorflow/tensorflow/blob/f24faa153ad31a4b51578f8181d3aaab77a1ddeb/tensorflow/core/kernels/resource_variable_ops.cc#L660-L668)
+  does not check that the `batch_dims` value that the user supplies is less than the
+  rank of the input tensor. Since the implementation uses several for loops over the
+  dimensions of `tensor`, this results in reading data from outside the bounds of
+  heap allocated buffer backing the tensor. We have patched the issue in GitHub commit
+  bc9c546ce7015c57c2f15c168b3d9201de679a1d. The fix will be included in TensorFlow
+  2.6.0. We will also cherrypick this commit on TensorFlow 2.5.1, TensorFlow 2.4.3,
+  and TensorFlow 2.3.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-37654
+modified: '2021-08-27T03:22:44.348474Z'
+published: '2021-08-12T21:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-2r8p-fg3c-wcj4
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/bc9c546ce7015c57c2f15c168b3d9201de679a1d

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37655.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37655.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 01cff3f986259d661103412a20745928c727326f
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37655
+- GHSA-7fvx-3jfc-2cpc
+details: 'TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can trigger a read from outside of bounds of heap
+  allocated data by sending invalid arguments to `tf.raw_ops.ResourceScatterUpdate`.
+  The [implementation](https://github.com/tensorflow/tensorflow/blob/f24faa153ad31a4b51578f8181d3aaab77a1ddeb/tensorflow/core/kernels/resource_variable_ops.cc#L919-L923)
+  has an incomplete validation of the relationship between the shapes of `indices`
+  and `updates`: instead of checking that the shape of `indices` is a prefix of the
+  shape of `updates` (so that broadcasting can happen), code only checks that the
+  number of elements in these two tensors are in a divisibility relationship. We have
+  patched the issue in GitHub commit 01cff3f986259d661103412a20745928c727326f. The
+  fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit on
+  TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.'
+id: PYSEC-0000-CVE-2021-37655
+modified: '2021-08-27T03:22:44.439225Z'
+published: '2021-08-12T21:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-7fvx-3jfc-2cpc
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/01cff3f986259d661103412a20745928c727326f

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37656.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37656.yaml
@@ -1,0 +1,36 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 1071f554dbd09f7e101324d366eec5f4fe5a3ece
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37656
+- GHSA-4xfp-4pfp-89wg
+details: 'TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can cause undefined behavior via binding a reference
+  to null pointer in `tf.raw_ops.RaggedTensorToSparse`. The [implementation](https://github.com/tensorflow/tensorflow/blob/f24faa153ad31a4b51578f8181d3aaab77a1ddeb/tensorflow/core/kernels/ragged_tensor_to_sparse_kernel.cc#L30)
+  has an incomplete validation of the splits values: it does not check that they are
+  in increasing order. We have patched the issue in GitHub commit 1071f554dbd09f7e101324d366eec5f4fe5a3ece.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.'
+id: PYSEC-0000-CVE-2021-37656
+modified: '2021-08-27T03:22:44.528249Z'
+published: '2021-08-12T21:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/1071f554dbd09f7e101324d366eec5f4fe5a3ece
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-4xfp-4pfp-89wg

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37657.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37657.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: f2a673bd34f0d64b8e40a551ac78989d16daad09
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37657
+- GHSA-5xwc-mrhx-5g3m
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can cause undefined behavior via binding a reference
+  to null pointer in all operations of type `tf.raw_ops.MatrixDiagV*`. The [implementation](https://github.com/tensorflow/tensorflow/blob/84d053187cb80d975ef2b9684d4b61981bca0c41/tensorflow/core/kernels/linalg/matrix_diag_op.cc)
+  has incomplete validation that the value of `k` is a valid tensor. We have check
+  that this value is either a scalar or a vector, but there is no check for the number
+  of elements. If this is an empty tensor, then code that accesses the first element
+  of the tensor is wrong. We have patched the issue in GitHub commit f2a673bd34f0d64b8e40a551ac78989d16daad09.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37657
+modified: '2021-08-27T03:22:44.622008Z'
+published: '2021-08-12T21:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/f2a673bd34f0d64b8e40a551ac78989d16daad09
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-5xwc-mrhx-5g3m

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37658.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37658.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: ff8894044dfae5568ecbf2ed514c1a37dc394f1b
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37658
+- GHSA-6p5r-g9mq-ggh2
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can cause undefined behavior via binding a reference
+  to null pointer in all operations of type `tf.raw_ops.MatrixSetDiagV*`. The [implementation](https://github.com/tensorflow/tensorflow/blob/84d053187cb80d975ef2b9684d4b61981bca0c41/tensorflow/core/kernels/linalg/matrix_diag_op.cc)
+  has incomplete validation that the value of `k` is a valid tensor. We have check
+  that this value is either a scalar or a vector, but there is no check for the number
+  of elements. If this is an empty tensor, then code that accesses the first element
+  of the tensor is wrong. We have patched the issue in GitHub commit ff8894044dfae5568ecbf2ed514c1a37dc394f1b.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37658
+modified: '2021-08-27T03:22:44.725554Z'
+published: '2021-08-12T21:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/ff8894044dfae5568ecbf2ed514c1a37dc394f1b
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-6p5r-g9mq-ggh2

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37659.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37659.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 93f428fd1768df147171ed674fee1fc5ab8309ec
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37659
+- GHSA-q3g3-h9r4-prrc
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can cause undefined behavior via binding a reference
+  to null pointer in all binary cwise operations that don't require broadcasting (e.g.,
+  gradients of binary cwise operations). The [implementation](https://github.com/tensorflow/tensorflow/blob/84d053187cb80d975ef2b9684d4b61981bca0c41/tensorflow/core/kernels/cwise_ops_common.h#L264)
+  assumes that the two inputs have exactly the same number of elements but does not
+  check that. Hence, when the eigen functor executes it triggers heap OOB reads and
+  undefined behavior due to binding to nullptr. We have patched the issue in GitHub
+  commit 93f428fd1768df147171ed674fee1fc5ab8309ec. The fix will be included in TensorFlow
+  2.6.0. We will also cherrypick this commit on TensorFlow 2.5.1, TensorFlow 2.4.3,
+  and TensorFlow 2.3.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-37659
+modified: '2021-08-27T03:22:44.808272Z'
+published: '2021-08-12T21:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/93f428fd1768df147171ed674fee1fc5ab8309ec
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-q3g3-h9r4-prrc

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37660.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37660.yaml
@@ -1,0 +1,36 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: e86605c0a336c088b638da02135ea6f9f6753618
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37660
+- GHSA-cm5x-837x-jf3c
+details: 'TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can cause a floating point exception by calling inplace
+  operations with crafted arguments that would result in a division by 0. The [implementation](https://github.com/tensorflow/tensorflow/blob/84d053187cb80d975ef2b9684d4b61981bca0c41/tensorflow/core/kernels/inplace_ops.cc#L283)
+  has a logic error: it should skip processing if `x` and `v` are empty but the code
+  uses `||` instead of `&&`. We have patched the issue in GitHub commit e86605c0a336c088b638da02135ea6f9f6753618.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.'
+id: PYSEC-0000-CVE-2021-37660
+modified: '2021-08-27T03:22:44.908068Z'
+published: '2021-08-12T18:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-cm5x-837x-jf3c
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/e86605c0a336c088b638da02135ea6f9f6753618

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37661.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37661.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 8a84f7a2b5a2b27ecf88d25bad9ac777cd2f7992
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37661
+- GHSA-gf88-j2mg-cc82
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can cause a denial of service in `boosted_trees_create_quantile_stream_resource`
+  by using negative arguments. The [implementation](https://github.com/tensorflow/tensorflow/blob/84d053187cb80d975ef2b9684d4b61981bca0c41/tensorflow/core/kernels/boosted_trees/quantile_ops.cc#L96)
+  does not validate that `num_streams` only contains non-negative numbers. In turn,
+  [this results in using this value to allocate memory](https://github.com/tensorflow/tensorflow/blob/84d053187cb80d975ef2b9684d4b61981bca0c41/tensorflow/core/kernels/boosted_trees/quantiles/quantile_stream_resource.h#L31-L40).
+  However, `reserve` receives an unsigned integer so there is an implicit conversion
+  from a negative value to a large positive unsigned. This results in a crash from
+  the standard library. We have patched the issue in GitHub commit 8a84f7a2b5a2b27ecf88d25bad9ac777cd2f7992.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37661
+modified: '2021-08-27T03:22:45.010979Z'
+published: '2021-08-12T21:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/8a84f7a2b5a2b27ecf88d25bad9ac777cd2f7992
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-gf88-j2mg-cc82

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37662.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37662.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 9c87c32c710d0b5b53dc6fd3bfde4046e1f7a5ad
+    - fixed: 429f009d2b2c09028647dd4bb7b3f6f414bbaad7
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37662
+- GHSA-f5cx-5wr3-5qrc
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can generate undefined behavior via a reference binding
+  to nullptr in `BoostedTreesCalculateBestGainsPerFeature` and similar attack can
+  occur in `BoostedTreesCalculateBestFeatureSplitV2`. The [implementation](https://github.com/tensorflow/tensorflow/blob/84d053187cb80d975ef2b9684d4b61981bca0c41/tensorflow/core/kernels/boosted_trees/stats_ops.cc)
+  does not validate the input values. We have patched the issue in GitHub commit 9c87c32c710d0b5b53dc6fd3bfde4046e1f7a5ad
+  and in commit 429f009d2b2c09028647dd4bb7b3f6f414bbaad7. The fix will be included
+  in TensorFlow 2.6.0. We will also cherrypick this commit on TensorFlow 2.5.1, TensorFlow
+  2.4.3, and TensorFlow 2.3.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-37662
+modified: '2021-08-27T03:22:45.118929Z'
+published: '2021-08-12T21:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/9c87c32c710d0b5b53dc6fd3bfde4046e1f7a5ad
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-f5cx-5wr3-5qrc
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/429f009d2b2c09028647dd4bb7b3f6f414bbaad7

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37663.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37663.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 6da6620efad397c85493b8f8667b821403516708
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37663
+- GHSA-g25h-jr74-qp5j
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions due to incomplete validation in `tf.raw_ops.QuantizeV2`, an attacker
+  can trigger undefined behavior via binding a reference to a null pointer or can
+  access data outside the bounds of heap allocated arrays. The [implementation](https://github.com/tensorflow/tensorflow/blob/84d053187cb80d975ef2b9684d4b61981bca0c41/tensorflow/core/kernels/quantize_op.cc#L59)
+  has some validation but does not check that `min_range` and `max_range` both have
+  the same non-zero number of elements. If `axis` is provided (i.e., not `-1`), then
+  validation should check that it is a value in range for the rank of `input` tensor
+  and then the lengths of `min_range` and `max_range` inputs match the `axis` dimension
+  of the `input` tensor. We have patched the issue in GitHub commit 6da6620efad397c85493b8f8667b821403516708.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37663
+modified: '2021-08-27T03:22:45.209094Z'
+published: '2021-08-12T23:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/6da6620efad397c85493b8f8667b821403516708
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-g25h-jr74-qp5j

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37664.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37664.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: e84c975313e8e8e38bb2ea118196369c45c51378
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37664
+- GHSA-r4c4-5fpq-56wg
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can read from outside of bounds of heap allocated
+  data by sending specially crafted illegal arguments to `BoostedTreesSparseCalculateBestFeatureSplit`.
+  The [implementation](https://github.com/tensorflow/tensorflow/blob/84d053187cb80d975ef2b9684d4b61981bca0c41/tensorflow/core/kernels/boosted_trees/stats_ops.cc)
+  needs to validate that each value in `stats_summary_indices` is in range. We have
+  patched the issue in GitHub commit e84c975313e8e8e38bb2ea118196369c45c51378. The
+  fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit on
+  TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37664
+modified: '2021-08-27T03:22:45.297527Z'
+published: '2021-08-12T21:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-r4c4-5fpq-56wg
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/e84c975313e8e8e38bb2ea118196369c45c51378

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37665.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37665.yaml
@@ -1,0 +1,42 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 9e62869465573cb2d9b5053f1fa02a81fce21d69
+    - fixed: 203214568f5bc237603dbab6e1fd389f1572f5c9
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37665
+- GHSA-v82p-hv3v-p6qp
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions due to incomplete validation in MKL implementation of requantization,
+  an attacker can trigger undefined behavior via binding a reference to a null pointer
+  or can access data outside the bounds of heap allocated arrays. The [implementation](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/core/kernels/mkl/mkl_requantization_range_per_channel_op.cc)
+  does not validate the dimensions of the `input` tensor. A similar issue occurs in
+  `MklRequantizePerChannelOp`. The [implementation](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/core/kernels/mkl/mkl_requantize_per_channel_op.cc)
+  does not perform full validation for all the input arguments. We have patched the
+  issue in GitHub commit 9e62869465573cb2d9b5053f1fa02a81fce21d69 and in the Github
+  commit 203214568f5bc237603dbab6e1fd389f1572f5c9. The fix will be included in TensorFlow
+  2.6.0. We will also cherrypick this commit on TensorFlow 2.5.1, TensorFlow 2.4.3,
+  and TensorFlow 2.3.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-37665
+modified: '2021-08-27T03:22:45.390087Z'
+published: '2021-08-12T23:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/9e62869465573cb2d9b5053f1fa02a81fce21d69
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-v82p-hv3v-p6qp
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/203214568f5bc237603dbab6e1fd389f1572f5c9

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37666.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37666.yaml
@@ -1,0 +1,36 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: be7a4de6adfbd303ce08be4332554dff70362612
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37666
+- GHSA-w4xf-2pqw-5mq7
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can cause undefined behavior via binding a reference
+  to null pointer in `tf.raw_ops.RaggedTensorToVariant`. The [implementation](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/core/kernels/ragged_tensor_to_variant_op.cc#L129)
+  has an incomplete validation of the splits values, missing the case when the argument
+  would be empty. We have patched the issue in GitHub commit be7a4de6adfbd303ce08be4332554dff70362612.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37666
+modified: '2021-08-27T03:22:45.481654Z'
+published: '2021-08-12T22:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/be7a4de6adfbd303ce08be4332554dff70362612
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-w4xf-2pqw-5mq7

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37667.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37667.yaml
@@ -1,0 +1,36 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 2e0ee46f1a47675152d3d865797a18358881d7a6
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37667
+- GHSA-w74j-v8xh-3w5h
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can cause undefined behavior via binding a reference
+  to null pointer in `tf.raw_ops.UnicodeEncode`. The [implementation](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/core/kernels/unicode_ops.cc#L533-L539)
+  reads the first dimension of the `input_splits` tensor before validating that this
+  tensor is not empty. We have patched the issue in GitHub commit 2e0ee46f1a47675152d3d865797a18358881d7a6.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37667
+modified: '2021-08-27T03:22:45.582995Z'
+published: '2021-08-12T22:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/2e0ee46f1a47675152d3d865797a18358881d7a6
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-w74j-v8xh-3w5h

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37668.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37668.yaml
@@ -1,0 +1,36 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: a776040a5e7ebf76eeb7eb923bf1ae417dd4d233
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37668
+- GHSA-2wmv-37vq-52g5
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can cause denial of service in applications serving
+  models using `tf.raw_ops.UnravelIndex` by triggering a division by 0. The [implementation](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/core/kernels/unravel_index_op.cc#L36)
+  does not check that the tensor subsumed by `dims` is not empty. Hence, if one element
+  of `dims` is 0, the implementation does a division by 0. We have patched the issue
+  in GitHub commit a776040a5e7ebf76eeb7eb923bf1ae417dd4d233. The fix will be included
+  in TensorFlow 2.6.0. We will also cherrypick this commit on TensorFlow 2.5.1, TensorFlow
+  2.4.3, and TensorFlow 2.3.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-37668
+modified: '2021-08-27T03:22:45.672870Z'
+published: '2021-08-12T23:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/a776040a5e7ebf76eeb7eb923bf1ae417dd4d233
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-2wmv-37vq-52g5

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37669.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37669.yaml
@@ -1,0 +1,43 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 3a7362750d5c372420aa8f0caf7bf5b5c3d0f52d
+    - fixed: b5cdbf12ffcaaffecf98f22a6be5a64bb96e4f58
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37669
+- GHSA-vmjw-c2vp-p33c
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can cause denial of service in applications serving
+  models using `tf.raw_ops.NonMaxSuppressionV5` by triggering a division by 0. The
+  [implementation](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/core/kernels/image/non_max_suppression_op.cc#L170-L271)
+  uses a user controlled argument to resize a `std::vector`. However, as `std::vector::resize`
+  takes the size argument as a `size_t` and `output_size` is an `int`, there is an
+  implicit conversion to unsigned. If the attacker supplies a negative value, this
+  conversion results in a crash. A similar issue occurs in `CombinedNonMaxSuppression`.
+  We have patched the issue in GitHub commit 3a7362750d5c372420aa8f0caf7bf5b5c3d0f52d
+  and commit [b5cdbf12ffcaaffecf98f22a6be5a64bb96e4f58. The fix will be included in
+  TensorFlow 2.6.0. We will also cherrypick this commit on TensorFlow 2.5.1, TensorFlow
+  2.4.3, and TensorFlow 2.3.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-37669
+modified: '2021-08-27T03:22:45.759545Z'
+published: '2021-08-12T23:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-vmjw-c2vp-p33c
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/3a7362750d5c372420aa8f0caf7bf5b5c3d0f52d
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/b5cdbf12ffcaaffecf98f22a6be5a64bb96e4f58

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37670.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37670.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 42459e4273c2e47a3232cc16c4f4fff3b3a35c38
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37670
+- GHSA-9697-98pf-4rw7
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can read from outside of bounds of heap allocated
+  data by sending specially crafted illegal arguments to `tf.raw_ops.UpperBound`.
+  The [implementation](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/core/kernels/searchsorted_op.cc#L85-L104)
+  does not validate the rank of `sorted_input` argument. A similar issue occurs in
+  `tf.raw_ops.LowerBound`. We have patched the issue in GitHub commit 42459e4273c2e47a3232cc16c4f4fff3b3a35c38.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37670
+modified: '2021-08-27T03:22:45.845259Z'
+published: '2021-08-12T23:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/42459e4273c2e47a3232cc16c4f4fff3b3a35c38
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-9697-98pf-4rw7

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37671.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37671.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 532f5c5a547126c634fefd43bbad1dc6417678ac
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37671
+- GHSA-qr82-2c78-4m8h
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can cause undefined behavior via binding a reference
+  to null pointer in `tf.raw_ops.Map*` and `tf.raw_ops.OrderedMap*` operations. The
+  [implementation](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/core/kernels/map_stage_op.cc#L222-L248)
+  has a check in place to ensure that `indices` is in ascending order, but does not
+  check that `indices` is not empty. We have patched the issue in GitHub commit 532f5c5a547126c634fefd43bbad1dc6417678ac.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37671
+modified: '2021-08-27T03:22:45.925209Z'
+published: '2021-08-12T22:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/532f5c5a547126c634fefd43bbad1dc6417678ac
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-qr82-2c78-4m8h

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37672.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37672.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: a4e138660270e7599793fa438cd7b2fc2ce215a6
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37672
+- GHSA-5hj3-vjjf-f5m7
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can read from outside of bounds of heap allocated
+  data by sending specially crafted illegal arguments to `tf.raw_ops.SdcaOptimizerV2`.
+  The [implementation](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/core/kernels/sdca_internal.cc#L320-L353)
+  does not check that the length of `example_labels` is the same as the number of
+  examples. We have patched the issue in GitHub commit a4e138660270e7599793fa438cd7b2fc2ce215a6.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37672
+modified: '2021-08-27T03:22:46.024313Z'
+published: '2021-08-12T23:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/a4e138660270e7599793fa438cd7b2fc2ce215a6
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-5hj3-vjjf-f5m7

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37673.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37673.yaml
@@ -1,0 +1,36 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: d7de67733925de196ec8863a33445b73f9562d1d
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37673
+- GHSA-278g-rq84-9hmg
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can trigger a denial of service via a `CHECK`-fail
+  in `tf.raw_ops.MapStage`. The [implementation](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/core/kernels/map_stage_op.cc#L513)
+  does not check that the `key` input is a valid non-empty tensor. We have patched
+  the issue in GitHub commit d7de67733925de196ec8863a33445b73f9562d1d. The fix will
+  be included in TensorFlow 2.6.0. We will also cherrypick this commit on TensorFlow
+  2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-37673
+modified: '2021-08-27T03:22:46.123018Z'
+published: '2021-08-12T23:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/d7de67733925de196ec8863a33445b73f9562d1d
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-278g-rq84-9hmg

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37674.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37674.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 136b51f10903e044308cf77117c0ed9871350475
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37674
+- GHSA-7ghq-fvr3-pj2x
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can trigger a denial of service via a segmentation
+  fault in `tf.raw_ops.MaxPoolGrad` caused by missing validation. The [implementation](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/core/kernels/maxpooling_op.cc)
+  misses some validation for the `orig_input` and `orig_output` tensors. The fixes
+  for CVE-2021-29579 were incomplete. We have patched the issue in GitHub commit 136b51f10903e044308cf77117c0ed9871350475.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37674
+modified: '2021-08-27T03:22:46.211223Z'
+published: '2021-08-12T23:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/136b51f10903e044308cf77117c0ed9871350475
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-7ghq-fvr3-pj2x
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/security/advisory/tfsa-2021-068.md

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37675.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37675.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 8a793b5d7f59e37ac7f3cd0954a750a2fe76bad4
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37675
+- GHSA-9c8h-2mv3-49ww
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions most implementations of convolution operators in TensorFlow are
+  affected by a division by 0 vulnerability where an attacker can trigger a denial
+  of service via a crash. The shape inference [implementation](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/core/framework/common_shape_fns.cc#L577)
+  is missing several validations before doing divisions and modulo operations. We
+  have patched the issue in GitHub commit 8a793b5d7f59e37ac7f3cd0954a750a2fe76bad4.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37675
+modified: '2021-08-27T03:22:46.293986Z'
+published: '2021-08-12T22:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-9c8h-2mv3-49ww
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/8a793b5d7f59e37ac7f3cd0954a750a2fe76bad4

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37676.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37676.yaml
@@ -1,0 +1,36 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 578e634b4f1c1c684d4b4294f9e5281b2133b3ed
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37676
+- GHSA-v768-w7m9-2vmm
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can cause undefined behavior via binding a reference
+  to null pointer in `tf.raw_ops.SparseFillEmptyRows`. The shape inference [implementation](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/core/ops/sparse_ops.cc#L608-L634)
+  does not validate that the input arguments are not empty tensors. We have patched
+  the issue in GitHub commit 578e634b4f1c1c684d4b4294f9e5281b2133b3ed. The fix will
+  be included in TensorFlow 2.6.0. We will also cherrypick this commit on TensorFlow
+  2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-37676
+modified: '2021-08-27T03:22:46.384345Z'
+published: '2021-08-12T22:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/578e634b4f1c1c684d4b4294f9e5281b2133b3ed
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-v768-w7m9-2vmm

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37677.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37677.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: da857cfa0fde8f79ad0afdbc94e88b5d4bbec764
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37677
+- GHSA-qfpc-5pjr-mh26
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions the shape inference code for `tf.raw_ops.Dequantize` has a vulnerability
+  that could trigger a denial of service via a segfault if an attacker provides invalid
+  arguments. The shape inference [implementation](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/core/ops/array_ops.cc#L2999-L3014)
+  uses `axis` to select between two different values for `minmax_rank` which is then
+  used to retrieve tensor dimensions. However, code assumes that `axis` can be either
+  `-1` or a value greater than `-1`, with no validation for the other values. We have
+  patched the issue in GitHub commit da857cfa0fde8f79ad0afdbc94e88b5d4bbec764. The
+  fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit on
+  TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37677
+modified: '2021-08-27T03:22:46.477427Z'
+published: '2021-08-12T23:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-qfpc-5pjr-mh26
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/da857cfa0fde8f79ad0afdbc94e88b5d4bbec764

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37678.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37678.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 23d6383eb6c14084a8fc3bdf164043b974818012
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37678
+- GHSA-r6jx-9g48-2r5r
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions TensorFlow and Keras can be tricked to perform arbitrary code
+  execution when deserializing a Keras model from YAML format. The [implementation](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/python/keras/saving/model_config.py#L66-L104)
+  uses `yaml.unsafe_load` which can perform arbitrary code execution on the input.
+  Given that YAML format support requires a significant amount of work, we have removed
+  it for now. We have patched the issue in GitHub commit 23d6383eb6c14084a8fc3bdf164043b974818012.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37678
+modified: '2021-08-27T03:22:46.598549Z'
+published: '2021-08-12T23:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-r6jx-9g48-2r5r
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/23d6383eb6c14084a8fc3bdf164043b974818012

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37679.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37679.yaml
@@ -1,0 +1,42 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 4e2565483d0ffcadc719bd44893fb7f609bb5f12
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37679
+- GHSA-g8wg-cjwc-xhhp
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions it is possible to nest a `tf.map_fn` within another `tf.map_fn`
+  call. However, if the input tensor is a `RaggedTensor` and there is no function
+  signature provided, code assumes the output is a fully specified tensor and fills
+  output buffer with uninitialized contents from the heap. The `t` and `z` outputs
+  should be identical, however this is not the case. The last row of `t` contains
+  data from the heap which can be used to leak other memory information. The bug lies
+  in the conversion from a `Variant` tensor to a `RaggedTensor`. The [implementation](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/core/kernels/ragged_tensor_from_variant_op.cc#L177-L190)
+  does not check that all inner shapes match and this results in the additional dimensions.
+  The same implementation can result in data loss, if input tensor is tweaked. We
+  have patched the issue in GitHub commit 4e2565483d0ffcadc719bd44893fb7f609bb5f12.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37679
+modified: '2021-08-27T03:22:46.691143Z'
+published: '2021-08-12T23:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-g8wg-cjwc-xhhp
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/4e2565483d0ffcadc719bd44893fb7f609bb5f12

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37680.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37680.yaml
@@ -1,0 +1,35 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 718721986aa137691ee23f03638867151f74935f
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37680
+- GHSA-cfpj-3q4c-jhvr
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions the implementation of fully connected layers in TFLite is [vulnerable
+  to a division by zero error](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/lite/kernels/fully_connected.cc#L226).
+  We have patched the issue in GitHub commit 718721986aa137691ee23f03638867151f74935f.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37680
+modified: '2021-08-27T03:22:46.794136Z'
+published: '2021-08-12T22:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/718721986aa137691ee23f03638867151f74935f
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-cfpj-3q4c-jhvr

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37681.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37681.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 5b048e87e4e55990dae6b547add4dae59f4e1c76
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37681
+- GHSA-7xwj-5r4v-429p
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions the implementation of SVDF in TFLite is [vulnerable to a null
+  pointer error](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/lite/kernels/svdf.cc#L300-L313).
+  The [`GetVariableInput` function](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/lite/kernels/kernel_util.cc#L115-L119)
+  can return a null pointer but `GetTensorData` assumes that the argument is always
+  a valid tensor. Furthermore, because `GetVariableInput` calls [`GetMutableInput`](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/lite/kernels/kernel_util.cc#L82-L90)
+  which might return `nullptr`, the `tensor->is_variable` expression can also trigger
+  a null pointer exception. We have patched the issue in GitHub commit 5b048e87e4e55990dae6b547add4dae59f4e1c76.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37681
+modified: '2021-08-27T03:22:46.881278Z'
+published: '2021-08-12T22:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/5b048e87e4e55990dae6b547add4dae59f4e1c76
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-7xwj-5r4v-429p

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37682.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37682.yaml
@@ -1,0 +1,44 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 537bc7c723439b9194a358f64d871dd326c18887
+    - fixed: 4a91f2069f7145aab6ba2d8cfe41be8a110c18a5
+    - fixed: 8933b8a21280696ab119b63263babdb54c298538
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37682
+- GHSA-4c4g-crqm-xrxw
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions all TFLite operations that use quantization can be made to use
+  unitialized values. [For example](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/lite/kernels/depthwise_conv.cc#L198-L200).
+  The issue stems from the fact that `quantization.params` is only valid if `quantization.type`
+  is different that `kTfLiteNoQuantization`. However, these checks are missing in
+  large parts of the code. We have patched the issue in GitHub commits 537bc7c723439b9194a358f64d871dd326c18887,
+  4a91f2069f7145aab6ba2d8cfe41be8a110c18a5 and 8933b8a21280696ab119b63263babdb54c298538.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37682
+modified: '2021-08-27T03:22:46.967506Z'
+published: '2021-08-12T23:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/537bc7c723439b9194a358f64d871dd326c18887
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/4a91f2069f7145aab6ba2d8cfe41be8a110c18a5
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/8933b8a21280696ab119b63263babdb54c298538
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-4c4g-crqm-xrxw

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37683.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37683.yaml
@@ -1,0 +1,36 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 1e206baedf8bef0334cca3eb92bab134ef525a28
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37683
+- GHSA-rhrq-64mq-hf9h
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions the implementation of division in TFLite is [vulnerable to a division
+  by 0 error](https://github.com/tensorflow/tensorflow/blob/460e000de3a83278fb00b61a16d161b1964f15f4/tensorflow/lite/kernels/div.cc).
+  There is no check that the divisor tensor does not contain zero elements. We have
+  patched the issue in GitHub commit 1e206baedf8bef0334cca3eb92bab134ef525a28. The
+  fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit on
+  TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37683
+modified: '2021-08-27T03:22:47.052583Z'
+published: '2021-08-12T23:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/1e206baedf8bef0334cca3eb92bab134ef525a28
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-rhrq-64mq-hf9h

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37684.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37684.yaml
@@ -1,0 +1,28 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37684
+- GHSA-q7f7-544h-67h9
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions the implementations of pooling in TFLite are vulnerable to division
+  by 0 errors as there are no checks for divisors not being 0. We have patched the
+  issue in GitHub commit [dfa22b348b70bb89d6d6ec0ff53973bacb4f4695](https://github.com/tensorflow/tensorflow/commit/dfa22b348b70bb89d6d6ec0ff53973bacb4f4695).
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37684
+modified: '2021-08-27T03:22:47.149147Z'
+published: '2021-08-12T23:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-q7f7-544h-67h9

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37685.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37685.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: d94ffe08a65400f898241c0374e9edc6fa8ed257
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37685
+- GHSA-c545-c4f9-rf6v
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions TFLite's [`expand_dims.cc`](https://github.com/tensorflow/tensorflow/blob/149562d49faa709ea80df1d99fc41d005b81082a/tensorflow/lite/kernels/expand_dims.cc#L36-L50)
+  contains a vulnerability which allows reading one element outside of bounds of heap
+  allocated data. If `axis` is a large negative value (e.g., `-100000`), then after
+  the first `if` it would still be negative. The check following the `if` statement
+  will pass and the `for` loop would read one element before the start of `input_dims.data`
+  (when `i = 0`). We have patched the issue in GitHub commit d94ffe08a65400f898241c0374e9edc6fa8ed257.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37685
+modified: '2021-08-27T03:22:47.234797Z'
+published: '2021-08-12T23:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/d94ffe08a65400f898241c0374e9edc6fa8ed257
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-c545-c4f9-rf6v

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37686.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37686.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: dfa22b348b70bb89d6d6ec0ff53973bacb4f4695
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37686
+- GHSA-mhhc-q96p-mfm9
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions the strided slice implementation in TFLite has a logic bug which
+  can allow an attacker to trigger an infinite loop. This arises from newly introduced
+  support for [ellipsis in axis definition](https://github.com/tensorflow/tensorflow/blob/149562d49faa709ea80df1d99fc41d005b81082a/tensorflow/lite/kernels/strided_slice.cc#L103-L122).
+  An attacker can craft a model such that `ellipsis_end_idx` is smaller than `i` (e.g.,
+  always negative). In this case, the inner loop does not increase `i` and the `continue`
+  statement causes execution to skip over the preincrement at the end of the outer
+  loop. We have patched the issue in GitHub commit dfa22b348b70bb89d6d6ec0ff53973bacb4f4695.
+  TensorFlow 2.6.0 is the only affected version.
+id: PYSEC-0000-CVE-2021-37686
+modified: '2021-08-27T03:22:47.333103Z'
+published: '2021-08-12T22:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-mhhc-q96p-mfm9
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/dfa22b348b70bb89d6d6ec0ff53973bacb4f4695

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37687.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37687.yaml
@@ -1,0 +1,40 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: eb921122119a6b6e470ee98b89e65d721663179d
+    - fixed: bb6a0383ed553c286f87ca88c207f6774d5c4a8f
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37687
+- GHSA-jwf9-w5xm-f437
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions TFLite's [`GatherNd` implementation](https://github.com/tensorflow/tensorflow/blob/149562d49faa709ea80df1d99fc41d005b81082a/tensorflow/lite/kernels/gather_nd.cc#L124)
+  does not support negative indices but there are no checks for this situation. Hence,
+  an attacker can read arbitrary data from the heap by carefully crafting a model
+  with negative values in `indices`. Similar issue exists in [`Gather` implementation](https://github.com/tensorflow/tensorflow/blob/149562d49faa709ea80df1d99fc41d005b81082a/tensorflow/lite/kernels/gather.cc).
+  We have patched the issue in GitHub commits bb6a0383ed553c286f87ca88c207f6774d5c4a8f
+  and eb921122119a6b6e470ee98b89e65d721663179d. The fix will be included in TensorFlow
+  2.6.0. We will also cherrypick this commit on TensorFlow 2.5.1, TensorFlow 2.4.3,
+  and TensorFlow 2.3.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-37687
+modified: '2021-08-27T03:22:47.431884Z'
+published: '2021-08-12T23:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/eb921122119a6b6e470ee98b89e65d721663179d
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/bb6a0383ed553c286f87ca88c207f6774d5c4a8f
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-jwf9-w5xm-f437

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37688.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37688.yaml
@@ -1,0 +1,35 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 15691e456c7dc9bd6be203b09765b063bf4a380c
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37688
+- GHSA-vcjj-9vg7-vf68
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can craft a TFLite model that would trigger a null
+  pointer dereference, which would result in a crash and denial of service. The [implementation](https://github.com/tensorflow/tensorflow/blob/149562d49faa709ea80df1d99fc41d005b81082a/tensorflow/lite/kernels/internal/optimized/optimized_ops.h#L268-L285)
+  unconditionally dereferences a pointer. We have patched the issue in GitHub commit
+  15691e456c7dc9bd6be203b09765b063bf4a380c. The fix will be included in TensorFlow
+  2.6.0. We will also cherrypick this commit on TensorFlow 2.5.1, TensorFlow 2.4.3,
+  and TensorFlow 2.3.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-37688
+modified: '2021-08-27T03:22:47.519318Z'
+published: '2021-08-12T22:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-vcjj-9vg7-vf68
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/15691e456c7dc9bd6be203b09765b063bf4a380c

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37689.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37689.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: d6b57f461b39fd1aa8c1b870f1b974aac3554955
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37689
+- GHSA-wf5p-c75w-w3wh
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can craft a TFLite model that would trigger a null
+  pointer dereference, which would result in a crash and denial of service. This is
+  caused by the MLIR optimization of `L2NormalizeReduceAxis` operator. The [implementation](https://github.com/tensorflow/tensorflow/blob/149562d49faa709ea80df1d99fc41d005b81082a/tensorflow/compiler/mlir/lite/transforms/optimize.cc#L67-L70)
+  unconditionally dereferences a pointer to an iterator to a vector without checking
+  that the vector has elements. We have patched the issue in GitHub commit d6b57f461b39fd1aa8c1b870f1b974aac3554955.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37689
+modified: '2021-08-27T03:22:47.601647Z'
+published: '2021-08-12T22:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/d6b57f461b39fd1aa8c1b870f1b974aac3554955
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-wf5p-c75w-w3wh

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37690.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37690.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: ee119d4a498979525046fba1c3dd3f13a039fbb1
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37690
+- GHSA-3hxh-8cp2-g4hg
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions when running shape functions, some functions (such as `MutableHashTableShape`)
+  produce extra output information in the form of a `ShapeAndType` struct. The shapes
+  embedded in this struct are owned by an inference context that is cleaned up almost
+  immediately; if the upstream code attempts to access this shape information, it
+  can trigger a segfault. `ShapeRefiner` is mitigating this for normal output shapes
+  by cloning them (and thus putting the newly created shape under ownership of an
+  inference context that will not die), but we were not doing the same for shapes
+  and types. This commit fixes that by doing similar logic on output shapes and types.
+  We have patched the issue in GitHub commit ee119d4a498979525046fba1c3dd3f13a039fbb1.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37690
+modified: '2021-08-27T03:22:47.685921Z'
+published: '2021-08-13T00:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-3hxh-8cp2-g4hg
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/ee119d4a498979525046fba1c3dd3f13a039fbb1

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37691.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37691.yaml
@@ -1,0 +1,35 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 0575b640091680cfb70f4dd93e70658de43b94f9
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37691
+- GHSA-27qf-jwm8-g7f3
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions an attacker can craft a TFLite model that would trigger a division
+  by zero error in LSH [implementation](https://github.com/tensorflow/tensorflow/blob/149562d49faa709ea80df1d99fc41d005b81082a/tensorflow/lite/kernels/lsh_projection.cc#L118).
+  We have patched the issue in GitHub commit 0575b640091680cfb70f4dd93e70658de43b94f9.
+  The fix will be included in TensorFlow 2.6.0. We will also cherrypick thiscommit
+  on TensorFlow 2.5.1, TensorFlow 2.4.3, and TensorFlow 2.3.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-37691
+modified: '2021-08-27T03:22:47.774010Z'
+published: '2021-08-12T23:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/0575b640091680cfb70f4dd93e70658de43b94f9
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-27qf-jwm8-g7f3

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37692.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-37692.yaml
@@ -1,0 +1,42 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 8721ba96e5760c229217b594f6d2ba332beedf22
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.3.0
+    - fixed: 2.3.4
+    - introduced: 2.4.0
+    - fixed: 2.4.3
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-37692
+- GHSA-cmgw-8vpc-rc59
+details: TensorFlow is an end-to-end open source platform for machine learning. In
+  affected versions under certain conditions, Go code can trigger a segfault in string
+  deallocation. For string tensors, `C.TF_TString_Dealloc` is called during garbage
+  collection within a finalizer function. However, tensor structure isn't checked
+  until encoding to avoid a performance penalty. The current method for dealloc assumes
+  that encoding succeeded, but segfaults when a string tensor is garbage collected
+  whose encoding failed (e.g., due to mismatched dimensions). To fix this, the call
+  to set the finalizer function is deferred until `NewTensor` returns and, if encoding
+  failed for a string tensor, deallocs are determined based on bytes written. We have
+  patched the issue in GitHub commit 8721ba96e5760c229217b594f6d2ba332beedf22. The
+  fix will be included in TensorFlow 2.6.0. We will also cherrypick this commit on
+  TensorFlow 2.5.1, which is the other affected version.
+id: PYSEC-0000-CVE-2021-37692
+modified: '2021-08-27T03:22:47.865620Z'
+published: '2021-08-12T23:15:00Z'
+references:
+- type: WEB
+  url: https://github.com/tensorflow/tensorflow/pull/50508
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-cmgw-8vpc-rc59
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/8721ba96e5760c229217b594f6d2ba332beedf22

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41196.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41196.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 12b1ff82b3f26ff8de17e58703231d5a02ef1b8b
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41196
+- GHSA-m539-j985-hcr8
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the Keras pooling layers can trigger a segfault if the size of the pool is 0 or
+  if a dimension is negative. This is due to the TensorFlow's implementation of pooling
+  operations where the values in the sliding window are not checked to be strictly
+  positive. The fix will be included in TensorFlow 2.7.0. We will also cherrypick
+  this commit on TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow 2.4.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41196
+modified: '2021-11-13T06:52:41.665281Z'
+published: '2021-11-05T20:15:00Z'
+references:
+- type: REPORT
+  url: https://github.com/tensorflow/tensorflow/issues/51936
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-m539-j985-hcr8
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/12b1ff82b3f26ff8de17e58703231d5a02ef1b8b

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41197.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41197.yaml
@@ -1,0 +1,51 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: a871989d7b6c18cdebf2fb4f0e5c5b62fbc19edf
+    - fixed: d81b1351da3e8c884ff836b64458d94e4a157c15
+    - fixed: 7c1692bd417eb4f9b33ead749a41166d6080af85
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41197
+- GHSA-prcg-wp5q-rv7p
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  TensorFlow allows tensor to have a large number of dimensions and each dimension
+  can be as large as desired. However, the total number of elements in a tensor must
+  fit within an `int64_t`. If an overflow occurs, `MultiplyWithoutOverflow` would
+  return a negative result. In the majority of TensorFlow codebase this then results
+  in a `CHECK`-failure. Newer constructs exist which return a `Status` instead of
+  crashing the binary. This is similar to CVE-2021-29584. The fix will be included
+  in TensorFlow 2.7.0. We will also cherrypick this commit on TensorFlow 2.6.1, TensorFlow
+  2.5.2, and TensorFlow 2.4.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41197
+modified: '2021-11-13T06:52:41.833730Z'
+published: '2021-11-05T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-prcg-wp5q-rv7p
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/a871989d7b6c18cdebf2fb4f0e5c5b62fbc19edf
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/d81b1351da3e8c884ff836b64458d94e4a157c15
+- type: REPORT
+  url: https://github.com/tensorflow/tensorflow/issues/46890
+- type: REPORT
+  url: https://github.com/tensorflow/tensorflow/issues/51908
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/7c1692bd417eb4f9b33ead749a41166d6080af85

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41198.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41198.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 9294094df6fea79271778eb7e7ae1bad8b5ef98f
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41198
+- GHSA-2p25-55c9-h58q
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  if `tf.tile` is called with a large input argument then the TensorFlow process will
+  crash due to a `CHECK`-failure caused by an overflow. The number of elements in
+  the output tensor is too much for the `int64_t` type and the overflow is detected
+  via a `CHECK` statement. This aborts the process. The fix will be included in TensorFlow
+  2.7.0. We will also cherrypick this commit on TensorFlow 2.6.1, TensorFlow 2.5.2,
+  and TensorFlow 2.4.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41198
+modified: '2021-11-13T06:52:42.007550Z'
+published: '2021-11-05T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/9294094df6fea79271778eb7e7ae1bad8b5ef98f
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-2p25-55c9-h58q
+- type: REPORT
+  url: https://github.com/tensorflow/tensorflow/issues/46911

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41199.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41199.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: e5272d4204ff5b46136a1ef1204fc00597e21837
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41199
+- GHSA-5hx2-qx8j-qjqm
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  if `tf.image.resize` is called with a large input argument then the TensorFlow process
+  will crash due to a `CHECK`-failure caused by an overflow. The number of elements
+  in the output tensor is too much for the `int64_t` type and the overflow is detected
+  via a `CHECK` statement. This aborts the process. The fix will be included in TensorFlow
+  2.7.0. We will also cherrypick this commit on TensorFlow 2.6.1, TensorFlow 2.5.2,
+  and TensorFlow 2.4.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41199
+modified: '2021-11-13T06:52:42.174686Z'
+published: '2021-11-05T20:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-5hx2-qx8j-qjqm
+- type: REPORT
+  url: https://github.com/tensorflow/tensorflow/issues/46914
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/e5272d4204ff5b46136a1ef1204fc00597e21837

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41200.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41200.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 874bda09e6702cd50bac90b453b50bcc65b2769e
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41200
+- GHSA-gh8h-7j2j-qv4f
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  if `tf.summary.create_file_writer` is called with non-scalar arguments code crashes
+  due to a `CHECK`-fail. The fix will be included in TensorFlow 2.7.0. We will also
+  cherrypick this commit on TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow 2.4.4,
+  as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41200
+modified: '2021-11-13T06:52:42.348013Z'
+published: '2021-11-05T20:15:00Z'
+references:
+- type: REPORT
+  url: https://github.com/tensorflow/tensorflow/issues/46909
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-gh8h-7j2j-qv4f
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/874bda09e6702cd50bac90b453b50bcc65b2769e

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41201.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41201.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: f09caa532b6e1ac8d2aa61b7832c78c5b79300c6
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41201
+- GHSA-j86v-p27c-73fm
+details: TensorFlow is an open source platform for machine learning. In affeced versions
+  during execution, `EinsumHelper::ParseEquation()` is supposed to set the flags in
+  `input_has_ellipsis` vector and `*output_has_ellipsis` boolean to indicate whether
+  there is ellipsis in the corresponding inputs and output. However, the code only
+  changes these flags to `true` and never assigns `false`. This results in unitialized
+  variable access if callers assume that `EinsumHelper::ParseEquation()` always sets
+  these flags. The fix will be included in TensorFlow 2.7.0. We will also cherrypick
+  this commit on TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow 2.4.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41201
+modified: '2021-11-13T06:52:42.499515Z'
+published: '2021-11-05T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/f09caa532b6e1ac8d2aa61b7832c78c5b79300c6
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-j86v-p27c-73fm

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41202.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41202.yaml
@@ -1,0 +1,47 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 1b0e0ec27e7895b9985076eab32445026ae5ca94
+    - fixed: 6d94002a09711d297dbba90390d5482b76113899
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41202
+- GHSA-xrqm-fpgr-6hhx
+details: 'TensorFlow is an open source platform for machine learning. In affected
+  versions while calculating the size of the output within the `tf.range` kernel,
+  there is a conditional statement of type `int64 = condition ? int64 : double`. Due
+  to C++ implicit conversion rules, both branches of the condition will be cast to
+  `double` and the result would be truncated before the assignment. This result in
+  overflows. The fix will be included in TensorFlow 2.7.0. We will also cherrypick
+  this commit on TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow 2.4.4, as these
+  are also affected and still in supported range.'
+id: PYSEC-0000-CVE-2021-41202
+modified: '2021-11-13T06:52:42.645758Z'
+published: '2021-11-05T22:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-xrqm-fpgr-6hhx
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/1b0e0ec27e7895b9985076eab32445026ae5ca94
+- type: REPORT
+  url: https://github.com/tensorflow/tensorflow/issues/46912
+- type: REPORT
+  url: https://github.com/tensorflow/tensorflow/issues/46889
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/6d94002a09711d297dbba90390d5482b76113899

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41203.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41203.yaml
@@ -1,0 +1,48 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 368af875869a204b4ac552b9ddda59f6a46a56ec
+    - fixed: abcced051cb1bd8fb05046ac3b6023a7ebcc4578
+    - fixed: e8dc63704c88007ee4713076605c90188d66f3d2
+    - fixed: b619c6f865715ca3b15ef1842b5b95edbaa710ad
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41203
+- GHSA-7pxj-m4jf-r6h2
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  an attacker can trigger undefined behavior, integer overflows, segfaults and `CHECK`-fail
+  crashes if they can change saved checkpoints from outside of TensorFlow. This is
+  because the checkpoints loading infrastructure is missing validation for invalid
+  file formats. The fixes will be included in TensorFlow 2.7.0. We will also cherrypick
+  these commits on TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow 2.4.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41203
+modified: '2021-11-13T06:52:42.793363Z'
+published: '2021-11-05T21:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-7pxj-m4jf-r6h2
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/368af875869a204b4ac552b9ddda59f6a46a56ec
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/abcced051cb1bd8fb05046ac3b6023a7ebcc4578
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/e8dc63704c88007ee4713076605c90188d66f3d2
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/b619c6f865715ca3b15ef1842b5b95edbaa710ad

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41204.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41204.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 7731e8dfbe4a56773be5dc94d631611211156659
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41204
+- GHSA-786j-5qwq-r36x
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  during TensorFlow's Grappler optimizer phase, constant folding might attempt to
+  deep copy a resource tensor. This results in a segfault, as these tensors are supposed
+  to not change. The fix will be included in TensorFlow 2.7.0. We will also cherrypick
+  this commit on TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow 2.4.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41204
+modified: '2021-11-13T06:52:42.949977Z'
+published: '2021-11-05T21:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/7731e8dfbe4a56773be5dc94d631611211156659
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-786j-5qwq-r36x

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41205.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41205.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 7cf73a2274732c9d82af51c2bc2cf90d13cd7e6d
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41205
+- GHSA-49rx-x2rw-pc6f
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the shape inference functions for the `QuantizeAndDequantizeV*` operations can trigger
+  a read outside of bounds of heap allocated array. The fix will be included in TensorFlow
+  2.7.0. We will also cherrypick this commit on TensorFlow 2.6.1, TensorFlow 2.5.2,
+  and TensorFlow 2.4.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41205
+modified: '2021-11-13T06:52:43.104468Z'
+published: '2021-11-05T21:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-49rx-x2rw-pc6f
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/7cf73a2274732c9d82af51c2bc2cf90d13cd7e6d

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41207.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41207.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: f2c3931113eaafe9ef558faaddd48e00a6606235
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41207
+- GHSA-7v94-64hj-m82h
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the implementation of `ParallelConcat` misses some input validation and can produce
+  a division by 0. The fix will be included in TensorFlow 2.7.0. We will also cherrypick
+  this commit on TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow 2.4.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41207
+modified: '2021-11-13T06:52:43.264871Z'
+published: '2021-11-05T22:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-7v94-64hj-m82h
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/f2c3931113eaafe9ef558faaddd48e00a6606235

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41208.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41208.yaml
@@ -1,0 +1,43 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 5c8c9a8bfe750f9743d0c859bae112060b216f5c
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41208
+- GHSA-57wx-m983-2f88
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the code for boosted trees in TensorFlow is still missing validation. As a result,
+  attackers can trigger denial of service (via dereferencing `nullptr`s or via `CHECK`-failures)
+  as well as abuse undefined behavior (binding references to `nullptr`s). An attacker
+  can also read and write from heap buffers, depending on the API that gets used and
+  the arguments that are passed to the call. Given that the boosted trees implementation
+  in TensorFlow is unmaintained, it is recommend to no longer use these APIs. We will
+  deprecate TensorFlow's boosted trees APIs in subsequent releases. The fix will be
+  included in TensorFlow 2.7.0. We will also cherrypick this commit on TensorFlow
+  2.6.1, TensorFlow 2.5.2, and TensorFlow 2.4.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-41208
+modified: '2021-11-13T06:52:43.429056Z'
+published: '2021-11-05T22:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/5c8c9a8bfe750f9743d0c859bae112060b216f5c
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-57wx-m983-2f88

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41209.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41209.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: f2c3931113eaafe9ef558faaddd48e00a6606235
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41209
+- GHSA-6hpv-v2rx-c5g6
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the implementations for convolution operators trigger a division by 0 if passed
+  empty filter tensor arguments. The fix will be included in TensorFlow 2.7.0. We
+  will also cherrypick this commit on TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow
+  2.4.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41209
+modified: '2021-11-13T06:52:43.607331Z'
+published: '2021-11-05T22:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/f2c3931113eaafe9ef558faaddd48e00a6606235
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-6hpv-v2rx-c5g6

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41210.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41210.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 701cfaca222a82afbeeb17496bd718baa65a67d2
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41210
+- GHSA-m342-ff57-4jcc
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the shape inference functions for `SparseCountSparseOutput` can trigger a read outside
+  of bounds of heap allocated array. The fix will be included in TensorFlow 2.7.0.
+  We will also cherrypick this commit on TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow
+  2.4.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41210
+modified: '2021-11-13T06:52:43.758467Z'
+published: '2021-11-05T20:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/701cfaca222a82afbeeb17496bd718baa65a67d2
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-m342-ff57-4jcc

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41211.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41211.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: a0d64445116c43cf46a5666bd4eee28e7a82f244
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41211
+- GHSA-cvgx-3v3q-m36c
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the shape inference code for `QuantizeV2` can trigger a read outside of bounds of
+  heap allocated array. This occurs whenever `axis` is a negative value less than
+  `-1`. In this case, we are accessing data before the start of a heap buffer. The
+  code allows `axis` to be an optional argument (`s` would contain an `error::NOT_FOUND`
+  error code). Otherwise, it assumes that `axis` is a valid index into the dimensions
+  of the `input` tensor. If `axis` is less than `-1` then this results in a heap OOB
+  read. The fix will be included in TensorFlow 2.7.0. We will also cherrypick this
+  commit on TensorFlow 2.6.1, as this version is the only one that is also affected.
+id: PYSEC-0000-CVE-2021-41211
+modified: '2021-11-13T06:52:43.843277Z'
+published: '2021-11-05T21:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-cvgx-3v3q-m36c
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/a0d64445116c43cf46a5666bd4eee28e7a82f244

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41212.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41212.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: fa6b7782fbb14aa08d767bc799c531f5e1fb3bb8
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41212
+- GHSA-fr77-rrx3-cp7g
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the shape inference code for `tf.ragged.cross` can trigger a read outside of bounds
+  of heap allocated array. The fix will be included in TensorFlow 2.7.0. We will also
+  cherrypick this commit on TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow 2.4.4,
+  as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41212
+modified: '2021-11-13T06:52:43.991676Z'
+published: '2021-11-05T21:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-fr77-rrx3-cp7g
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/fa6b7782fbb14aa08d767bc799c531f5e1fb3bb8

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41213.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41213.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: afac8158d43691661ad083f6dd9e56f327c1dcb7
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41213
+- GHSA-h67m-xg8f-fxcf
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the code behind `tf.function` API can be made to deadlock when two `tf.function`
+  decorated Python functions are mutually recursive. This occurs due to using a non-reentrant
+  `Lock` Python object. Loading any model which contains mutually recursive functions
+  is vulnerable. An attacker can cause denial of service by causing users to load
+  such models and calling a recursive `tf.function`, although this is not a frequent
+  scenario. The fix will be included in TensorFlow 2.7.0. We will also cherrypick
+  this commit on TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow 2.4.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41213
+modified: '2021-11-13T06:52:44.160284Z'
+published: '2021-11-05T23:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/afac8158d43691661ad083f6dd9e56f327c1dcb7
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-h67m-xg8f-fxcf

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41214.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41214.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: fa6b7782fbb14aa08d767bc799c531f5e1fb3bb8
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41214
+- GHSA-vwhq-49r4-gj9v
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the shape inference code for `tf.ragged.cross` has an undefined behavior due to
+  binding a reference to `nullptr`. The fix will be included in TensorFlow 2.7.0.
+  We will also cherrypick this commit on TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow
+  2.4.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41214
+modified: '2021-11-13T06:52:44.328170Z'
+published: '2021-11-05T21:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-vwhq-49r4-gj9v
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/fa6b7782fbb14aa08d767bc799c531f5e1fb3bb8

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41215.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41215.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: d3738dd70f1c9ceb547258cbb82d853da8771850
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41215
+- GHSA-x3v8-c8qx-3j3r
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the shape inference code for `DeserializeSparse` can trigger a null pointer dereference.
+  This is because the shape inference function assumes that the `serialize_sparse`
+  tensor is a tensor with positive rank (and having `3` as the last dimension). The
+  fix will be included in TensorFlow 2.7.0. We will also cherrypick this commit on
+  TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow 2.4.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-41215
+modified: '2021-11-13T06:52:44.476075Z'
+published: '2021-11-05T21:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/d3738dd70f1c9ceb547258cbb82d853da8771850
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-x3v8-c8qx-3j3r

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41216.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41216.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: c79ba87153ee343401dbe9d1954d7f79e521eb14
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41216
+- GHSA-3ff2-r28g-w7h9
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the shape inference function for `Transpose` is vulnerable to a heap buffer overflow.
+  This occurs whenever `perm` contains negative elements. The shape inference function
+  does not validate that the indices in `perm` are all valid. The fix will be included
+  in TensorFlow 2.7.0. We will also cherrypick this commit on TensorFlow 2.6.1, TensorFlow
+  2.5.2, and TensorFlow 2.4.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41216
+modified: '2021-11-13T06:52:44.644675Z'
+published: '2021-11-05T23:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-3ff2-r28g-w7h9
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/c79ba87153ee343401dbe9d1954d7f79e521eb14

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41217.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41217.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 05cbebd3c6bb8f517a158b0155debb8df79017ff
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41217
+- GHSA-5crj-c72x-m7gq
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the process of building the control flow graph for a TensorFlow model is vulnerable
+  to a null pointer exception when nodes that should be paired are not. This occurs
+  because the code assumes that the first node in the pairing (e.g., an `Enter` node)
+  always exists when encountering the second node (e.g., an `Exit` node). When this
+  is not the case, `parent` is `nullptr` so dereferencing it causes a crash. The fix
+  will be included in TensorFlow 2.7.0. We will also cherrypick this commit on TensorFlow
+  2.6.1, TensorFlow 2.5.2, and TensorFlow 2.4.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-41217
+modified: '2021-11-13T06:52:44.799831Z'
+published: '2021-11-05T21:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/05cbebd3c6bb8f517a158b0155debb8df79017ff
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-5crj-c72x-m7gq

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41218.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41218.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: a8ad3e5e79c75f36edb81e0ba3f3c0c5442aeddc
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41218
+- GHSA-9crf-c6qr-r273
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the shape inference code for `AllToAll` can be made to execute a division by 0.
+  This occurs whenever the `split_count` argument is 0. The fix will be included in
+  TensorFlow 2.7.0. We will also cherrypick this commit on TensorFlow 2.6.1, TensorFlow
+  2.5.2, and TensorFlow 2.4.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41218
+modified: '2021-11-13T06:52:44.955817Z'
+published: '2021-11-05T22:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-9crf-c6qr-r273
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/a8ad3e5e79c75f36edb81e0ba3f3c0c5442aeddc

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41219.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41219.yaml
@@ -1,0 +1,42 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: e6cf28c72ba2eb949ca950d834dd6d66bb01cfae
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41219
+- GHSA-4f99-p9c2-3j8x
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the code for sparse matrix multiplication is vulnerable to undefined behavior via
+  binding a reference to `nullptr`. This occurs whenever the dimensions of `a` or
+  `b` are 0 or less. In the case on one of these is 0, an empty output tensor should
+  be allocated (to conserve the invariant that output tensors are always allocated
+  when the operation is successful) but nothing should be written to it (that is,
+  we should return early from the kernel implementation). Otherwise, attempts to write
+  to this empty tensor would result in heap OOB access. The fix will be included in
+  TensorFlow 2.7.0. We will also cherrypick this commit on TensorFlow 2.6.1, TensorFlow
+  2.5.2, and TensorFlow 2.4.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41219
+modified: '2021-11-13T06:52:45.099185Z'
+published: '2021-11-05T21:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-4f99-p9c2-3j8x
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/e6cf28c72ba2eb949ca950d834dd6d66bb01cfae

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41220.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41220.yaml
@@ -1,0 +1,34 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: ca38dab9d3ee66c5de06f11af9a4b1200da5ef75
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41220
+- GHSA-gpfh-jvf9-7wg5
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the async implementation of `CollectiveReduceV2` suffers from a memory leak and
+  a use after free. This occurs due to the asynchronous computation and the fact that
+  objects that have been `std::move()`d from are still accessed. The fix will be included
+  in TensorFlow 2.7.0. We will also cherrypick this commit on TensorFlow 2.6.1, as
+  this version is the only one that is also affected.
+id: PYSEC-0000-CVE-2021-41220
+modified: '2021-11-13T06:52:45.180075Z'
+published: '2021-11-05T23:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-gpfh-jvf9-7wg5
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/ca38dab9d3ee66c5de06f11af9a4b1200da5ef75

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41221.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41221.yaml
@@ -1,0 +1,39 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: af5fcebb37c8b5d71c237f4e59c6477015c78ce6
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41221
+- GHSA-cqv6-3phm-hcwx
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the shape inference code for the `Cudnn*` operations in TensorFlow can be tricked
+  into accessing invalid memory, via a heap buffer overflow. This occurs because the
+  ranks of the `input`, `input_h` and `input_c` parameters are not validated, but
+  code assumes they have certain values. The fix will be included in TensorFlow 2.7.0.
+  We will also cherrypick this commit on TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow
+  2.4.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41221
+modified: '2021-11-13T06:52:45.325083Z'
+published: '2021-11-05T23:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-cqv6-3phm-hcwx
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/af5fcebb37c8b5d71c237f4e59c6477015c78ce6

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41222.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41222.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 25d622ffc432acc736b14ca3904177579e733cc6
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41222
+- GHSA-cpf4-wx82-gxp6
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the implementation of `SplitV` can trigger a segfault is an attacker supplies negative
+  arguments. This occurs whenever `size_splits` contains more than one value and at
+  least one value is negative. The fix will be included in TensorFlow 2.7.0. We will
+  also cherrypick this commit on TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow
+  2.4.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41222
+modified: '2021-11-13T06:52:45.470098Z'
+published: '2021-11-05T23:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-cpf4-wx82-gxp6
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/25d622ffc432acc736b14ca3904177579e733cc6

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41223.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41223.yaml
@@ -1,0 +1,37 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: aab9998916c2ffbd8f0592059fad352622f89cda
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41223
+- GHSA-f54p-f6jp-4rhr
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the implementation of `FusedBatchNorm` kernels is vulnerable to a heap OOB access.
+  The fix will be included in TensorFlow 2.7.0. We will also cherrypick this commit
+  on TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow 2.4.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-41223
+modified: '2021-11-13T06:52:45.621437Z'
+published: '2021-11-05T21:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/aab9998916c2ffbd8f0592059fad352622f89cda
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-f54p-f6jp-4rhr

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41224.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41224.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 67bfd9feeecfb3c61d80f0e46d89c170fbee682b
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41224
+- GHSA-rg3m-hqc5-344v
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the implementation of `SparseFillEmptyRows` can be made to trigger a heap OOB access.
+  This occurs whenever the size of `indices` does not match the size of `values`.
+  The fix will be included in TensorFlow 2.7.0. We will also cherrypick this commit
+  on TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow 2.4.4, as these are also affected
+  and still in supported range.
+id: PYSEC-0000-CVE-2021-41224
+modified: '2021-11-13T06:52:45.767410Z'
+published: '2021-11-05T21:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/67bfd9feeecfb3c61d80f0e46d89c170fbee682b
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-rg3m-hqc5-344v

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41225.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41225.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 68867bf01239d9e1048f98cbad185bf4761bedd3
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41225
+- GHSA-7r94-xv9v-63jw
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  TensorFlow's Grappler optimizer has a use of unitialized variable. If the `train_nodes`
+  vector (obtained from the saved model that gets optimized) does not contain a `Dequeue`
+  node, then `dequeue_node` is left unitialized. The fix will be included in TensorFlow
+  2.7.0. We will also cherrypick this commit on TensorFlow 2.6.1, TensorFlow 2.5.2,
+  and TensorFlow 2.4.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41225
+modified: '2021-11-13T06:52:45.918636Z'
+published: '2021-11-05T23:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/68867bf01239d9e1048f98cbad185bf4761bedd3
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-7r94-xv9v-63jw

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41226.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41226.yaml
@@ -1,0 +1,38 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: f410212e373eb2aec4c9e60bf3702eba99a38aba
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41226
+- GHSA-374m-jm66-3vj8
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the implementation of `SparseBinCount` is vulnerable to a heap OOB access. This
+  is because of missing validation between the elements of the `values` argument and
+  the shape of the sparse output. The fix will be included in TensorFlow 2.7.0. We
+  will also cherrypick this commit on TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow
+  2.4.4, as these are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41226
+modified: '2021-11-13T06:52:46.070716Z'
+published: '2021-11-05T21:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/f410212e373eb2aec4c9e60bf3702eba99a38aba
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-374m-jm66-3vj8

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41227.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41227.yaml
@@ -1,0 +1,42 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 3712a2d3455e6ccb924daa5724a3652a86f6b585
+    - fixed: 1cb6bb6c2a6019417c9adaf9e6843ba75ee2580b
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41227
+- GHSA-j8c8-67vp-6mx7
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  the `ImmutableConst` operation in TensorFlow can be tricked into reading arbitrary
+  memory contents. This is because the `tstring` TensorFlow string class has a special
+  case for memory mapped strings but the operation itself does not offer any support
+  for this datatype. The fix will be included in TensorFlow 2.7.0. We will also cherrypick
+  this commit on TensorFlow 2.6.1, TensorFlow 2.5.2, and TensorFlow 2.4.4, as these
+  are also affected and still in supported range.
+id: PYSEC-0000-CVE-2021-41227
+modified: '2021-11-13T06:52:46.221231Z'
+published: '2021-11-05T23:15:00Z'
+references:
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-j8c8-67vp-6mx7
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/3712a2d3455e6ccb924daa5724a3652a86f6b585
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/1cb6bb6c2a6019417c9adaf9e6843ba75ee2580b

--- a/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41228.yaml
+++ b/vulns/tensorflow-gpu/PYSEC-0000-CVE-2021-41228.yaml
@@ -1,0 +1,41 @@
+affected:
+- package:
+    ecosystem: PyPI
+    name: tensorflow-gpu
+    purl: pkg:pypi:tensorflow-gpu
+  ranges:
+  - events:
+    - introduced: '0'
+    - fixed: 8b202f08d52e8206af2bdb2112a62fafbc546ec7
+    repo: https://github.com/tensorflow/tensorflow
+    type: GIT
+  - events:
+    - introduced: '0'
+    - fixed: 2.4.4
+    - introduced: 2.5.0
+    - fixed: 2.5.2
+    - introduced: 2.6.0
+    - fixed: 2.6.1
+    - introduced: 2.7.0rc0
+    - fixed: 2.7.0
+    type: ECOSYSTEM
+aliases:
+- CVE-2021-41228
+- GHSA-3rcw-9p9x-582v
+details: TensorFlow is an open source platform for machine learning. In affected versions
+  TensorFlow's `saved_model_cli` tool is vulnerable to a code injection as it calls
+  `eval` on user supplied strings. This can be used by attackers to run arbitrary
+  code on the plaform where the CLI tool runs. However, given that the tool is always
+  run manually, the impact of this is not severe. We have patched this by adding a
+  `safe` flag which defaults to `True` and an explicit warning for users. The fix
+  will be included in TensorFlow 2.7.0. We will also cherrypick this commit on TensorFlow
+  2.6.1, TensorFlow 2.5.2, and TensorFlow 2.4.4, as these are also affected and still
+  in supported range.
+id: PYSEC-0000-CVE-2021-41228
+modified: '2021-11-13T06:52:46.380831Z'
+published: '2021-11-05T23:15:00Z'
+references:
+- type: FIX
+  url: https://github.com/tensorflow/tensorflow/commit/8b202f08d52e8206af2bdb2112a62fafbc546ec7
+- type: ADVISORY
+  url: https://github.com/tensorflow/tensorflow/security/advisories/GHSA-3rcw-9p9x-582v


### PR DESCRIPTION
All advisories for [tensorflow](pypi.org/project/tensorflow) should also apply to [tensorflow-cpu](pypi.org/project/tensorflow-cpu) and [tensorflow-gpu](pypi.org/project/tensorflow-gpu)

Signed-off-by: Weston Steimel <weston.steimel@gmail.com>